### PR TITLE
added systemd units

### DIFF
--- a/systemd/openvas-scanner.default
+++ b/systemd/openvas-scanner.default
@@ -1,0 +1,27 @@
+# Options to pass to the openvassd daemon
+OPTIONS=""
+
+# Set to yes if plugins should be automatically updated via a cron job
+auto_plugin_update=no
+
+# Notify OpenVAS scanner after update by seding it SIGHUP?
+notify_openvas_scanner=yes
+
+# Method to use to get updates. The default is via rsync
+# Note that only wget and curl support retrieval via proxy
+# update_method=rsync|wget|curl
+
+# Additionaly, you can specify the following variables
+#NVT_DIR		where to extract plugins (absolute path)
+#OV_RSYNC_FEED		URL of rsync feed
+#OV_HTTP_FEED		URL of http feed
+
+# First time install token
+FIRSTBOOT=no
+
+# TLS Encryption options
+# Somewhat paranoid defaults. TLS1.2 only
+GNUTLS_PRIORITIES="SECURE256:+SUITEB192:+SECURE192:+SECURE128:+SUITEB128:-MD5:-SHA1:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-SSL3.0"
+
+# Reasonably secure, if you need to connect with an old web browser.
+#GNUTLS_PRIORITIES="SECURE256:+SUITEB192:+SECURE192:+SECURE128:+SUITEB128:-MD5:+VERS-TLS1.0:+VERS-TLS1.1:-VERS-SSL3.0"

--- a/systemd/openvas-scanner.logrotate
+++ b/systemd/openvas-scanner.logrotate
@@ -1,0 +1,11 @@
+# logrotate for openvas
+/var/log/openvas/openvassd.log {
+        rotate 4
+        weekly
+        compress
+        delaycompress
+        missingok
+	postrotate
+	    /bin/kill -HUP `pidof openvassd`
+	endscript
+}

--- a/systemd/openvas-scanner.service
+++ b/systemd/openvas-scanner.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=OpenVAS Scanner
+After=network.target
+Before=openvas-manager.service
+
+[Service]
+Type=forking
+EnvironmentFile=-/etc/sysconfig/openvas-scanner
+ExecStart=/usr/sbin/openvassd $OPTIONS
+#ExecStart=/usr/sbin/openvassd --gnutls-priorities $GNUTLS_PRIORITIES $OPTIONS
+Restart=always
+RestartSec=1
+User=root
+Group=root
+TimeoutSec=1200
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
As requested. Here is my systemd unit for openvas-scanner.

There is a .service file. the default file gets renamed to openvas-scanner and put in either /etc/default or /etc/sysconfig depending on the distro

there is also a file for logrotated if rsyslog is being used on top of this