### PR TITLE
Backport part of PR #24 

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -100,6 +100,9 @@ Number of seconds that the security checks will wait for when doing a recv(). Yo
 .IP timeout_retry
 Number of retries when a socket connection attempt timesout.
 
+.IP time_between_request
+Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in miliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
+
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvassd to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvassd to designate a service formally. Ex: "139, Services/www", will prevent openvassd from making two connections at the same time on port 139 and on every port which hosts a web server.
 

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -132,6 +132,7 @@ static openvassd_option openvassd_defaults[] = {
   {"report_host_details", "yes"},
   {"kb_location", KB_PATH_DEFAULT},
   {"timeout_retry", "3"},
+  {"time_between_request", "0"},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
With adjustments due to code change

Add new scanner option "time_between_request". This option avoid quick
connection establishment, termination and quick request to a single host.
* src/openvassd.c (openvassd_defaults): Add new option time_between_request.
* doc/openvassd.8.in: Add description for the new option time_between_request.