### PR TITLE
Add basic CircleCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: wiegandm/openvas-scanner-core-debian-stretch
+    steps:
+      - run:
+          working_directory: ~/gvm-libs
+          name: Checkout gvm-libs
+          command: git clone https://github.com/greenbone/gvm-libs.git
+      - run:
+          working_directory: ~/gvm-libs
+          name: Configure and compile gvm-libs
+          command: pushd gvm-libs && mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install && popd
+      - checkout
+      - run:
+          name: Configure and Compile
+          command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install


### PR DESCRIPTION
This basic job is based on a Docker image providing only the minimum set of dependencies required to build openvas-scanner and not optional dependencies like openvas-smb or libsnmp.