### PR TITLE
Improvements for CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build_gcc_core:
     docker:
       - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
     steps:
@@ -16,3 +16,27 @@ jobs:
       - run:
           name: Configure and Compile
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
+  scan_build:
+    docker:
+      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-clang-core
+    steps:
+      - run:
+          working_directory: ~/gvm-libs
+          name: Checkout gvm-libs
+          command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git
+      - run:
+          working_directory: ~/gvm-libs
+          name: Configure and compile gvm-libs
+          command: pushd gvm-libs && mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Debug .. && make install && popd
+      - checkout
+      - run:
+          name: Configure and Scan Build
+          command: mkdir build && cd build/ && scan-build cmake -DCMAKE_BUILD_TYPE=Debug .. && scan-build -o ~/scan-build-report make
+      - store_artifacts:
+          path: ~/scan-build-report
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build_gcc_core
+      - scan_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: wiegandm/openvas-scanner-core-debian-stretch
+      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
     steps:
       - run:
           working_directory: ~/gvm-libs


### PR DESCRIPTION
This PR updates the location of the Docker image used in the CI environment and adds a job for performing static analysis using scan-build (ccc-analyzer) and collecting the resulting report as a build artifact, similar to greenbone/gvm-libs#84.

Note that the job is currently mainly informational, i.e. issues found by scan-build will not cause the build to fail. This can (and likely will) be changed easily in the future so that scan-build issues trigger a CI failure to be reported in GitHub.