### PR TITLE
Backport PR #16

### DIFF
--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -371,7 +371,7 @@ plugin_next_unrun_dependency (plugins_scheduler_t sched,
             if (deps_ptr == NULL)
               return plugin;
 
-            ret = plugin_next_unrun_dependency (sched, deps_ptr, calls++);
+            ret = plugin_next_unrun_dependency (sched, deps_ptr, calls + 1);
             if (ret == NULL)
               return plugin;
 


### PR DESCRIPTION
Do not increment calls variable, as it might be used in subsequent loop
iterations within the same function.