### PR TITLE
Backport PR #61.

### DIFF
--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -274,7 +274,6 @@ static pid_t
 loading_handler_start ()
 {
   pid_t child_pid, parent_pid;
-  int opts;
 
   init_loading_shm ();
   parent_pid = getpid ();
@@ -302,17 +301,6 @@ loading_handler_start ()
       if (loading_stop_signal || kill (parent_pid, 0) < 0)
         break;
       lg_address = sizeof (struct sockaddr_un);
-
-      if ((opts = fcntl (global_iana_socket, F_GETFL, 0)) < 0)
-        {
-          log_write ("fcntl: %s", strerror (errno));
-          exit (0);
-        }
-      if (fcntl (global_iana_socket, F_SETFL, opts | O_NONBLOCK) < 0)
-        {
-          log_write ("fcntl: %s", strerror (errno));
-          exit (0);
-        }
 
       if (listen (global_iana_socket, 5) < 0)
         continue;
@@ -342,9 +330,6 @@ loading_handler_start ()
           exit (0);
         }
       waitpid (child_pid1, &ret, WNOHANG);
-
-      if (fcntl (global_iana_socket, F_SETFL, opts) < 0)
-        log_write ("fcntl: %s", strerror (errno));
     }
   exit (0);
 }


### PR DESCRIPTION
Setting O_NONBLOCK for global_iana_socket causes the main loop to run
continuously.