### PR TITLE
Fix duplicate cmd in pread args list.

### DIFF
--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -148,13 +148,12 @@ nasl_pread (lex_ctxt * lexic)
     nasl_perror (lexic, "pread: named elements in 'cmd' are ignored!\n");
   n = av->max_idx;
   args = g_malloc0 (sizeof (char **) * (n + 2));  /* Last arg is NULL */
-  for (j = 1, i = 0; i < n; i++)
+  for (j = 0, i = 0; i < n; i++)
     {
       str = (char *) var2str (av->num_elt[i]);
       if (str != NULL)
         args[j++] = g_strdup (str);
     }
-  args[0] = g_strdup (cmd);
   args[j] = NULL;
 
   old_sig_t = signal (SIGTERM, sig_h);


### PR DESCRIPTION
As the command name is already passed in the args list. Issue introduced
in 575c100001aff418e3cf67bd33b22c0bc96fce57.

This led to some 'Failed to resolve "nmap"' messages in stdout during scans.