### PR TITLE
Rename "Authenticated" mode to clarify that it is only disabling

### DIFF
--- a/doc/openvas-nasl.1
+++ b/doc/openvas-nasl.1
@@ -50,9 +50,7 @@ the script  (run extended checks).
 
 .TP
 .B \-X
-Run the script in 
-.BI authenticated
-mode. For more information see the nasl reference manual
+Run the script with disabled signature verification.
 
 .TP
 .B \-h

--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1759,7 +1759,7 @@ exec_nasl_script (struct script_infos *script_infos, const char *name,
 
   bzero (&ctx, sizeof (ctx));
   if (mode & NASL_ALWAYS_SIGNED)
-    ctx.always_authenticated = 1;
+    ctx.always_signed = 1;
   if (nvticache_initialized ())
     ctx.kb = nvticache_get_kb ();
   else

--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -191,7 +191,7 @@ main (int argc, char **argv)
   g_option_context_free (option_context);
 
   mode |= NASL_COMMAND_LINE;
-  /* authenticated mode */
+  /* signing mode */
   mode |= NASL_ALWAYS_SIGNED;
   /* linter on */
   mode |= NASL_LINT;

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -170,7 +170,7 @@ main (int argc, char **argv)
   static gchar *source_iface = NULL;
   static gchar *vendor_version_string = NULL;
   static gboolean with_safe_checks = FALSE;
-  static gboolean authenticated_mode = FALSE;
+  static gboolean signing_mode = FALSE;
   static gchar *include_dir = NULL;
   static gchar **nasl_filenames = NULL;
   static gchar **kb_values = NULL;
@@ -204,8 +204,8 @@ main (int argc, char **argv)
     {"safe", 's', 0, G_OPTION_ARG_NONE, &with_safe_checks,
      "Specifies that the script should be run with 'safe checks' enabled",
      NULL},
-    {"authenticated", 'X', 0, G_OPTION_ARG_NONE, &authenticated_mode,
-     "Run the script in 'authenticated' mode", NULL},
+    {"disable-signing", 'X', 0, G_OPTION_ARG_NONE, &signing_mode,
+     "Run the script with disabled signature verification", NULL},
     {"include-dir", 'i', 0, G_OPTION_ARG_STRING, &include_dir,
      "Search for includes in <dir>", "<dir>"},
     {"debug-tls", 0, 0, G_OPTION_ARG_INT, &debug_tls,
@@ -248,7 +248,7 @@ main (int argc, char **argv)
   if (nasl_debug)
     global_nasl_debug = 1;
   mode |= NASL_COMMAND_LINE;
-  if (authenticated_mode)
+  if (signing_mode)
     mode |= NASL_ALWAYS_SIGNED;
   if (description_only)
     mode |= NASL_EXEC_DESCR;

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -26,7 +26,7 @@
 typedef struct
 {
   int line_nb;
-  int always_authenticated;
+  int always_signed;
   int index;
   tree_cell *tree;
   char *buffer;

--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -332,7 +332,7 @@ inc: INCLUDE '(' string ')'
 	  naslctxt	subctx;
 
           bzero (&subctx, sizeof (subctx));
-          subctx.always_authenticated = ((naslctxt*)parm)->always_authenticated;
+          subctx.always_signed = ((naslctxt*)parm)->always_signed;
           subctx.kb = ((naslctxt *) parm)->kb;
           subctx.tree = ((naslctxt*) parm)->tree;
           $$ = NULL;
@@ -776,7 +776,7 @@ init_nasl_ctx(naslctxt* pc, const char* name)
     return -1;
   }
 
-  if (pc->always_authenticated)
+  if (pc->always_signed)
     {
       g_free(full_name);
       return 0;

--- a/nasl/nasl_lex_ctxt.h
+++ b/nasl/nasl_lex_ctxt.h
@@ -35,7 +35,7 @@ typedef struct struct_lex_ctxt
   unsigned fct_ctxt:1;          /* This is a function context */
   unsigned break_flag:1;        /* Break from loop */
   unsigned cont_flag:1;         /* Next iteration in loop */
-  unsigned always_authenticated:1;
+  unsigned always_signed:1;
   struct script_infos *script_infos;
   const char *oid;
   int recv_timeout;


### PR DESCRIPTION
signature verification.

"Authenticated" mode has no meaning and should be clarified that it is disabling the signature / checksum verification of the script.