### PR TITLE
Update sync script and docs for auto-sync.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -155,16 +155,9 @@ Setting up an openvas-scanner requires the following steps:
 
    $ openvassd
 
-   Be aware that the first launch of openvas-scanner after the initial feed
-   synchronization or after large feed updates will take longer than usual since
-   the internal scanner cache has to be updated. Subsequent launches will be
-   much quicker.
-
    Sending SIGHUP to the scanner main process will initiate a reload of the
    feed content and of the scanner preferences. This will not affect running
-   scans. The NVT synchronisation routine will try to send the SIGHUP to the
-   scanner on its own. This works only if the pid-file of scanner is found
-   which is expected to be /var/run/openvassd.pid.
+   scans.
 
    Please note that although you can start openvassd as a user without elevated
    privileges, it is recommended that you start openvassd as root since a number

--- a/doc/greenbone-nvt-sync.8
+++ b/doc/greenbone-nvt-sync.8
@@ -18,9 +18,8 @@ In case no subscription key is present, the update synchronisation will use the 
 The script 
 .B greenbone-nvt-sync
 will fetch all new and updated security checks and install them at the proper
-location. Once this is done it will send a signal to the OpenVAS Scanner, openvassd(8)
-so that the new NVTs are loaded and considered for new security scans. If your installation
-does not allow automatic restart, you need to restart the scanner manually.
+location. Once this is done OpenVAS Scanner, openvassd(8) will automatically detect
+that new and updated NVTs are present and consider them for next activities.
 
 .SH SEE ALSO
 For more information see:

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -73,9 +73,6 @@ SELFTEST_FAIL=0
 # Port to use for synchronization. Default value is 24.
 PORT=24
 
-# Directory where pidfiles are located
-PIDFILEDIR="@OPENVAS_RUN_DIR@"
-
 # Directory where the OpenVAS Scanner configuration is located
 OPENVAS_SYSCONF_DIR="@OPENVAS_SYSCONF_DIR@"
 
@@ -89,11 +86,6 @@ ENABLED=1
 # rather only update OpenVAS Scanner. This can be controlled via the --refresh
 # parameter.
 REFRESH_ONLY=0
-
-# If SYNC_ONLY is set to 1, the sync script will only perform the
-# synchronization but will not update OpenVAS Scanner.
-# This can be controlled via the --sync-only parameter.
-SYNC_ONLY=0
 
 # LOG_CMD defines the command to use for logging. To have logger log to stderr
 # as well as syslog, add "-s" here.
@@ -600,25 +592,6 @@ sync_nvts(){
   fi
 }
 
-update_openvassd (){
-  if [ $SYNC_ONLY -eq 1 ]
-  then
-    return
-  fi
-
-  SCANNER_PIDFILE="$PIDFILEDIR/openvassd.pid"
-  if [ -r "$SCANNER_PIDFILE" ]
-  then
-    SCANNER_PID=`cat $SCANNER_PIDFILE`
-    kill -HUP $SCANNER_PID
-    log_write "Sent signal to OpenVAS Scanner to update (PID $SCANNER_PID)."
-  else
-    log_err "$PIDFILEDIR/openvassd.pid not found, not updating OpenVAS Scanner."
-    log_write "Please restart OpenVAS Scanner or send SIGHUP to it"
-    SYNC_ONLY=1
-  fi
-}
-
 do_self_test ()
 {
   MD5SUM_AVAIL=`command -v md5sum`
@@ -668,7 +641,6 @@ do_sync ()
     log_write "Feed is already current, skipping synchronization."
   else
     sync_nvts
-    update_openvassd
   fi
 }
 
@@ -684,7 +656,6 @@ do_help () {
   echo " --refresh      update OpenVAS Scanner without downloading new state"
   echo " --rsync        only use rsync to download feed files"
   echo " --selftest     perform self-test"
-  echo " --sync-only    download new state without updating OpenVAS Scanner"
   echo " --verbose      makes the sync process print details"
   echo " --version      display version"
   echo " --wget         only use wget to download feed files"
@@ -733,9 +704,6 @@ while test $# -gt 0; do
     --help)
       do_help
       exit 0
-      ;;
-    --sync-only)
-      SYNC_ONLY=1
       ;;
     --refresh)
       REFRESH_ONLY=1


### PR DESCRIPTION
Meanwhile the scanner auto-updates NVTs when it finds new
feed status. Thus simplify the sync script and update
the documentation.

* tools/greenbone-nvt-sync.in: Drop the HUP signal sending
  to the openvassd process to make it update the feed because
  meanwhile the scanner watches the version file and will
  update on its own.
  Thus remote PIDFILE elements completely as it was only
  used for this purpose.
  Also remove the option --sync-only because now the sync
  script does only sync anyway.

* INSTALL: Remove/adapt parts where the manual sync or
  addtional waiting times were discussed since this
  also is simpler and faster now.

* doc/greenbone-nvt-sync.8: Adapt to the new updating scheme.