### PR TITLE
Cleanup finished plugins while searching for next plugin to run.

### DIFF
--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -499,11 +499,10 @@ void
 pluginlaunch_wait_for_free_process (void)
 {
   int num = num_running_processes;
-  do
+  while (num && num_running_processes == num)
     {
       wait_for_children ();
       read_running_processes ();
       update_running_processes ();
     }
-  while (num_running_processes == num);
 }

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -334,6 +334,8 @@ plugin_next_unrun_dependency (plugins_scheduler_t sched,
                  dependencies_ptr[0]->plugin->oid);
       return NULL;
     }
+  if (calls && calls % 15 == 0)
+    pluginlaunch_wait_for_free_process ();
 
   for (i = 0; dependencies_ptr[i] != NULL; i++)
     {


### PR DESCRIPTION
As sometimes the scanner host process gets stuck searching for plugins
to run while dependencies are still being run, while the later are
waiting for the scanner host process receiving their IPC messages.