### PR TITLE
src/openvassd.c (stop_all_scan): Set processID with the right pid

### DIFF
--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -508,7 +508,7 @@ stop_all_scans (void)
         {
           contents_split = g_strsplit (contents," ", 6);
           parentID = g_strdup (contents_split[3]);
-          processID = g_strdup (contents_split[4]);
+          processID = g_strdup (contents_split[0]);
 
           g_free (pidstatfn);
           pidstatfn = NULL;


### PR DESCRIPTION
Set processID with the right pid to avoid to kill the parent process.