### PR TITLE
Rename setting "kb_location" to "db_address"

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -151,7 +151,7 @@ report_kb_failure (int soc, int errcode)
 
   errcode = abs (errcode);
   msg = g_strdup_printf ("WARNING: Cannot connect to KB at '%s': %s'",
-                         prefs_get ("kb_location"), strerror (errcode));
+                         prefs_get ("db_address"), strerror (errcode));
   g_warning ("%s", msg);
   error_message_to_client (soc, msg, NULL, NULL);
   g_free (msg);
@@ -371,7 +371,7 @@ init_host_kb (struct scan_globals *globals, char *ip_str, kb_t *network_kb)
   kb_t kb;
   gchar *hostname_pattern;
   enum net_scan_status nss;
-  const gchar *kb_path = prefs_get ("kb_location");
+  const gchar *kb_path = prefs_get ("db_address");
   int rc, soc;
 
   nss = network_scan_status (globals);
@@ -838,7 +838,7 @@ check_kb_access (int soc)
   int rc;
   kb_t kb;
 
-  rc = kb_new (&kb, prefs_get ("kb_location"));
+  rc = kb_new (&kb, prefs_get ("db_address"));
   if (rc)
       report_kb_failure (soc, rc);
   else
@@ -966,7 +966,7 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
                      "in network phase with target %s",
                      hostlist, network_targets);
 
-          rc = kb_new (network_kb, prefs_get ("kb_location"));
+          rc = kb_new (network_kb, prefs_get ("db_address"));
           if (rc)
             {
               report_kb_failure (global_socket, rc);
@@ -1008,7 +1008,7 @@ attack_network (struct scan_globals *globals, kb_t *network_kb)
       struct attack_start_args args;
       char *host_str;
 
-      rc = kb_new (&host_kb, prefs_get ("kb_location"));
+      rc = kb_new (&host_kb, prefs_get ("db_address"));
       if (rc)
         {
           report_kb_failure (global_socket, rc);

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -143,7 +143,7 @@ static openvassd_option openvassd_defaults[] = {
   // Empty options must be "\0", not NULL, to match the behavior of
   // prefs_init.
   {"report_host_details", "yes"},
-  {"kb_location", KB_PATH_DEFAULT},
+  {"db_address", KB_PATH_DEFAULT},
   {"timeout_retry", "3"},
   {"open_sock_max_attempts", "5"},
   {"time_between_request", "0"},
@@ -636,7 +636,7 @@ check_kb_status ()
 
   while (waitredis != 0)
     {
-      ret = kb_new (&kb_access_aux, prefs_get ("kb_location"));
+      ret = kb_new (&kb_access_aux, prefs_get ("db_address"));
       if (ret)
         {
           g_message ("Redis connection lost. Trying to reconnect.");
@@ -658,7 +658,7 @@ check_kb_status ()
     }
   while (waitkb != 0)
     {
-      kb_access_aux = kb_find (prefs_get ("kb_location"), NVTICACHE_STR);
+      kb_access_aux = kb_find (prefs_get ("db_address"), NVTICACHE_STR);
       if (!kb_access_aux)
         {
           g_message ("Redis kb not found. Trying again in 2 seconds.");
@@ -870,7 +870,7 @@ flush_all_kbs ()
   kb_t kb;
   int rc;
 
-  rc = kb_new (&kb, prefs_get ("kb_location"));
+  rc = kb_new (&kb, prefs_get ("db_address"));
   if (rc)
     return rc;
 

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -368,7 +368,7 @@ plugins_init (void)
   pid_t child_pid;
   const char *plugins_folder = prefs_get ("plugins_folder");
 
-  if (nvticache_init (plugins_folder, prefs_get ("kb_location")))
+  if (nvticache_init (plugins_folder, prefs_get ("db_address")))
     {
       g_debug ("Failed to initialize nvti cache.");
       return -1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -181,7 +181,8 @@ is_scanner_only_pref (const char *pref)
     return 0;
   if (!strcmp (pref, "logfile") || !strcmp (pref, "config_file")
       || !strcmp (pref, "plugins_folder")
-      || !strcmp (pref, "kb_location")
+      || !strcmp (pref, "kb_location") // old name of db_address, ignore from old conf's
+      || !strcmp (pref, "db_address")
       || !strcmp (pref, "negot_timeout")
       || !strcmp (pref, "force_pubkey_auth")
       || !strcmp (pref, "log_whole_attack")


### PR DESCRIPTION
Meanhile the redis database is not only used to store temporarily
some information about a host during a scan.
It is used as a general database backend, for example to store the
NVT meta data.

This name change reflects the new usage. Also it is more of an "address"
rather than a "location".