### PR TITLE
Backport PR #18.

### DIFF
--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -369,7 +369,6 @@ reload_openvassd ()
   prefs_config (config_file);
 
   /* Reload the plugins */
-  nvticache_free ();
   ret = plugins_init ();
   set_globals_from_preferences ();
   loading_handler_stop (handler_pid);


### PR DESCRIPTION
Do not call nvticache_free() on reload.

This prevents complete deletion of nvticache before
reloading.