### PR TITLE
Don't check for new vhosts values on plugin launch.

### DIFF
--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -119,6 +119,7 @@ get_hostname_source (lex_ctxt * lexic)
 tree_cell *
 add_hostname (lex_ctxt * lexic)
 {
+  pid_t host_pid;
   char buffer[4096];
   char *value = get_str_var_by_name (lexic, "hostname");
   char *source = get_str_var_by_name (lexic, "source");
@@ -131,10 +132,13 @@ add_hostname (lex_ctxt * lexic)
   if (!source || !*source)
     source = "NASL";
 
-  /* Push to KB. To be fetched by scan host process. */
+  /* Push to KB. Signal host process to fetch it. */
   kb_item_push_str (lexic->script_infos->key, "internal/vhosts", value);
   snprintf (buffer, sizeof (buffer), "internal/source/%s", value);
   kb_item_push_str (lexic->script_infos->key, buffer, source);
+  host_pid = kb_item_get_int (lexic->script_infos->key, "internal/hostpid");
+  if (host_pid)
+    kill (host_pid, SIGUSR1);
 
   /* Add to current process' vhosts list. */
   plug_add_host_fqdn (lexic->script_infos, value, source);


### PR DESCRIPTION
Instead make child process signal the host process that a new one was
inserted.

Reduces number of requests sent to Redis (~46k per-host in F&F scan)