### PR TITLE
Add scan_id command line option and get scan prefs from redis.

### DIFF
--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -36,6 +36,7 @@ struct scan_globals {
   GHashTable *files_translation;
   GHashTable *files_size_translation;
   int global_socket;
+  char *scan_id;
 };
 
 struct host_info;

--- a/src/ntp.c
+++ b/src/ntp.c
@@ -409,8 +409,10 @@ __ntp_timestamp_scan_host (int soc, kb_t kb, char *msg, char *host)
   if (timestr[len - 1] == '\n')
     timestr[len - 1] = '\0';
 
-  send_printf (soc, "SERVER <|> TIME <|> %s <|> %s <|> %s <|> SERVER\n", msg,
-               host, timestr);
+  /* Send the message to the client only if it is a OTP scan. */
+  if (is_otp_scan ())
+    send_printf (soc, "SERVER <|> TIME <|> %s <|> %s <|> %s <|> SERVER\n", msg,
+                 host, timestr);
   /* For external tools */
   if (!strcmp (msg, "HOST_START"))
     kb_item_push_str (kb, "internal/start_time", timestr);

--- a/src/utils.c
+++ b/src/utils.c
@@ -43,12 +43,32 @@
 
 extern int global_max_hosts;
 extern int global_max_checks;
+int global_scan_type = 1;
 
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib log domain.
  */
 #define G_LOG_DOMAIN "sd   main"
+
+/**
+ * @brief Check the scan type
+ * @return 1 if OTP type, 0 if OSP.
+ */
+int
+is_otp_scan ()
+{
+  return global_scan_type;
+}
+
+/**
+ * @brief Set the scan type
+ */
+void
+set_scan_type (int type)
+{
+  global_scan_type = type;
+}
 
 /**
  * Get the max number of hosts to test at the same time.

--- a/src/utils.h
+++ b/src/utils.h
@@ -31,6 +31,9 @@
 #ifndef _OPENVAS_UTILS_H
 #define _OPENVAS_UTILS_H
 
+int is_otp_scan (void);
+void set_scan_type (int);
+
 int get_max_hosts_number (void);
 int get_max_checks_number (void);
 


### PR DESCRIPTION
A new command line option 'scan-start' is added and receive a scan_id.
If no scan_id is passed, for each new task is autogenerated.
The scan_id is used to identify a Redis DB where the scan preferences should be
stored if the scanner has been started with the --scan-start option.
Then, beforethe attack, the preferences are taken from redis and stored in the
globals structure. After that the attack continues as before.

* misc/scanneraux.h (scan_globals): Add scan_id and otp_scan members.

* src/attack.c (attack_start): Add the item "internal/scan_id" into the KB
which stores the scan_id. New global_scan_type global variable.
(is_otp_scan, set_scan_type): New functions.
(error_message_to_client): Check the scan type (OTP or OSP) before trying
to send a message to the client. In OSP type there is no socket, since the
information is forwarded through redis.

* src/hosts.c: (forward, forward_status): Check for the scan type before
forwarding a message.
(host_rm): Check for scan type before deleting the kb.
(hosts_read_client): Only check for a socket if it is an OTP scan type.

* src/ntp.c (__ntp_timestamp_scan_host):  Check for the scan type before
forwarding a message

* src/openvassd.c: (load_scan_preferences): New function. Search the KB
with the corresponding scan_id, get the preferences and store them into
globals structures.
(handle_client): Call load_scan_preferences
(scanner_thread): Check if the scan_id was passed as command line option.
In other case, generate the scan_id.
(main): Add new 'scan-start' command line option. If it is set, start a scan
without global socket and without wait for a client.
(start_single_task_scan): Start a single scan using the preferences from redis.