### PR TITLE
Move check for pkg-config to where it is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,6 @@ endif (POLICY CMP0005)
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-include (FindPkgConfig)
-
-if (NOT PKG_CONFIG_FOUND)
-  message(FATAL_ERROR "pkg-config executable not found. Aborting.")
-endif (NOT PKG_CONFIG_FOUND)
-
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Debug)
 endif (NOT CMAKE_BUILD_TYPE)

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -25,6 +25,12 @@
 ## Dependency checks
 ##
 
+include (FindPkgConfig)
+
+if (NOT PKG_CONFIG_FOUND)
+  message(FATAL_ERROR "pkg-config executable not found. Aborting.")
+endif (NOT PKG_CONFIG_FOUND)
+
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -42,6 +42,12 @@ set (NASL_VERSION_STRING "${NASL_VERSION_MAJOR}.${NASL_VERSION_MINOR}${NASL_VERS
 set (NASL_PACKAGE_VERSION "${NASL_VERSION_STRING}${PROJECT_VERSION_GIT}")
 set (NASL_VERSION "${NASL_VERSION_STRING}")
 
+include (FindPkgConfig)
+
+if (NOT PKG_CONFIG_FOUND)
+  message(FATAL_ERROR "pkg-config executable not found. Aborting.")
+endif (NOT PKG_CONFIG_FOUND)
+
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (GIO REQUIRED gio-2.0)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,12 @@
 
 ## Dependency checks
 
+include (FindPkgConfig)
+
+if (NOT PKG_CONFIG_FOUND)
+  message(FATAL_ERROR "pkg-config executable not found. Aborting.")
+endif (NOT PKG_CONFIG_FOUND)
+
 pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=1.0.0)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=1.0.0)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)


### PR DESCRIPTION
As the top-level CMakeLists.txt no longer checks dependencies directly
it makes no sense for it to consider a missing pkg-config binary a fatal
error.

Instead, it is the job of the second-level CMakeLists.txt files which
are actually using pkg-config to ensure it is available and fail if not.

This change makes openvas-scanner consistent with gvm-libs. It also
means pkg-config is no longer a (useless) dependency for generating
source code documentation.