### PR TITLE
Add the new scanner option "time_between_request". This option avoid …

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -91,6 +91,9 @@ Number of retries when a socket connection attempt timesout.
 .IP open_sock_max_attempts
 When a port  is found as opened at the beginning of the scan, and for some reason the status changes to filtered/closed, it will not be possible to open a socket. This is the number of unsuccessful retries to open the socket before to set the port as closed. This avoids to launch plugins which need the opened port as a mandatory key, therefore it avoids an overlong scan duration. If the set value is 0 or a negative value, this option is disabled. It should be take in account that one unsuccessful attempt needs the number of retries set in "timeout_retry".
 
+.IP time_between_request
+Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in miliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
+
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvassd to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvassd to designate a service formally. Ex: "139, Services/www", will prevent openvassd from making two connections at the same time on port 139 and on every port which hosts a web server.
 

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -146,6 +146,7 @@ static openvassd_option openvassd_defaults[] = {
   {"kb_location", KB_PATH_DEFAULT},
   {"timeout_retry", "3"},
   {"open_sock_max_attempts", "5"},
+  {"time_between_request", "0"},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
…quick connection establishment, termination and quick request to a single host.

* nasl/nasl_socket.c: Include gvm/base/prefs.h, stdlib.h and sys/time.h.
  (wait_before_next_probe): New function.
  (nasl_open_privileged_socket, nasl_open_sock_tcp_bufsz, nasl_send,
  nasl_close_socket): Call new function.

* src/openvassd.c (openvassd_defaults): Add new option time_between_request.

* doc/openvassd.8.in: Add description for the new option time_between_request.