### PR TITLE
Drop NASL command script_id.

### DIFF
--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -86,7 +86,6 @@ static init_func libfuncs[] = {
   {"script_get_preference", script_get_preference},
   {"script_get_preference_file_content", script_get_preference_file_content},
   {"script_get_preference_file_location", script_get_preference_file_location},
-  {"script_id", script_id},
   {"script_oid", script_oid},
   {"script_cve_id", script_cve_id},
   {"script_bugtraq_id", script_bugtraq_id},

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -106,23 +106,6 @@ script_timeout (lex_ctxt * lexic)
 
 
 tree_cell *
-script_id (lex_ctxt * lexic)
-{
-  int id;
-  char * oid;
-
-  id = get_int_var_by_num (lexic, 0, -1);
-  if (id > 0)
-    {
-      oid = g_strdup_printf ("%s%i", LEGACY_OID, id);
-      nvti_set_oid (lexic->script_infos->nvti, oid);
-      g_free (oid);
-    }
-
-  return FAKE_CELL;
-}
-
-tree_cell *
 script_oid (lex_ctxt * lexic)
 {
   nvti_set_oid (lexic->script_infos->nvti, get_str_var_by_num (lexic, 0));

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -19,7 +19,6 @@
 #ifndef NASL_SCANNER_GLUE_H
 #define NASL_SCANNER_GLUE_H
 tree_cell *script_timeout (lex_ctxt *);
-tree_cell *script_id (lex_ctxt *);
 tree_cell *script_oid (lex_ctxt *);
 tree_cell *script_cve_id (lex_ctxt *);
 tree_cell *script_bugtraq_id (lex_ctxt *);


### PR DESCRIPTION
This command was redundant for quite some time already.
The new command is script_oid.
Since the usage of script_id has been entirely removed from
GSF and GCF, this function finally can be removed from the code.

* nasl/nasl_init.c (libfuncs): Remove script_id from table.

* nasl/nasl_scanner_glue.c (script_id): Removed this function.

* nasl/nasl_scanner_glue.h: Removed proto accordingly.