### PR TITLE
Remove old TODO.

### DIFF
--- a/nasl/nasl_signature.c
+++ b/nasl/nasl_signature.c
@@ -90,7 +90,6 @@ examine_signatures (gpgme_verify_result_t result, int sig_count)
   else
     {
       nasl_trace (NULL, "examine_signatures: signature is invalid\n");
-      /** @todo Early stop might be possible. Can return here. */
     }
 
   return 0;


### PR DESCRIPTION
Before, this function checked for more than one signature, and all
of them had to be valid. The behavior has changed and this TODO
makes no sence anymore.