### PR TITLE
Check if a pattern was provided for get_kb_list().

### DIFF
--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -675,7 +675,10 @@ get_kb_list (lex_ctxt * lexic)
   retc->type = DYN_ARRAY;
   retc->x.ref_val = a = g_malloc0 (sizeof (nasl_array));
 
-  top = res = kb_item_get_pattern (kb, kb_mask);
+  if (strchr (kb_mask, '*'))
+    top = res = kb_item_get_pattern (kb, kb_mask);
+  else
+    top = res = kb_item_get_all (kb, kb_mask);
 
   while (res != NULL)
     {


### PR DESCRIPTION
If not, use kb_item_get_all() instead of kb_item_get_pattern(), to use
SMEMBERS instead of KEYS Redis command.