### PR TITLE
Add the new scanner option "time_between_request". This option avoid …

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -91,6 +91,9 @@ Number of retries when a socket connection attempt timesout.
 .IP open_sock_max_attempts
 When a port  is found as opened at the beginning of the scan, and for some reason the status changes to filtered/closed, it will not be possible to open a socket. This is the number of unsuccessful retries to open the socket before to set the port as closed. This avoids to launch plugins which need the opened port as a mandatory key, therefore it avoids an overlong scan duration. If the set value is 0 or a negative value, this option is disabled. It should be take in account that one unsuccessful attempt needs the number of retries set in "timeout_retry".
 
+.IP time_between_request
+Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in miliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
+
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvassd to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvassd to designate a service formally. Ex: "139, Services/www", will prevent openvassd from making two connections at the same time on port 139 and on every port which hosts a web server.
 

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -43,10 +43,14 @@
 #include <netinet/in.h>         /* for sockaddr_in */
 #include <string.h>             /* for bzero */
 #include <unistd.h>             /* for close */
+#include <stdlib.h>             /* for atoi() */
+#include <sys/time.h>
+
 
 #include <gnutls/gnutls.h>
 #include <gvm/base/networking.h> /* for gvm_source_set_socket */
 #include <gvm/base/logging.h>
+#include <gvm/base/prefs.h>      /* for prefs_get */
 
 #include "../misc/network.h"
 #include "../misc/plugutils.h"          /* for plug_get_host_ip */
@@ -109,6 +113,49 @@ block_socket (int soc)
   return 0;
 }
 
+static void
+wait_before_next_probe ()
+{
+  const char *time_between_request;
+  int minwaittime = 0;
+
+  time_between_request = prefs_get ("time_between_request");
+  if (time_between_request)
+    minwaittime = atoi (time_between_request);
+
+  if (minwaittime > 0)
+    {
+      static double lastprobesec = 0;
+      static double lastprobeusec = 0;
+      struct timeval tvnow, tvdiff;
+      double diff_msec;
+      int time2wait = 0;
+
+      gettimeofday (&tvnow, NULL);
+      if (lastprobesec <= 0)
+        {
+          lastprobesec = tvnow.tv_sec - 10;
+          lastprobeusec = tvnow.tv_usec;
+        }
+
+      tvdiff.tv_sec = tvnow.tv_sec - lastprobesec;
+      tvdiff.tv_usec = tvnow.tv_usec - lastprobeusec;
+      if (tvdiff.tv_usec <= 0)
+        {
+          tvdiff.tv_sec += 1;
+          tvdiff.tv_usec *= -1;
+        }
+
+      diff_msec = tvdiff.tv_sec * 1000 + tvdiff.tv_usec / 1000;
+      time2wait  = (minwaittime - diff_msec) * 1000;
+      if (time2wait > 0)
+        usleep (time2wait);
+
+      gettimeofday(&tvnow, NULL);
+      lastprobesec = tvnow.tv_sec;
+      lastprobeusec = tvnow.tv_usec;
+    }
+}
 
 /*
  * NASL automatically re-send data when a recv() on a UDP packet
@@ -218,6 +265,8 @@ nasl_open_privileged_socket (lex_ctxt * lexic, int proto)
 
 
 restart:
+  if (proto == IPPROTO_TCP)
+    wait_before_next_probe ();
   p = plug_get_host_ip (script_infos);
   if (IN6_IS_ADDR_V4MAPPED (p))
     {
@@ -416,6 +465,8 @@ nasl_open_sock_tcp_bufsz (lex_ctxt * lexic, int bufsz)
   port = get_int_var_by_num (lexic, 0, -1);
   if (port < 0)
     return NULL;
+
+  wait_before_next_probe ();
 
   /* If "transport" has not been given, use auto detection if enabled
      in the KB. if "transport" has been given with a value of 0 force
@@ -865,7 +916,6 @@ nasl_send (lex_ctxt * lexic)
   int type;
   unsigned int type_len = sizeof (type);
 
-
   if (soc <= 0 || data == NULL)
     {
       nasl_perror (lexic, "Syntax error with the send() function\n");
@@ -886,7 +936,10 @@ nasl_send (lex_ctxt * lexic)
       add_udp_data (lexic->script_infos, soc, data, length);
     }
   else
-    n = nsend (soc, data, length, option);
+    {
+      wait_before_next_probe ();
+      n = nsend (soc, data, length, option);
+    }
 
   retc = alloc_tree_cell ();
   retc->type = CONST_INT;
@@ -907,8 +960,10 @@ nasl_close_socket (lex_ctxt * lexic)
 
   soc = get_int_var_by_num (lexic, 0, -1);
   if (fd_is_stream (soc))
-    return close_stream_connection (soc) < 0 ? NULL : FAKE_CELL;
-
+    {
+      wait_before_next_probe ();
+      return close_stream_connection (soc) < 0 ? NULL : FAKE_CELL;
+    }
   if (lowest_socket == 0 || soc < lowest_socket)
     {
       nasl_perror (lexic, "close(%d): Invalid socket value\n", soc);

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -146,6 +146,7 @@ static openvassd_option openvassd_defaults[] = {
   {"kb_location", KB_PATH_DEFAULT},
   {"timeout_retry", "3"},
   {"open_sock_max_attempts", "5"},
+  {"time_between_request", "0"},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
…quick connection establishment, termination and quick request to a single host.

* nasl/nasl_socket.c: Include gvm/base/prefs.h, stdlib.h and sys/time.h.
  (wait_before_next_probe): New function.
  (nasl_open_privileged_socket, nasl_open_sock_tcp_bufsz, nasl_send,
  nasl_close_socket): Call new function.

* src/openvassd.c (openvassd_defaults): Add new option time_between_request.

* doc/openvassd.8.in: Add description for the new option time_between_request.