### PR TITLE
Check the version of libgcrypt

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,7 +17,7 @@ Prerequisites:
 * gio-2.0
 * bison
 * flex
-* libgcrypt
+* libgcrypt >= 1.6
 * pkg-config
 * libpcap
 * libgpgme >= 1.1.2

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -116,6 +116,13 @@ if (NOT MINGW)
     execute_process (COMMAND libgcrypt-config --cflags
       OUTPUT_VARIABLE GCRYPT_CFLAGS
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process (COMMAND libgcrypt-config --version
+      OUTPUT_VARIABLE GCRYPT_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message (STATUS "  found libgcrypt, version ${GCRYPT_VERSION}")
+    if (GCRYPT_VERSION VERSION_LESS "1.6")
+      message (SEND_ERROR "libgcrypt 1.6 or greater is required")
+    endif (GCRYPT_VERSION VERSION_LESS "1.6")
   endif (NOT GCRYPT)
 
 endif (NOT MINGW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,13 @@ else (NOT GCRYPT)
   execute_process (COMMAND libgcrypt-config --cflags
     OUTPUT_VARIABLE GCRYPT_CFLAGS
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process (COMMAND libgcrypt-config --version
+    OUTPUT_VARIABLE GCRYPT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  message (STATUS "  found libgcrypt, version ${GCRYPT_VERSION}")
+  if (GCRYPT_VERSION VERSION_LESS "1.6")
+    message (SEND_ERROR "libgcrypt 1.6 or greater is required")
+  endif (GCRYPT_VERSION VERSION_LESS "1.6")
 endif (NOT GCRYPT)
 
 add_executable (openvassd attack.c comm.c hosts.c


### PR DESCRIPTION
Previously CMake only checked for the presence of libgcrypt, causing
build failures when the installed libgcrypt was too old and did not
provide the required symbols.

This commit adds a version check for libgcrypt which will fail if the
version is below 1.6. This version requirement is now documented in the
INSTALL file as well.

This commit was adapted from greenbone/gvm-libs#41 (which in turn was in
reaction to greenbone/gvm-libs#40) since the relevant checks have moved
from gvm-libs to openvas-scanner in the master branch.