### PR TITLE
Define MAXPATHLEN for specific downstream architectures.

### DIFF
--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -43,6 +43,11 @@
 #include "nasl_cmd_exec.h"
 #include "nasl_debug.h"
 
+/* MAXPATHLEN doesn't exist on some architectures like hurd i386 */
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 4096
+#endif
+
 static pid_t pid = 0;
 
 static char *


### PR DESCRIPTION
Partly pulled the patch from https://sources.debian.org/patches/openvas-libraries/9.0.3-1/Fix-PATH_MAX-undeclared-issue-on-hurd-i386-platform.patch/

Rationale:

Help downstream with the maintenance of our code base without having to track patches to it.

Reference for the openvas-libraries-9.0 changes: https://github.com/greenbone/gvm-libs/pull/119