### PR TITLE
Fix typo in man page file.

### DIFF
--- a/doc/openvas-nasl.1
+++ b/doc/openvas-nasl.1
@@ -73,7 +73,7 @@ Set KB key to value. Can be used multiple times.
 NASL comes from a private project called 'pkt_forge', which was written in late 1998 by Renaud Deraison and which was an interactive shell to forge and send raw IP packets (this pre-dates Perl's Net::RawIP by a couple of weeks). It was then extended to do a wide range of network-related operations and integrated into Nessus as 'NASL'. 
 
 The parser was completely hand-written and a pain to work with. In Mid-2002, Michel Arboi wrote a bison parser for NASL, and he and Renaud Deraison re-wrote NASL from scratch. Although the "new" NASL was nearly working as early as 
-August 2002, Michel's lazyness made us wait for early 2003 to have it working completely.
+August 2002, Michel's laziness made us wait for early 2003 to have it working completely.
 
 .SH AUTHOR
 Most of the engine is (C) 2003 Michel Arboi, most of the built-in functions


### PR DESCRIPTION
From a downstream patch available at:

https://salsa.debian.org/pkg-security-team/openvas-libraries/commit/b8f8788d03de3593faf73b795906c1bfa3e89d78