### PR TITLE
Cleanup processes table more frequently.

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -542,8 +542,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip,
         }
       else if (plugin == NULL)
         break;
-      else
-        pluginlaunch_wait_for_free_process (kb);
+      pluginlaunch_wait_for_free_process (kb);
     }
 
   pluginlaunch_wait (kb);


### PR DESCRIPTION
Move usleep() call outside of update_running_processes(). Wait inside
pluginlaunch_wait_for_free_process() only when processes table is full.
This fixes scan host process being occasionaly stuck waiting before
launching new plugins.