### PR TITLE
[5.1] Add CODEOWNERS and .gitignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default reviewers
+*                 @greenbone/gvm-dev

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+nasl/nasl_grammar.output
+nasl/nasl_grammar.tab.c
+nasl/nasl_grammar.tab.h


### PR DESCRIPTION
Backport of #3 and #85 to the openvas-scanner-5.1 branch.