### PR TITLE
Drop NASL command script_summary.

### DIFF
--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -73,7 +73,6 @@ static init_func libfuncs[] = {
   {"script_version", script_version},
   {"script_timeout", script_timeout},
   {"script_copyright", script_copyright},
-  {"script_summary", script_summary},
   {"script_category", script_category},
   {"script_family", script_family},
   {"script_dependencies", script_dependencies},

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -263,14 +263,6 @@ script_copyright (lex_ctxt * lexic)
 }
 
 tree_cell *
-script_summary (lex_ctxt * lexic)
-{
-  /* XXX: For backward compatibility. */
-  (void) lexic;
-  return FAKE_CELL;
-}
-
-tree_cell *
 script_category (lex_ctxt * lexic)
 {
   struct script_infos *script_infos = lexic->script_infos;

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -27,7 +27,6 @@ tree_cell *script_tag (lex_ctxt *);
 tree_cell *script_name (lex_ctxt *);
 tree_cell *script_version (lex_ctxt *);
 tree_cell *script_copyright (lex_ctxt *);
-tree_cell *script_summary (lex_ctxt *);
 tree_cell *script_category (lex_ctxt *);
 tree_cell *script_family (lex_ctxt *);
 tree_cell *script_dependencies (lex_ctxt *);


### PR DESCRIPTION
This command was unused already since quite a while,
because the summary was specified via a tag.
Since the usage of script_summary has been entirely removed from
GSF and GCF, this function finally can be removed from the code.

* nasl/nasl_init.c (libfuncs): Remove script_summary from table.

* nasl/nasl_scanner_glue.c (script_summary): Removed this function.
  It was an empty stub anyway.

* nasl/nasl_scanner_glue.h: Removed proto accordingly.