### PR TITLE
Fix parameter pollution in certain nasl functions.

### DIFF
--- a/nasl/nasl_cert.c
+++ b/nasl/nasl_cert.c
@@ -811,7 +811,7 @@ nasl_cert_query (lex_ctxt *lexic)
     }
 
   /* Get the index which defaults to 0.  */
-  cmdidx = get_int_local_var_by_name (lexic, "idx", 0);
+  cmdidx = get_int_var_by_name (lexic, "idx", 0);
 
   /* Command dispatcher.  */
   retc = NULL;

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -92,7 +92,7 @@ nasl_pread (lex_ctxt * lexic)
     }
 
   a = get_variable_by_name (lexic, "argv");
-  cmd = get_str_local_var_by_name (lexic, "cmd");
+  cmd = get_str_var_by_name (lexic, "cmd");
   if (cmd == NULL || a == NULL || (v = a->x.ref_val) == NULL)
     {
       deref_cell (a);
@@ -110,7 +110,7 @@ nasl_pread (lex_ctxt * lexic)
       return NULL;
     }
 
-  cd = get_int_local_var_by_name (lexic, "cd", 0);
+  cd = get_int_var_by_name (lexic, "cd", 0);
 
   cwd[0] = '\0';
   if (cd)
@@ -297,8 +297,8 @@ nasl_fwrite (lex_ctxt * lexic)
   size_t flen;
   GError *ferror = NULL;
 
-  fcontent = get_str_local_var_by_name (lexic, "data");
-  fname = get_str_local_var_by_name (lexic, "file");
+  fcontent = get_str_var_by_name (lexic, "data");
+  fname = get_str_var_by_name (lexic, "file");
   if (!fcontent || !fname)
     {
       nasl_perror (lexic, "fwrite: need two arguments 'data' and 'file'\n");
@@ -385,14 +385,14 @@ nasl_file_open (lex_ctxt * lexic)
   int fd;
   int imode = O_RDONLY;
 
-  fname = get_str_local_var_by_name (lexic, "name");
+  fname = get_str_var_by_name (lexic, "name");
   if (fname == NULL)
     {
       nasl_perror (lexic, "file_open: need file name argument\n");
       return NULL;
     }
 
-  mode = get_str_local_var_by_name (lexic, "mode");
+  mode = get_str_var_by_name (lexic, "mode");
   if (mode == NULL)
     {
       nasl_perror (lexic, "file_open: need file mode argument\n");
@@ -499,14 +499,14 @@ nasl_file_read (lex_ctxt * lexic)
   int flength;
   int n;
 
-  fd = get_int_local_var_by_name (lexic, "fp", -1);
+  fd = get_int_var_by_name (lexic, "fp", -1);
   if (fd < 0)
     {
       nasl_perror (lexic, "file_read: need file pointer argument\n");
       return NULL;
     }
 
-  flength = get_int_local_var_by_name (lexic, "length", 0);
+  flength = get_int_var_by_name (lexic, "length", 0);
 
   buf = g_malloc0 (flength + 1);
 
@@ -542,8 +542,8 @@ nasl_file_write (lex_ctxt * lexic)
   int fd;
   int n;
 
-  content = get_str_local_var_by_name (lexic, "data");
-  fd = get_int_local_var_by_name (lexic, "fp", -1);
+  content = get_str_var_by_name (lexic, "data");
+  fd = get_int_var_by_name (lexic, "fp", -1);
   if (content == NULL || fd < 0)
     {
       nasl_perror (lexic, "file_write: need two arguments 'fp' and 'data'\n");
@@ -586,8 +586,8 @@ nasl_file_seek (lex_ctxt * lexic)
   int fd;
   int foffset;
 
-  foffset = get_int_local_var_by_name (lexic, "offset", 0);
-  fd = get_int_local_var_by_name (lexic, "fp", -1);
+  foffset = get_int_var_by_name (lexic, "offset", 0);
+  fd = get_int_var_by_name (lexic, "fp", -1);
   if (fd < 0)
     {
       nasl_perror (lexic, "file_seek: need one arguments 'fp'\n");

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -207,10 +207,10 @@ nasl_cipher_des (lex_ctxt *lexic)
 static tree_cell *
 nasl_hmac (lex_ctxt * lexic, int algorithm)
 {
-  char *data = get_str_local_var_by_name (lexic, "data");
-  char *key = get_str_local_var_by_name (lexic, "key");
-  int data_len = get_local_var_size_by_name (lexic, "data");
-  int key_len = get_local_var_size_by_name (lexic, "key");
+  char *data = get_str_var_by_name (lexic, "data");
+  char *key = get_str_var_by_name (lexic, "key");
+  int data_len = get_var_size_by_name (lexic, "data");
+  int key_len = get_var_size_by_name (lexic, "key");
 
   return nasl_gcrypt_hash (lexic, algorithm, data, data_len, key, key_len);
 }
@@ -358,8 +358,8 @@ nasl_hmac_sha256 (lex_ctxt * lexic)
 
   key = get_str_var_by_name (lexic, "key");
   data = get_str_var_by_name (lexic, "data");
-  datalen = get_local_var_size_by_name (lexic, "data");
-  keylen = get_local_var_size_by_name (lexic, "key");
+  datalen = get_var_size_by_name (lexic, "data");
+  keylen = get_var_size_by_name (lexic, "key");
   if (!key || !data || keylen <= 0 || datalen <= 0)
     {
       nasl_perror (lexic,
@@ -526,9 +526,9 @@ nasl_prf (lex_ctxt * lexic, int hmac)
   seed = get_str_var_by_name (lexic, "seed");
   label = get_str_var_by_name (lexic, "label");
   outlen = get_int_var_by_name (lexic, "outlen", -1);
-  seed_len = get_local_var_size_by_name (lexic, "seed");
-  secret_len = get_local_var_size_by_name (lexic, "secret");
-  label_len = get_local_var_size_by_name (lexic, "label");
+  seed_len = get_var_size_by_name (lexic, "seed");
+  secret_len = get_var_size_by_name (lexic, "secret");
+  label_len = get_var_size_by_name (lexic, "label");
   if (!secret || !seed || secret_len <= 0 || seed_len <= 0 || !label
       || label_len <= 0 || outlen <= 0)
     {

--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -121,7 +121,7 @@ mpi_from_named_parameter (lex_ctxt * lexic, gcry_mpi_t * dest,
   long size;
   char *s;
 
-  s = get_str_local_var_by_name (lexic, parameter);
+  s = get_str_var_by_name (lexic, parameter);
   size = get_var_size_by_name (lexic, parameter);
 
   if (!s)
@@ -223,7 +223,7 @@ nasl_bn_random (lex_ctxt * lexic)
   retc->type = CONST_DATA;
 
   /* number of random bits */
-  need = get_int_local_var_by_name (lexic, "need", 0);
+  need = get_int_var_by_name (lexic, "need", 0);
 
   key = gcry_mpi_new (0);
   if (!key)
@@ -263,11 +263,11 @@ nasl_load_privkey_param (lex_ctxt * lexic, const char *priv_name,
   int err;
 
   /* PEM encoded privkey */
-  priv = get_str_local_var_by_name (lexic, priv_name);
+  priv = get_str_var_by_name (lexic, priv_name);
   privlen = get_var_size_by_name (lexic, priv_name);
 
   /* passphrase */
-  passphrase = get_str_local_var_by_name (lexic, passphrase_name);
+  passphrase = get_str_var_by_name (lexic, passphrase_name);
   pem.data = (unsigned char *) priv;
   pem.size = privlen;
 
@@ -995,7 +995,7 @@ nasl_rsa_sign (lex_ctxt * lexic)
   retc = alloc_tree_cell ();
   retc->type = CONST_DATA;
 
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   data_size = get_var_size_by_name (lexic, "data");
   if (!data)
     goto fail;
@@ -1268,15 +1268,15 @@ nasl_bf_cbc (lex_ctxt * lexic, int enc)
   retc->type = CONST_DATA;
 
   /* key */
-  enckey = get_str_local_var_by_name (lexic, "key");
+  enckey = get_str_var_by_name (lexic, "key");
   enckeylen = get_var_size_by_name (lexic, "key");
 
   /* initialization vector */
-  iv = get_str_local_var_by_name (lexic, "iv");
+  iv = get_str_var_by_name (lexic, "iv");
   ivlen = get_var_size_by_name (lexic, "iv");
 
   /* data to decrypt/encrypt */
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   datalen = get_var_size_by_name (lexic, "data");
 
   if (enckey == NULL || data == NULL || iv == NULL)

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -366,7 +366,7 @@ get_port_transport (lex_ctxt * lexic)
       int trp = plug_get_port_transport (script_infos, port);
 
       retc = alloc_tree_cell ();
-      if (get_int_local_var_by_name (lexic, "asstring", 0))
+      if (get_int_var_by_name (lexic, "asstring", 0))
         {
           const char *s = get_encaps_name (trp);
           retc->type = CONST_STR;
@@ -392,7 +392,7 @@ nasl_same_host (lex_ctxt * lexic)
   char *hn[2], **names[2];
   struct in_addr ia, *a[2];
   int i, j, n[2], names_nb[2], flag;
-  int cmp_hostname = get_int_local_var_by_name (lexic, "cmp_hostname", 0);
+  int cmp_hostname = get_int_var_by_name (lexic, "cmp_hostname", 0);
 
   memset (names_nb, '\0', sizeof (names_nb));
   memset (names, '\0', sizeof (names));

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -78,9 +78,9 @@ _http_req (lex_ctxt * lexic, char *keyword)
 {
   tree_cell *retc;
   char *str;
-  char *item = get_str_local_var_by_name (lexic, "item");
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int port = get_int_local_var_by_name (lexic, "port", -1);
+  char *item = get_str_var_by_name (lexic, "item");
+  char *data = get_str_var_by_name (lexic, "data");
+  int port = get_int_var_by_name (lexic, "port", -1);
   char *url = NULL;
   struct script_infos *script_infos = lexic->script_infos;
   char *auth, tmp[32];

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -784,9 +784,9 @@ nasl_isotime_add (lex_ctxt *lexic)
   memcpy (timebuf, string, ISOTIME_SIZE -1);
   timebuf[ISOTIME_SIZE - 1] = 0;
 
-  nyears = get_int_local_var_by_name (lexic, "years", 0);
-  ndays = get_int_local_var_by_name (lexic, "days", 0);
-  nseconds = get_int_local_var_by_name (lexic, "seconds", 0);
+  nyears = get_int_var_by_name (lexic, "years", 0);
+  ndays = get_int_var_by_name (lexic, "days", 0);
+  nseconds = get_int_var_by_name (lexic, "seconds", 0);
 
   if (nyears && add_years_to_isotime (timebuf, nyears))
     return NULL;

--- a/nasl/nasl_lex_ctxt.h
+++ b/nasl/nasl_lex_ctxt.h
@@ -76,13 +76,10 @@ tree_cell *cell2atom (lex_ctxt *, tree_cell *);
 long int get_int_var_by_num (lex_ctxt *, int, int);
 char *get_str_var_by_num (lex_ctxt *, int);
 long int get_int_var_by_name (lex_ctxt *, const char *, int);
-long int get_int_local_var_by_name (lex_ctxt *, const char *, int);
 char *get_str_var_by_name (lex_ctxt *, const char *);
-char *get_str_local_var_by_name (lex_ctxt *, const char *);
 
 int get_var_size_by_name (lex_ctxt *, const char *);
-int get_local_var_size_by_name (lex_ctxt *, const char *);
-int get_local_var_type_by_name (lex_ctxt *, const char *);
+int get_var_type_by_name (lex_ctxt *, const char *);
 
 
 int get_var_size_by_num (lex_ctxt *, int);

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -92,15 +92,15 @@ nasl_ftp_log_in (lex_ctxt * lexic)
   tree_cell *retc;
   int res;
 
-  soc = get_int_local_var_by_name (lexic, "socket", 0);
+  soc = get_int_var_by_name (lexic, "socket", 0);
   if (soc <= 0)
     return NULL;
 
-  u = get_str_local_var_by_name (lexic, "user");
+  u = get_str_var_by_name (lexic, "user");
   if (u == NULL)
     u = "";
 
-  p = get_str_local_var_by_name (lexic, "pass");
+  p = get_str_var_by_name (lexic, "pass");
   if (p == NULL)
     p = "";
 
@@ -120,7 +120,7 @@ nasl_ftp_get_pasv_address (lex_ctxt * lexic)
   struct sockaddr_in addr;
   tree_cell *retc;
 
-  soc = get_int_local_var_by_name (lexic, "socket", 0);
+  soc = get_int_var_by_name (lexic, "socket", 0);
   if (soc <= 0)
     return NULL;
 
@@ -702,7 +702,7 @@ nasl_localtime (lex_ctxt * lexic)
   tictac = get_int_var_by_num (lexic, 0, 0);
   if (tictac == 0)
     tictac = time (NULL);
-  utc = get_int_local_var_by_name (lexic, "utc", 0);
+  utc = get_int_var_by_name (lexic, "utc", 0);
 
   if (utc)
     ptm = gmtime (&tictac);
@@ -751,16 +751,16 @@ nasl_mktime (lex_ctxt * lexic)
   tree_cell *retc;
   time_t tictac;
 
-  tm.tm_sec = get_int_local_var_by_name (lexic, "sec", 0);      /* seconds */
-  tm.tm_min = get_int_local_var_by_name (lexic, "min", 0);      /* minutes */
-  tm.tm_hour = get_int_local_var_by_name (lexic, "hour", 0);    /* hours */
-  tm.tm_mday = get_int_local_var_by_name (lexic, "mday", 0);    /* day of the month */
-  tm.tm_mon = get_int_local_var_by_name (lexic, "mon", 1);      /* month */
+  tm.tm_sec = get_int_var_by_name (lexic, "sec", 0);      /* seconds */
+  tm.tm_min = get_int_var_by_name (lexic, "min", 0);      /* minutes */
+  tm.tm_hour = get_int_var_by_name (lexic, "hour", 0);    /* hours */
+  tm.tm_mday = get_int_var_by_name (lexic, "mday", 0);    /* day of the month */
+  tm.tm_mon = get_int_var_by_name (lexic, "mon", 1);      /* month */
   tm.tm_mon -= 1;
-  tm.tm_year = get_int_local_var_by_name (lexic, "year", 0);    /* year */
+  tm.tm_year = get_int_var_by_name (lexic, "year", 0);    /* year */
   if (tm.tm_year >= 1900)
     tm.tm_year -= 1900;
-  tm.tm_isdst = get_int_local_var_by_name (lexic, "isdst", -1); /* daylight saving time */
+  tm.tm_isdst = get_int_var_by_name (lexic, "isdst", -1); /* daylight saving time */
   errno = 0;
   tictac = mktime (&tm);
   if (tictac == (time_t) (-1))
@@ -827,7 +827,7 @@ nasl_gunzip (lex_ctxt * lexic)
   void *data, *uncompressed;
   unsigned long datalen, uncomplen;
 
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   if (data == NULL)
     return NULL;
   datalen = get_var_size_by_name (lexic, "data");
@@ -853,14 +853,14 @@ nasl_gzip (lex_ctxt * lexic)
   void *data, *compressed, *headerformat;
   unsigned long datalen, complen;
 
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   if (data == NULL)
     return NULL;
   datalen = get_var_size_by_name (lexic, "data");
   if (datalen <= 0)
     return NULL;
 
-  headerformat = get_str_local_var_by_name (lexic, "headformat");
+  headerformat = get_str_var_by_name (lexic, "headformat");
   if (!g_strcmp0 (headerformat, "gzip"))
     {
       compressed = gvm_compress_gzipheader (data, datalen, &complen);
@@ -890,7 +890,7 @@ nasl_dec2str (lex_ctxt * lexic)
 {
   /*converts integer to 4 byte buffer */
   (void) lexic;
-  int num = get_int_local_var_by_name (lexic, "num", -1);
+  int num = get_int_var_by_name (lexic, "num", -1);
   if (num == -1)
     {
       nasl_perror (lexic, "Syntax : dec2str(num:<n>)\n");

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -112,8 +112,8 @@ forge_ip_packet (lex_ctxt * lexic)
   if (dst_addr == NULL || (IN6_IS_ADDR_V4MAPPED (dst_addr) != 1))
     return NULL;
 
-  data = get_str_local_var_by_name (lexic, "data");
-  data_len = get_local_var_size_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
+  data_len = get_var_size_by_name (lexic, "data");
 
   retc = alloc_tree_cell ();
   retc->type = CONST_DATA;
@@ -122,28 +122,28 @@ forge_ip_packet (lex_ctxt * lexic)
   pkt = (struct ip *) g_malloc0 (sizeof (struct ip) + data_len);
   retc->x.str_val = (char *) pkt;
 
-  pkt->ip_hl = get_int_local_var_by_name (lexic, "ip_hl", 5);
-  pkt->ip_v = get_int_local_var_by_name (lexic, "ip_v", 4);
-  pkt->ip_tos = get_int_local_var_by_name (lexic, "ip_tos", 0);
-  /* pkt->ip_len = FIX(get_int_local_var_by_name(lexic, "ip_len", 20 + data_len)); */
+  pkt->ip_hl = get_int_var_by_name (lexic, "ip_hl", 5);
+  pkt->ip_v = get_int_var_by_name (lexic, "ip_v", 4);
+  pkt->ip_tos = get_int_var_by_name (lexic, "ip_tos", 0);
+  /* pkt->ip_len = FIX(get_int_var_by_name(lexic, "ip_len", 20 + data_len)); */
 
   pkt->ip_len = FIX (20 + data_len);
 
-  pkt->ip_id = htons (get_int_local_var_by_name (lexic, "ip_id", rand ()));
-  pkt->ip_off = get_int_local_var_by_name (lexic, "ip_off", 0);
+  pkt->ip_id = htons (get_int_var_by_name (lexic, "ip_id", rand ()));
+  pkt->ip_off = get_int_var_by_name (lexic, "ip_off", 0);
   pkt->ip_off = FIX (pkt->ip_off);
-  pkt->ip_ttl = get_int_local_var_by_name (lexic, "ip_ttl", 64);
-  pkt->ip_p = get_int_local_var_by_name (lexic, "ip_p", 0);
-  pkt->ip_sum = htons (get_int_local_var_by_name (lexic, "ip_sum", 0));
+  pkt->ip_ttl = get_int_var_by_name (lexic, "ip_ttl", 64);
+  pkt->ip_p = get_int_var_by_name (lexic, "ip_p", 0);
+  pkt->ip_sum = htons (get_int_var_by_name (lexic, "ip_sum", 0));
   /* source */
-  s = get_str_local_var_by_name (lexic, "ip_src");
+  s = get_str_var_by_name (lexic, "ip_src");
   if (s != NULL)
     inet_aton (s, &pkt->ip_src);
   /* else this host address? */
 
   /* I know that this feature looks dangerous, but anybody can edit an IP
    * packet with the string functions */
-  s = get_str_local_var_by_name (lexic, "ip_dst");
+  s = get_str_var_by_name (lexic, "ip_dst");
   if (s != NULL)
     inet_aton (s, &pkt->ip_dst);
   else
@@ -157,7 +157,7 @@ forge_ip_packet (lex_ctxt * lexic)
 
   if (!pkt->ip_sum)
     {
-      if (get_int_local_var_by_name (lexic, "ip_sum", -1) < 0)
+      if (get_int_var_by_name (lexic, "ip_sum", -1) < 0)
         pkt->ip_sum = np_in_cksum ((u_short *) pkt, sizeof (struct ip));
     }
 
@@ -169,8 +169,8 @@ tree_cell *
 get_ip_element (lex_ctxt * lexic)
 {
   tree_cell *retc;
-  struct ip *ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
-  char *element = get_str_local_var_by_name (lexic, "element");
+  struct ip *ip = (struct ip *) get_str_var_by_name (lexic, "ip");
+  char *element = get_str_var_by_name (lexic, "element");
   char ret_ascii[32];
   int ret_int = 0;
   int flag = 0;
@@ -273,7 +273,7 @@ get_ip_element (lex_ctxt * lexic)
 tree_cell *
 set_ip_elements (lex_ctxt * lexic)
 {
-  struct ip *o_pkt = (struct ip *) get_str_local_var_by_name (lexic, "ip");
+  struct ip *o_pkt = (struct ip *) get_str_var_by_name (lexic, "ip");
   int size = get_var_size_by_name (lexic, "ip");
   tree_cell *retc = alloc_tree_cell ();
   struct ip *pkt;
@@ -291,22 +291,22 @@ set_ip_elements (lex_ctxt * lexic)
   bcopy (o_pkt, pkt, size);
 
 
-  pkt->ip_hl = get_int_local_var_by_name (lexic, "ip_hl", pkt->ip_hl);
-  pkt->ip_v = get_int_local_var_by_name (lexic, "ip_v", pkt->ip_v);
-  pkt->ip_tos = get_int_local_var_by_name (lexic, "ip_tos", pkt->ip_tos);
+  pkt->ip_hl = get_int_var_by_name (lexic, "ip_hl", pkt->ip_hl);
+  pkt->ip_v = get_int_var_by_name (lexic, "ip_v", pkt->ip_v);
+  pkt->ip_tos = get_int_var_by_name (lexic, "ip_tos", pkt->ip_tos);
   pkt->ip_len =
-    FIX (get_int_local_var_by_name (lexic, "ip_len", UNFIX (pkt->ip_len)));
-  pkt->ip_id = htons (get_int_local_var_by_name (lexic, "ip_id", pkt->ip_id));
+    FIX (get_int_var_by_name (lexic, "ip_len", UNFIX (pkt->ip_len)));
+  pkt->ip_id = htons (get_int_var_by_name (lexic, "ip_id", pkt->ip_id));
   pkt->ip_off =
-    FIX (get_int_local_var_by_name (lexic, "ip_off", UNFIX (pkt->ip_off)));
-  pkt->ip_ttl = get_int_local_var_by_name (lexic, "ip_ttl", pkt->ip_ttl);
-  pkt->ip_p = get_int_local_var_by_name (lexic, "ip_p", pkt->ip_p);
+    FIX (get_int_var_by_name (lexic, "ip_off", UNFIX (pkt->ip_off)));
+  pkt->ip_ttl = get_int_var_by_name (lexic, "ip_ttl", pkt->ip_ttl);
+  pkt->ip_p = get_int_var_by_name (lexic, "ip_p", pkt->ip_p);
 
-  s = get_str_local_var_by_name (lexic, "ip_src");
+  s = get_str_var_by_name (lexic, "ip_src");
   if (s != NULL)
     inet_aton (s, &pkt->ip_src);
 
-  pkt->ip_sum = htons (get_int_local_var_by_name (lexic, "ip_sum", 0));
+  pkt->ip_sum = htons (get_int_var_by_name (lexic, "ip_sum", 0));
   if (pkt->ip_sum == 0)
     pkt->ip_sum = np_in_cksum ((u_short *) pkt, sizeof (struct ip));
 
@@ -321,10 +321,10 @@ set_ip_elements (lex_ctxt * lexic)
 tree_cell *
 insert_ip_options (lex_ctxt * lexic)
 {
-  struct ip *ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
-  int code = get_int_local_var_by_name (lexic, "code", 0);
-  int len = get_int_local_var_by_name (lexic, "length", 0);
-  char *value = get_str_local_var_by_name (lexic, "value");
+  struct ip *ip = (struct ip *) get_str_var_by_name (lexic, "ip");
+  int code = get_int_var_by_name (lexic, "code", 0);
+  int len = get_int_var_by_name (lexic, "length", 0);
+  char *value = get_str_var_by_name (lexic, "value");
   int value_size = get_var_size_by_name (lexic, "value");
   tree_cell *retc;
   struct ip *new_packet;
@@ -469,7 +469,7 @@ forge_tcp_packet (lex_ctxt * lexic)
   int ipsz;
 
 
-  ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
+  ip = (struct ip *) get_str_var_by_name (lexic, "ip");
   if (ip == NULL)
     {
       nasl_perror (lexic,
@@ -477,13 +477,13 @@ forge_tcp_packet (lex_ctxt * lexic)
       return NULL;
     }
 
-  ipsz = get_local_var_size_by_name (lexic, "ip");
+  ipsz = get_var_size_by_name (lexic, "ip");
   if (ipsz > ip->ip_hl * 4)
     ipsz = ip->ip_hl * 4;
 
 
 
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
 
   retc = alloc_tree_cell ();
@@ -495,7 +495,7 @@ forge_tcp_packet (lex_ctxt * lexic)
   /* recompute the ip checksum, because the ip length changed */
   if (UNFIX (tcp_packet->ip_len) <= tcp_packet->ip_hl * 4)
     {
-      if (get_int_local_var_by_name (lexic, "update_ip_len", 1))
+      if (get_int_var_by_name (lexic, "update_ip_len", 1))
         {
           tcp_packet->ip_len =
             FIX (tcp_packet->ip_hl * 4 + sizeof (struct tcphdr) + len);
@@ -506,16 +506,16 @@ forge_tcp_packet (lex_ctxt * lexic)
     }
   tcp = (struct tcphdr *) ((char *) tcp_packet + tcp_packet->ip_hl * 4);
 
-  tcp->th_sport = ntohs (get_int_local_var_by_name (lexic, "th_sport", 0));
-  tcp->th_dport = ntohs (get_int_local_var_by_name (lexic, "th_dport", 0));
-  tcp->th_seq = htonl (get_int_local_var_by_name (lexic, "th_seq", rand ()));
-  tcp->th_ack = htonl (get_int_local_var_by_name (lexic, "th_ack", 0));
-  tcp->th_x2 = get_int_local_var_by_name (lexic, "th_x2", 0);
-  tcp->th_off = get_int_local_var_by_name (lexic, "th_off", 5);
-  tcp->th_flags = get_int_local_var_by_name (lexic, "th_flags", 0);
-  tcp->th_win = htons (get_int_local_var_by_name (lexic, "th_win", 0));
-  tcp->th_sum = get_int_local_var_by_name (lexic, "th_sum", 0);
-  tcp->th_urp = get_int_local_var_by_name (lexic, "th_urp", 0);
+  tcp->th_sport = ntohs (get_int_var_by_name (lexic, "th_sport", 0));
+  tcp->th_dport = ntohs (get_int_var_by_name (lexic, "th_dport", 0));
+  tcp->th_seq = htonl (get_int_var_by_name (lexic, "th_seq", rand ()));
+  tcp->th_ack = htonl (get_int_var_by_name (lexic, "th_ack", 0));
+  tcp->th_x2 = get_int_var_by_name (lexic, "th_x2", 0);
+  tcp->th_off = get_int_var_by_name (lexic, "th_off", 5);
+  tcp->th_flags = get_int_var_by_name (lexic, "th_flags", 0);
+  tcp->th_win = htons (get_int_var_by_name (lexic, "th_win", 0));
+  tcp->th_sum = get_int_var_by_name (lexic, "th_sum", 0);
+  tcp->th_urp = get_int_var_by_name (lexic, "th_urp", 0);
 
   if (data != NULL)
     bcopy (data, (char *) tcp + sizeof (struct tcphdr), len);
@@ -557,7 +557,7 @@ forge_tcp_packet (lex_ctxt * lexic)
 tree_cell *
 get_tcp_element (lex_ctxt * lexic)
 {
-  u_char *packet = (u_char *) get_str_local_var_by_name (lexic, "tcp");
+  u_char *packet = (u_char *) get_str_var_by_name (lexic, "tcp");
   struct ip *ip;
   int ipsz;
   struct tcphdr *tcp;
@@ -566,7 +566,7 @@ get_tcp_element (lex_ctxt * lexic)
   tree_cell *retc;
 
 
-  ipsz = get_local_var_size_by_name (lexic, "tcp");
+  ipsz = get_var_size_by_name (lexic, "tcp");
 
 
   if (packet == NULL)
@@ -586,7 +586,7 @@ get_tcp_element (lex_ctxt * lexic)
 
   tcp = (struct tcphdr *) (packet + ip->ip_hl * 4);
 
-  element = get_str_local_var_by_name (lexic, "element");
+  element = get_str_var_by_name (lexic, "element");
   if (!element)
     {
       nasl_perror (lexic,
@@ -639,13 +639,13 @@ get_tcp_element (lex_ctxt * lexic)
 tree_cell *
 set_tcp_elements (lex_ctxt * lexic)
 {
-  char *pkt = get_str_local_var_by_name (lexic, "tcp");
+  char *pkt = get_str_var_by_name (lexic, "tcp");
   struct ip *ip = (struct ip *) pkt;
-  int pktsz = get_local_var_size_by_name (lexic, "tcp");
+  int pktsz = get_var_size_by_name (lexic, "tcp");
   struct tcphdr *tcp;
   tree_cell *retc;
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int data_len = get_local_var_size_by_name (lexic, "data");
+  char *data = get_str_var_by_name (lexic, "data");
+  int data_len = get_var_size_by_name (lexic, "data");
   char *npkt;
 
   if (!ip)
@@ -678,25 +678,25 @@ set_tcp_elements (lex_ctxt * lexic)
   tcp = (struct tcphdr *) (npkt + ip->ip_hl * 4);
 
   tcp->th_sport =
-    htons (get_int_local_var_by_name
+    htons (get_int_var_by_name
            (lexic, "th_sport", ntohs (tcp->th_sport)));
   tcp->th_dport =
-    htons (get_int_local_var_by_name
+    htons (get_int_var_by_name
            (lexic, "th_dport", ntohs (tcp->th_dport)));
   tcp->th_seq =
-    htonl (get_int_local_var_by_name (lexic, "th_seq", ntohl (tcp->th_seq)));
+    htonl (get_int_var_by_name (lexic, "th_seq", ntohl (tcp->th_seq)));
   tcp->th_ack =
-    htonl (get_int_local_var_by_name (lexic, "th_ack", ntohl (tcp->th_ack)));
-  tcp->th_x2 = get_int_local_var_by_name (lexic, "th_x2", tcp->th_x2);
-  tcp->th_off = get_int_local_var_by_name (lexic, "th_off", tcp->th_off);
-  tcp->th_flags = get_int_local_var_by_name (lexic, "th_flags", tcp->th_flags);
+    htonl (get_int_var_by_name (lexic, "th_ack", ntohl (tcp->th_ack)));
+  tcp->th_x2 = get_int_var_by_name (lexic, "th_x2", tcp->th_x2);
+  tcp->th_off = get_int_var_by_name (lexic, "th_off", tcp->th_off);
+  tcp->th_flags = get_int_var_by_name (lexic, "th_flags", tcp->th_flags);
   tcp->th_win =
-    htons (get_int_local_var_by_name (lexic, "th_win", ntohs (tcp->th_win)));
-  tcp->th_sum = get_int_local_var_by_name (lexic, "th_sum", 0);
-  tcp->th_urp = get_int_local_var_by_name (lexic, "th_urp", tcp->th_urp);
+    htons (get_int_var_by_name (lexic, "th_win", ntohs (tcp->th_win)));
+  tcp->th_sum = get_int_var_by_name (lexic, "th_sum", 0);
+  tcp->th_urp = get_int_var_by_name (lexic, "th_urp", tcp->th_urp);
   bcopy (data, (char *) tcp + tcp->th_off * 4, data_len);
 
-  if (get_int_local_var_by_name (lexic, "update_ip_len", 1) != 0)
+  if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
     {
       ip->ip_len = ip->ip_hl * 4 + tcp->th_off * 4 + data_len;
       ip->ip_sum = 0;
@@ -841,12 +841,12 @@ tree_cell *
 forge_udp_packet (lex_ctxt * lexic)
 {
   tree_cell *retc;
-  struct ip *ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
+  struct ip *ip = (struct ip *) get_str_var_by_name (lexic, "ip");
 
   if (ip != NULL)
     {
-      char *data = get_str_local_var_by_name (lexic, "data");
-      int data_len = get_local_var_size_by_name (lexic, "data");
+      char *data = get_str_var_by_name (lexic, "data");
+      int data_len = get_var_size_by_name (lexic, "data");
       u_char *pkt;
       struct ip *udp_packet;
       struct udphdr *udp;
@@ -858,10 +858,10 @@ forge_udp_packet (lex_ctxt * lexic)
       udp = (struct udphdr *) (pkt + ip->ip_hl * 4);
 
 
-      udp->uh_sport = htons (get_int_local_var_by_name (lexic, "uh_sport", 0));
-      udp->uh_dport = htons (get_int_local_var_by_name (lexic, "uh_dport", 0));
+      udp->uh_sport = htons (get_int_var_by_name (lexic, "uh_sport", 0));
+      udp->uh_dport = htons (get_int_var_by_name (lexic, "uh_dport", 0));
       udp->uh_ulen =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_ulen", data_len + sizeof (struct udphdr)));
 
 
@@ -869,7 +869,7 @@ forge_udp_packet (lex_ctxt * lexic)
       if (data_len != 0 && data != NULL)
         bcopy (data, (pkt + ip->ip_hl * 4 + sizeof (struct udphdr)), data_len);
 
-      udp->uh_sum = get_int_local_var_by_name (lexic, "uh_sum", 0);
+      udp->uh_sum = get_int_var_by_name (lexic, "uh_sum", 0);
       bcopy ((char *) ip, pkt, ip->ip_hl * 4);
       if (udp->uh_sum == 0)
         {
@@ -903,7 +903,7 @@ forge_udp_packet (lex_ctxt * lexic)
 
       if (UNFIX (udp_packet->ip_len) <= udp_packet->ip_hl * 4)
         {
-          int v = get_int_local_var_by_name (lexic, "update_ip_len", 1);
+          int v = get_int_var_by_name (lexic, "update_ip_len", 1);
           if (v != 0)
             {
               udp_packet->ip_len =
@@ -939,11 +939,11 @@ get_udp_element (lex_ctxt * lexic)
   int ret;
 
 
-  udp = get_str_local_var_by_name (lexic, "udp");
-  ipsz = get_local_var_size_by_name (lexic, "udp");
+  udp = get_str_var_by_name (lexic, "udp");
+  ipsz = get_var_size_by_name (lexic, "udp");
 
 
-  element = get_str_local_var_by_name (lexic, "element");
+  element = get_str_var_by_name (lexic, "element");
   if (udp == NULL || element == NULL)
     {
       printf ("get_udp_element() usage :\n");
@@ -999,10 +999,10 @@ get_udp_element (lex_ctxt * lexic)
 tree_cell *
 set_udp_elements (lex_ctxt * lexic)
 {
-  struct ip *ip = (struct ip *) get_str_local_var_by_name (lexic, "udp");
-  unsigned int sz = get_local_var_size_by_name (lexic, "udp");
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int data_len = get_local_var_size_by_name (lexic, "data");
+  struct ip *ip = (struct ip *) get_str_var_by_name (lexic, "udp");
+  unsigned int sz = get_var_size_by_name (lexic, "udp");
+  char *data = get_str_var_by_name (lexic, "data");
+  int data_len = get_var_size_by_name (lexic, "data");
 
   if (ip != NULL)
     {
@@ -1040,16 +1040,16 @@ set_udp_elements (lex_ctxt * lexic)
 
 
       udp->uh_sport =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_sport", ntohs (udp->uh_sport)));
       udp->uh_dport =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_dport", ntohs (udp->uh_dport)));
       old_len = ntohs (udp->uh_ulen);
       udp->uh_ulen =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_ulen", ntohs (udp->uh_ulen)));
-      udp->uh_sum = get_int_local_var_by_name (lexic, "uh_sum", 0);
+      udp->uh_sum = get_int_var_by_name (lexic, "uh_sum", 0);
 
       if (data != NULL)
         {
@@ -1155,15 +1155,15 @@ forge_icmp_packet (lex_ctxt * lexic)
   u_char *pkt;
   int t;
 
-  ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
-  ip_sz = get_local_var_size_by_name (lexic, "ip");
+  ip = (struct ip *) get_str_var_by_name (lexic, "ip");
+  ip_sz = get_var_size_by_name (lexic, "ip");
   if (ip != NULL)
     {
-      data = get_str_local_var_by_name (lexic, "data");
+      data = get_str_var_by_name (lexic, "data");
       len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
 
 
-      t = get_int_local_var_by_name (lexic, "icmp_type", 0);
+      t = get_int_var_by_name (lexic, "icmp_type", 0);
       if (t == 13 || t == 14)
         len += 3 * sizeof (time_t);
 
@@ -1177,7 +1177,7 @@ forge_icmp_packet (lex_ctxt * lexic)
       bcopy (ip, ip_icmp, ip_sz);
       if (UNFIX (ip_icmp->ip_len) <= (ip_icmp->ip_hl * 4))
         {
-          if (get_int_local_var_by_name (lexic, "update_ip_len", 1) != 0)
+          if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
             {
               ip_icmp->ip_len = FIX (ip->ip_hl * 4 + 8 + len);
               ip_icmp->ip_sum = 0;
@@ -1188,19 +1188,19 @@ forge_icmp_packet (lex_ctxt * lexic)
       p = (char *) (pkt + (ip->ip_hl * 4));
       icmp = (struct icmp *) p;
 
-      icmp->icmp_code = get_int_local_var_by_name (lexic, "icmp_code", 0);
+      icmp->icmp_code = get_int_var_by_name (lexic, "icmp_code", 0);
       icmp->icmp_type = t;
-      icmp->icmp_seq = htons (get_int_local_var_by_name (lexic, "icmp_seq", 0));
-      icmp->icmp_id = htons (get_int_local_var_by_name (lexic, "icmp_id", 0));
+      icmp->icmp_seq = htons (get_int_var_by_name (lexic, "icmp_seq", 0));
+      icmp->icmp_id = htons (get_int_var_by_name (lexic, "icmp_id", 0));
 
       if (data != NULL)
         bcopy (data, &(p[8]), len);
 
-      if (get_int_local_var_by_name (lexic, "icmp_cksum", -1) == -1)
+      if (get_int_var_by_name (lexic, "icmp_cksum", -1) == -1)
         icmp->icmp_cksum = np_in_cksum ((u_short *) icmp, len + 8);
       else
         icmp->icmp_cksum =
-          htons (get_int_local_var_by_name (lexic, "icmp_cksum", 0));
+          htons (get_int_var_by_name (lexic, "icmp_cksum", 0));
 
 
       retc = alloc_tree_cell ();
@@ -1221,9 +1221,9 @@ get_icmp_element (lex_ctxt * lexic)
   char *p;
 
 
-  if ((p = get_str_local_var_by_name (lexic, "icmp")) != NULL)
+  if ((p = get_str_var_by_name (lexic, "icmp")) != NULL)
     {
-      char *elem = get_str_local_var_by_name (lexic, "element");
+      char *elem = get_str_var_by_name (lexic, "element");
       int value;
       struct ip *ip = (struct ip *) p;
       tree_cell *retc;
@@ -1299,26 +1299,26 @@ struct igmp
 tree_cell *
 forge_igmp_packet (lex_ctxt * lexic)
 {
-  struct ip *ip = (struct ip *) get_str_local_var_by_name (lexic, "ip");
+  struct ip *ip = (struct ip *) get_str_var_by_name (lexic, "ip");
 
   if (ip != NULL)
     {
-      char *data = get_str_local_var_by_name (lexic, "data");
-      int len = data ? get_local_var_size_by_name (lexic, "data") : 0;
+      char *data = get_str_var_by_name (lexic, "data");
+      int len = data ? get_var_size_by_name (lexic, "data") : 0;
       u_char *pkt = g_malloc0 (sizeof (struct igmp) + ip->ip_hl * 4 + len);
       struct ip *ip_igmp = (struct ip *) pkt;
       struct igmp *igmp;
       char *p;
       char *grp;
       tree_cell *retc;
-      int ipsz = get_local_var_size_by_name (lexic, "ip");
+      int ipsz = get_var_size_by_name (lexic, "ip");
 
       bcopy (ip, ip_igmp, ipsz);
 
 
       if (UNFIX (ip_igmp->ip_len) <= ip_igmp->ip_hl * 4)
         {
-          int v = get_int_local_var_by_name (lexic, "update_ip_len", 1);
+          int v = get_int_var_by_name (lexic, "update_ip_len", 1);
           if (v != 0)
             {
               ip_igmp->ip_len =
@@ -1331,9 +1331,9 @@ forge_igmp_packet (lex_ctxt * lexic)
       p = (char *) (pkt + ip_igmp->ip_hl * 4);
       igmp = (struct igmp *) p;
 
-      igmp->code = get_int_local_var_by_name (lexic, "code", 0);
-      igmp->type = get_int_local_var_by_name (lexic, "type", 0);
-      grp = get_str_local_var_by_name (lexic, "group");
+      igmp->code = get_int_var_by_name (lexic, "code", 0);
+      igmp->type = get_int_var_by_name (lexic, "type", 0);
+      grp = get_str_var_by_name (lexic, "group");
 
       if (grp != NULL)
         {
@@ -1408,7 +1408,7 @@ nasl_tcp_ping (lex_ctxt * lexic)
   if (setsockopt (soc, IPPROTO_IP, IP_HDRINCL, (char *) &opt, sizeof (opt)) < 0)
     perror ("setsockopt ");
 
-  port = get_int_local_var_by_name (lexic, "port", -1);
+  port = get_int_var_by_name (lexic, "port", -1);
   if (port == -1)
     port = plug_get_host_open_port (script_infos);
 
@@ -1515,10 +1515,10 @@ nasl_send_packet (lex_ctxt * lexic)
   struct ip *sip = NULL;
   int vi = 0, b, len = 0;
   int soc;
-  int use_pcap = get_int_local_var_by_name (lexic, "pcap_active", 1);
-  int to = get_int_local_var_by_name (lexic, "pcap_timeout", 5);
-  char *filter = get_str_local_var_by_name (lexic, "pcap_filter");
-  int dfl_len = get_int_local_var_by_name (lexic, "length", -1);
+  int use_pcap = get_int_var_by_name (lexic, "pcap_active", 1);
+  int to = get_int_var_by_name (lexic, "pcap_timeout", 5);
+  char *filter = get_str_var_by_name (lexic, "pcap_filter");
+  int dfl_len = get_int_var_by_name (lexic, "length", -1);
   int i = 1;
   struct script_infos *script_infos = lexic->script_infos;
   struct in6_addr *dstip = plug_get_host_ip (script_infos);
@@ -1623,14 +1623,14 @@ nasl_send_packet (lex_ctxt * lexic)
 tree_cell *
 nasl_pcap_next (lex_ctxt * lexic)
 {
-  char *interface = get_str_local_var_by_name (lexic, "interface");
+  char *interface = get_str_var_by_name (lexic, "interface");
   int bpf = -1;
   static char errbuf[PCAP_ERRBUF_SIZE];
   int is_ip = 0;
   struct ip *ret = NULL;
   struct ip6_hdr *ret6 = NULL;
-  char *filter = get_str_local_var_by_name (lexic, "pcap_filter");
-  int timeout = get_int_local_var_by_name (lexic, "timeout", 5);
+  char *filter = get_str_var_by_name (lexic, "pcap_filter");
+  int timeout = get_int_var_by_name (lexic, "timeout", 5);
   tree_cell *retc;
   int sz;
   struct in6_addr *dst = plug_get_host_ip (lexic->script_infos);
@@ -1759,14 +1759,14 @@ nasl_pcap_next (lex_ctxt * lexic)
 tree_cell *
 nasl_send_capture (lex_ctxt * lexic)
 {
-  char *interface = get_str_local_var_by_name (lexic, "interface");
+  char *interface = get_str_var_by_name (lexic, "interface");
   int bpf = -1;
   static char errbuf[PCAP_ERRBUF_SIZE];
   int is_ip = 0;
   struct ip *ret = NULL;
   struct ip6_hdr *ret6 = NULL;
-  char *filter = get_str_local_var_by_name (lexic, "pcap_filter");
-  int timeout = get_int_local_var_by_name (lexic, "timeout", 5);
+  char *filter = get_str_var_by_name (lexic, "pcap_filter");
+  int timeout = get_int_var_by_name (lexic, "timeout", 5);
   tree_cell *retc;
   int sz;
   struct in6_addr *dst = plug_get_host_ip (lexic->script_infos);

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -141,8 +141,8 @@ forge_ipv6_packet (lex_ctxt * lexic)
   if (dst_addr == NULL || (IN6_IS_ADDR_V4MAPPED (dst_addr) == 1))
     return NULL;
 
-  data = get_str_local_var_by_name (lexic, "data");
-  data_len = get_local_var_size_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
+  data_len = get_var_size_by_name (lexic, "data");
 
   retc = alloc_tree_cell ();
   retc->type = CONST_DATA;
@@ -151,23 +151,23 @@ forge_ipv6_packet (lex_ctxt * lexic)
   pkt = (struct ip6_hdr *) g_malloc0 (sizeof (struct ip6_hdr) + data_len);
   retc->x.str_val = (char *) pkt;
 
-  version = get_int_local_var_by_name (lexic, "ip6_v", 6);
-  tc = get_int_local_var_by_name (lexic, "ip6_tc", 0);
-  fl = get_int_local_var_by_name (lexic, "ip6_fl", 0);
+  version = get_int_var_by_name (lexic, "ip6_v", 6);
+  tc = get_int_var_by_name (lexic, "ip6_tc", 0);
+  fl = get_int_var_by_name (lexic, "ip6_fl", 0);
 
   pkt->ip6_ctlun.ip6_un1.ip6_un1_flow = version | tc | fl;
 
   pkt->ip6_plen = FIX (data_len);       /* No extension headers ? */
-  pkt->ip6_nxt = get_int_local_var_by_name (lexic, "ip6_p", 0);
-  pkt->ip6_hlim = get_int_local_var_by_name (lexic, "ip6_hlim", 64);
+  pkt->ip6_nxt = get_int_var_by_name (lexic, "ip6_p", 0);
+  pkt->ip6_hlim = get_int_var_by_name (lexic, "ip6_hlim", 64);
 
   /* source */
-  s = get_str_local_var_by_name (lexic, "ip6_src");
+  s = get_str_var_by_name (lexic, "ip6_src");
   if (s != NULL)
     inet_pton (AF_INET6, s, &pkt->ip6_src);
   /* else this host address? */
 
-  s = get_str_local_var_by_name (lexic, "ip6_dst");
+  s = get_str_var_by_name (lexic, "ip6_dst");
   if (s != NULL)
     inet_pton (AF_INET6, s, &pkt->ip6_dst);
   else
@@ -197,8 +197,8 @@ get_ipv6_element (lex_ctxt * lexic)
 {
   tree_cell *retc;
   struct ip6_hdr *ip6 =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ipv6");
-  char *element = get_str_local_var_by_name (lexic, "element");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "ipv6");
+  char *element = get_str_var_by_name (lexic, "element");
   char ret_ascii[INET6_ADDRSTRLEN];
   int ret_int = 0;
   int flag = 0;
@@ -290,7 +290,7 @@ tree_cell *
 set_ipv6_elements (lex_ctxt * lexic)
 {
   struct ip6_hdr *o_pkt =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
   int size = get_var_size_by_name (lexic, "ip6");
   tree_cell *retc = alloc_tree_cell ();
   struct ip6_hdr *pkt;
@@ -305,11 +305,11 @@ set_ipv6_elements (lex_ctxt * lexic)
   pkt = (struct ip6_hdr *) g_malloc0 (size);
   bcopy (o_pkt, pkt, size);
 
-  pkt->ip6_plen = get_int_local_var_by_name (lexic, "ip6_plen", pkt->ip6_plen);
-  pkt->ip6_nxt = get_int_local_var_by_name (lexic, "ip6_nxt", pkt->ip6_nxt);
-  pkt->ip6_hlim = get_int_local_var_by_name (lexic, "ip6_hlim", pkt->ip6_hlim);
+  pkt->ip6_plen = get_int_var_by_name (lexic, "ip6_plen", pkt->ip6_plen);
+  pkt->ip6_nxt = get_int_var_by_name (lexic, "ip6_nxt", pkt->ip6_nxt);
+  pkt->ip6_hlim = get_int_var_by_name (lexic, "ip6_hlim", pkt->ip6_hlim);
 
-  s = get_str_local_var_by_name (lexic, "ip6_src");
+  s = get_str_var_by_name (lexic, "ip6_src");
   if (s != NULL)
     inet_pton (AF_INET6, s, &pkt->ip6_src);
 
@@ -378,10 +378,10 @@ tree_cell *
 insert_ipv6_options (lex_ctxt * lexic)
 {
   struct ip6_hdr *ip6 =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
-  int code = get_int_local_var_by_name (lexic, "code", 0);
-  int len = get_int_local_var_by_name (lexic, "length", 0);
-  char *value = get_str_local_var_by_name (lexic, "value");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
+  int code = get_int_var_by_name (lexic, "code", 0);
+  int len = get_int_var_by_name (lexic, "length", 0);
+  char *value = get_str_var_by_name (lexic, "value");
   int value_size = get_var_size_by_name (lexic, "value");
   tree_cell *retc;
   struct ip6_hdr *new_packet;
@@ -475,7 +475,7 @@ forge_tcp_v6_packet (lex_ctxt * lexic)
   struct tcphdr *tcp;
   int ipsz;
 
-  ip6 = (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
+  ip6 = (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
   if (ip6 == NULL)
     {
       nasl_perror (lexic,
@@ -483,13 +483,13 @@ forge_tcp_v6_packet (lex_ctxt * lexic)
       return NULL;
     }
 
-  ipsz = get_local_var_size_by_name (lexic, "ip6");
+  ipsz = get_var_size_by_name (lexic, "ip6");
 
   // Not considering IP Options.
   if (ipsz != 40)
     ipsz = 40;
 
-  data = get_str_local_var_by_name (lexic, "data");
+  data = get_str_var_by_name (lexic, "data");
   len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
 
   retc = alloc_tree_cell ();
@@ -503,16 +503,16 @@ forge_tcp_v6_packet (lex_ctxt * lexic)
     FIX (sizeof (struct tcphdr) + len);
   tcp = (struct tcphdr *) ((char *) tcp_packet + 40);
 
-  tcp->th_sport = ntohs (get_int_local_var_by_name (lexic, "th_sport", 0));
-  tcp->th_dport = ntohs (get_int_local_var_by_name (lexic, "th_dport", 0));
-  tcp->th_seq = htonl (get_int_local_var_by_name (lexic, "th_seq", rand ()));
-  tcp->th_ack = htonl (get_int_local_var_by_name (lexic, "th_ack", 0));
-  tcp->th_x2 = get_int_local_var_by_name (lexic, "th_x2", 0);
-  tcp->th_off = get_int_local_var_by_name (lexic, "th_off", 5);
-  tcp->th_flags = get_int_local_var_by_name (lexic, "th_flags", 0);
-  tcp->th_win = htons (get_int_local_var_by_name (lexic, "th_win", 0));
-  tcp->th_sum = get_int_local_var_by_name (lexic, "th_sum", 0);
-  tcp->th_urp = get_int_local_var_by_name (lexic, "th_urp", 0);
+  tcp->th_sport = ntohs (get_int_var_by_name (lexic, "th_sport", 0));
+  tcp->th_dport = ntohs (get_int_var_by_name (lexic, "th_dport", 0));
+  tcp->th_seq = htonl (get_int_var_by_name (lexic, "th_seq", rand ()));
+  tcp->th_ack = htonl (get_int_var_by_name (lexic, "th_ack", 0));
+  tcp->th_x2 = get_int_var_by_name (lexic, "th_x2", 0);
+  tcp->th_off = get_int_var_by_name (lexic, "th_off", 5);
+  tcp->th_flags = get_int_var_by_name (lexic, "th_flags", 0);
+  tcp->th_win = htons (get_int_var_by_name (lexic, "th_win", 0));
+  tcp->th_sum = get_int_var_by_name (lexic, "th_sum", 0);
+  tcp->th_urp = get_int_var_by_name (lexic, "th_urp", 0);
 
   if (data != NULL)
     bcopy (data, (char *) tcp + sizeof (struct tcphdr), len);
@@ -554,7 +554,7 @@ forge_tcp_v6_packet (lex_ctxt * lexic)
 tree_cell *
 get_tcp_v6_element (lex_ctxt * lexic)
 {
-  u_char *packet = (u_char *) get_str_local_var_by_name (lexic, "tcp");
+  u_char *packet = (u_char *) get_str_var_by_name (lexic, "tcp");
   struct ip6_hdr *ip6;
   int ipsz;
   struct tcphdr *tcp;
@@ -562,7 +562,7 @@ get_tcp_v6_element (lex_ctxt * lexic)
   int ret;
   tree_cell *retc;
 
-  ipsz = get_local_var_size_by_name (lexic, "tcp");
+  ipsz = get_var_size_by_name (lexic, "tcp");
 
   if (packet == NULL)
     {
@@ -579,7 +579,7 @@ get_tcp_v6_element (lex_ctxt * lexic)
 
   tcp = (struct tcphdr *) (packet + 40);
 
-  element = get_str_local_var_by_name (lexic, "element");
+  element = get_str_var_by_name (lexic, "element");
   if (!element)
     {
       nasl_perror (lexic,
@@ -644,13 +644,13 @@ get_tcp_v6_element (lex_ctxt * lexic)
 tree_cell *
 set_tcp_v6_elements (lex_ctxt * lexic)
 {
-  char *pkt = get_str_local_var_by_name (lexic, "tcp");
+  char *pkt = get_str_var_by_name (lexic, "tcp");
   struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
-  int pktsz = get_local_var_size_by_name (lexic, "tcp");
+  int pktsz = get_var_size_by_name (lexic, "tcp");
   struct tcphdr *tcp;
   tree_cell *retc;
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int data_len = get_local_var_size_by_name (lexic, "data");
+  char *data = get_str_var_by_name (lexic, "data");
+  int data_len = get_var_size_by_name (lexic, "data");
   char *npkt;
 
   if (pkt == NULL)
@@ -678,26 +678,26 @@ set_tcp_v6_elements (lex_ctxt * lexic)
   tcp = (struct tcphdr *) (npkt + 40);
 
   tcp->th_sport =
-    htons (get_int_local_var_by_name
+    htons (get_int_var_by_name
            (lexic, "th_sport", ntohs (tcp->th_sport)));
   tcp->th_dport =
-    htons (get_int_local_var_by_name
+    htons (get_int_var_by_name
            (lexic, "th_dport", ntohs (tcp->th_dport)));
   tcp->th_seq =
-    htonl (get_int_local_var_by_name (lexic, "th_seq", ntohl (tcp->th_seq)));
+    htonl (get_int_var_by_name (lexic, "th_seq", ntohl (tcp->th_seq)));
   tcp->th_ack =
-    htonl (get_int_local_var_by_name (lexic, "th_ack", ntohl (tcp->th_ack)));
-  tcp->th_x2 = get_int_local_var_by_name (lexic, "th_x2", tcp->th_x2);
-  tcp->th_off = get_int_local_var_by_name (lexic, "th_off", tcp->th_off);
-  tcp->th_flags = get_int_local_var_by_name (lexic, "th_flags", tcp->th_flags);
+    htonl (get_int_var_by_name (lexic, "th_ack", ntohl (tcp->th_ack)));
+  tcp->th_x2 = get_int_var_by_name (lexic, "th_x2", tcp->th_x2);
+  tcp->th_off = get_int_var_by_name (lexic, "th_off", tcp->th_off);
+  tcp->th_flags = get_int_var_by_name (lexic, "th_flags", tcp->th_flags);
   tcp->th_win =
-    htons (get_int_local_var_by_name (lexic, "th_win", ntohs (tcp->th_win)));
-  tcp->th_sum = get_int_local_var_by_name (lexic, "th_sum", 0);
-  tcp->th_urp = get_int_local_var_by_name (lexic, "th_urp", tcp->th_urp);
+    htons (get_int_var_by_name (lexic, "th_win", ntohs (tcp->th_win)));
+  tcp->th_sum = get_int_var_by_name (lexic, "th_sum", 0);
+  tcp->th_urp = get_int_var_by_name (lexic, "th_urp", tcp->th_urp);
 
   bcopy (data, (char *) tcp + tcp->th_off * 4, data_len);
 
-  if (get_int_local_var_by_name (lexic, "update_ip_len", 1) != 0)
+  if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
     {
       ip6->ip6_plen = tcp->th_off * 4 + data_len;
     }
@@ -854,12 +854,12 @@ forge_udp_v6_packet (lex_ctxt * lexic)
 {
   tree_cell *retc;
   struct ip6_hdr *ip6 =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
 
   if (ip6 != NULL)
     {
-      char *data = get_str_local_var_by_name (lexic, "data");
-      int data_len = get_local_var_size_by_name (lexic, "data");
+      char *data = get_str_var_by_name (lexic, "data");
+      int data_len = get_var_size_by_name (lexic, "data");
       u_char *pkt;
       struct ip6_hdr *udp_packet;
       struct udphdr *udp;
@@ -868,13 +868,13 @@ forge_udp_v6_packet (lex_ctxt * lexic)
       udp_packet = (struct ip6_hdr *) pkt;
       udp = (struct udphdr *) (pkt + 40);
 
-      udp->uh_sum = get_int_local_var_by_name (lexic, "uh_sum", 0);
+      udp->uh_sum = get_int_var_by_name (lexic, "uh_sum", 0);
       bcopy ((char *) ip6, pkt, 40);
 
-      udp->uh_sport = htons (get_int_local_var_by_name (lexic, "uh_sport", 0));
-      udp->uh_dport = htons (get_int_local_var_by_name (lexic, "uh_dport", 0));
+      udp->uh_sport = htons (get_int_var_by_name (lexic, "uh_sport", 0));
+      udp->uh_dport = htons (get_int_var_by_name (lexic, "uh_dport", 0));
       udp->uh_ulen =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_ulen", data_len + sizeof (struct udphdr)));
 
       if (data_len != 0 && data != NULL)
@@ -908,7 +908,7 @@ forge_udp_v6_packet (lex_ctxt * lexic)
 
       if (UNFIX (udp_packet->ip6_ctlun.ip6_un1.ip6_un1_plen) <= 40)
         {
-          int v = get_int_local_var_by_name (lexic, "update_ip6_len", 1);
+          int v = get_int_var_by_name (lexic, "update_ip6_len", 1);
           if (v != 0)
             {
               udp_packet->ip6_ctlun.ip6_un1.ip6_un1_plen =
@@ -947,10 +947,10 @@ get_udp_v6_element (lex_ctxt * lexic)
   struct udphdr *udphdr;
   int ret;
 
-  udp = get_str_local_var_by_name (lexic, "udp");
-  ipsz = get_local_var_size_by_name (lexic, "udp");
+  udp = get_str_var_by_name (lexic, "udp");
+  ipsz = get_var_size_by_name (lexic, "udp");
 
-  element = get_str_local_var_by_name (lexic, "element");
+  element = get_str_var_by_name (lexic, "element");
   if (udp == NULL || element == NULL)
     {
       printf ("get_udp_v6_element() usage :\n");
@@ -1009,10 +1009,10 @@ tree_cell *
 set_udp_v6_elements (lex_ctxt * lexic)
 {
   struct ip6_hdr *ip6 =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "udp");
-  unsigned int sz = get_local_var_size_by_name (lexic, "udp");
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int data_len = get_local_var_size_by_name (lexic, "data");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "udp");
+  unsigned int sz = get_var_size_by_name (lexic, "udp");
+  char *data = get_str_var_by_name (lexic, "data");
+  int data_len = get_var_size_by_name (lexic, "data");
 
   if (ip6 != NULL)
     {
@@ -1045,17 +1045,17 @@ set_udp_v6_elements (lex_ctxt * lexic)
       udp = (struct udphdr *) (pkt + 40);
 
       udp->uh_sport =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_sport", ntohs (udp->uh_sport)));
       udp->uh_dport =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_dport", ntohs (udp->uh_dport)));
 
       old_len = ntohs (udp->uh_ulen);
       udp->uh_ulen =
-        htons (get_int_local_var_by_name
+        htons (get_int_var_by_name
                (lexic, "uh_ulen", ntohs (udp->uh_ulen)));
-      udp->uh_sum = get_int_local_var_by_name (lexic, "uh_sum", 0);
+      udp->uh_sum = get_int_var_by_name (lexic, "uh_sum", 0);
 
       if (data != NULL)
         {
@@ -1188,16 +1188,16 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
   int len;
   u_char *pkt;
   int t;
-  ip6 = (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
-  ip6_sz = get_local_var_size_by_name (lexic, "ip6");
+  ip6 = (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
+  ip6_sz = get_var_size_by_name (lexic, "ip6");
 
   if (ip6 != NULL)
     {
       retc = alloc_tree_cell ();
       retc->type = CONST_DATA;
-      data = get_str_local_var_by_name (lexic, "data");
+      data = get_str_var_by_name (lexic, "data");
       len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
-      t = get_int_local_var_by_name (lexic, "icmp_type", 0);
+      t = get_int_var_by_name (lexic, "icmp_type", 0);
       if (40 > ip6_sz)
         return NULL;
 
@@ -1210,7 +1210,7 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
 
       icmp = (struct icmp6_hdr *) p;
 
-      icmp->icmp6_code = get_int_local_var_by_name (lexic, "icmp_code", 0);
+      icmp->icmp6_code = get_int_var_by_name (lexic, "icmp_code", 0);
       icmp->icmp6_type = t;
 
       switch (t)
@@ -1219,8 +1219,8 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
           {
             if (data != NULL)
               bcopy (data, &(p[8]), len);
-            icmp->icmp6_id = get_int_local_var_by_name (lexic, "icmp_id", 0);
-            icmp->icmp6_seq = get_int_local_var_by_name (lexic, "icmp_seq", 0);
+            icmp->icmp6_id = get_int_var_by_name (lexic, "icmp_id", 0);
+            icmp->icmp6_seq = get_int_var_by_name (lexic, "icmp_seq", 0);
             size = ip6_sz + 8 + len;
             sz = 8;
           }
@@ -1258,12 +1258,12 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
             ra->icmp6_code = icmp->icmp6_code;
             ra->icmp6_cksum = icmp->icmp6_cksum;
             routeradvert->nd_ra_reachable =
-              get_int_local_var_by_name (lexic, "reacheable_time", 0);
+              get_int_var_by_name (lexic, "reacheable_time", 0);
             routeradvert->nd_ra_retransmit =
-              get_int_local_var_by_name (lexic, "retransmit_timer", 0);
+              get_int_var_by_name (lexic, "retransmit_timer", 0);
             routeradvert->nd_ra_curhoplimit = ip6_icmp->ip6_hlim;
             routeradvert->nd_ra_flags_reserved =
-              get_int_local_var_by_name (lexic, "flags", 0);
+              get_int_var_by_name (lexic, "flags", 0);
             size = ip6_sz + sizeof (struct nd_router_advert) - 8 + len; /*not taking lifetime(8 bytes) into consideration */
             sz = 5;             /*type-1 byte, code-1byte, cksum-2bytes, current hoplimit-1byte */
           }
@@ -1300,14 +1300,14 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
             na->icmp6_code = icmp->icmp6_code;
             na->icmp6_cksum = icmp->icmp6_cksum;
             neighboradvert->nd_na_flags_reserved =
-              get_int_local_var_by_name (lexic, "flags", 0);
+              get_int_var_by_name (lexic, "flags", 0);
             if (neighboradvert->nd_na_flags_reserved & 0x00000020)
               memcpy (&neighboradvert->nd_na_target, &ip6_icmp->ip6_src, sizeof (struct in6_addr));     /*dst ip should be link local */
             else
               {
                 if (get_var_size_by_name (lexic, "target") != 0)
                   inet_pton (AF_INET6,
-                             get_str_local_var_by_name (lexic, "target"),
+                             get_str_var_by_name (lexic, "target"),
                              &neighboradvert->nd_na_target);
                 else
                   {
@@ -1329,12 +1329,12 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
 
       if (UNFIX (ip6_icmp->ip6_ctlun.ip6_un1.ip6_un1_plen) <= 40)
         {
-          if (get_int_local_var_by_name (lexic, "update_ip_len", 1) != 0)
+          if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
             {
               ip6_icmp->ip6_ctlun.ip6_un1.ip6_un1_plen = FIX (size - ip6_sz);
             }
         }
-      if (get_int_local_var_by_name (lexic, "icmp_cksum", -1) == -1)
+      if (get_int_var_by_name (lexic, "icmp_cksum", -1) == -1)
         {
           struct v6pseudo_icmp_hdr pseudohdr;
           char *icmpsumdata = g_malloc0 (sizeof (struct v6pseudo_icmp_hdr) +
@@ -1356,7 +1356,7 @@ forge_icmp_v6_packet (lex_ctxt * lexic)
         }
       else
         icmp->icmp6_cksum =
-          htons (get_int_local_var_by_name (lexic, "icmp_cksum", 0));
+          htons (get_int_var_by_name (lexic, "icmp_cksum", 0));
       switch (t)
         {
         case ICMP6_ECHO_REQUEST:
@@ -1410,9 +1410,9 @@ get_icmp_v6_element (lex_ctxt * lexic)
   char *p;
 
 
-  if ((p = get_str_local_var_by_name (lexic, "icmp")) != NULL)
+  if ((p = get_str_var_by_name (lexic, "icmp")) != NULL)
     {
-      char *elem = get_str_local_var_by_name (lexic, "element");
+      char *elem = get_str_var_by_name (lexic, "element");
       int value;
       tree_cell *retc;
 
@@ -1483,26 +1483,26 @@ tree_cell *
 forge_igmp_v6_packet (lex_ctxt * lexic)
 {
   struct ip6_hdr *ip6 =
-    (struct ip6_hdr *) get_str_local_var_by_name (lexic, "ip6");
+    (struct ip6_hdr *) get_str_var_by_name (lexic, "ip6");
 
   if (ip6 != NULL)
     {
-      char *data = get_str_local_var_by_name (lexic, "data");
-      int len = data ? get_local_var_size_by_name (lexic, "data") : 0;
+      char *data = get_str_var_by_name (lexic, "data");
+      int len = data ? get_var_size_by_name (lexic, "data") : 0;
       u_char *pkt = g_malloc0 (sizeof (struct igmp6_hdr) + 40 + len);
       struct ip6_hdr *ip6_igmp = (struct ip6_hdr *) pkt;
       struct igmp6_hdr *igmp;
       char *p;
       char *grp;
       tree_cell *retc;
-      int ipsz = get_local_var_size_by_name (lexic, "ip6");
+      int ipsz = get_var_size_by_name (lexic, "ip6");
 
       bcopy (ip6, ip6_igmp, ipsz);
 
 
       if (UNFIX (ip6_igmp->ip6_ctlun.ip6_un1.ip6_un1_plen) <= 40)
         {
-          int v = get_int_local_var_by_name (lexic, "update_ip6_len", 1);
+          int v = get_int_var_by_name (lexic, "update_ip6_len", 1);
           if (v != 0)
             {
               ip6_igmp->ip6_ctlun.ip6_un1.ip6_un1_plen =
@@ -1512,9 +1512,9 @@ forge_igmp_v6_packet (lex_ctxt * lexic)
       p = (char *) (pkt + 40);
       igmp = (struct igmp6_hdr *) p;
 
-      igmp->code = get_int_local_var_by_name (lexic, "code", 0);
-      igmp->type = get_int_local_var_by_name (lexic, "type", 0);
-      grp = get_str_local_var_by_name (lexic, "group");
+      igmp->code = get_int_var_by_name (lexic, "code", 0);
+      igmp->type = get_int_var_by_name (lexic, "type", 0);
+      grp = get_str_var_by_name (lexic, "group");
 
       if (grp != NULL)
         {
@@ -1593,7 +1593,7 @@ nasl_tcp_v6_ping (lex_ctxt * lexic)
       0)
     perror ("setsockopt");
 
-  port = get_int_local_var_by_name (lexic, "port", -1);
+  port = get_int_var_by_name (lexic, "port", -1);
   if (port == -1)
     port = plug_get_host_open_port (script_infos);
   if (v6_islocalhost (destination) > 0)
@@ -1700,10 +1700,10 @@ nasl_send_v6packet (lex_ctxt * lexic)
   struct ip6_hdr *sip = NULL;
   int vi = 0, b = 0, len = 0;
   int soc;
-  int use_pcap = get_int_local_var_by_name (lexic, "pcap_active", 1);
-  int to = get_int_local_var_by_name (lexic, "pcap_timeout", 5);
-  char *filter = get_str_local_var_by_name (lexic, "pcap_filter");
-  int dfl_len = get_int_local_var_by_name (lexic, "length", -1);
+  int use_pcap = get_int_var_by_name (lexic, "pcap_active", 1);
+  int to = get_int_var_by_name (lexic, "pcap_timeout", 5);
+  char *filter = get_str_var_by_name (lexic, "pcap_filter");
+  int dfl_len = get_int_var_by_name (lexic, "length", -1);
   struct script_infos *script_infos = lexic->script_infos;
   struct in6_addr *dstip = plug_get_host_ip (script_infos);
   int offset = 1;

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -435,9 +435,9 @@ script_require_udp_ports (lex_ctxt * lexic)
 tree_cell *
 script_add_preference (lex_ctxt * lexic)
 {
-  char *name = get_str_local_var_by_name (lexic, "name");
-  char *type = get_str_local_var_by_name (lexic, "type");
-  char *value = get_str_local_var_by_name (lexic, "value");
+  char *name = get_str_var_by_name (lexic, "name");
+  char *type = get_str_var_by_name (lexic, "type");
+  char *value = get_str_var_by_name (lexic, "value");
   struct script_infos *script_infos = lexic->script_infos;
 
   if (name == NULL || type == NULL || value == NULL)
@@ -764,8 +764,8 @@ tree_cell *
 replace_kb_item (lex_ctxt * lexic)
 {
   struct script_infos *script_infos = lexic->script_infos;
-  char *name = get_str_local_var_by_name (lexic, "name");
-  int type = get_local_var_type_by_name (lexic, "value");
+  char *name = get_str_var_by_name (lexic, "name");
+  int type = get_var_type_by_name (lexic, "value");
 
   if (name == NULL)
     {
@@ -776,7 +776,7 @@ replace_kb_item (lex_ctxt * lexic)
 
   if (type == VAR2_INT)
     {
-      int value = get_int_local_var_by_name (lexic, "value", -1);
+      int value = get_int_var_by_name (lexic, "value", -1);
       if (value != -1)
         plug_replace_key (script_infos, name, ARG_INT,
                           GSIZE_TO_POINTER (value));
@@ -787,8 +787,8 @@ replace_kb_item (lex_ctxt * lexic)
     }
   else
     {
-      char *value = get_str_local_var_by_name (lexic, "value");
-      int len = get_local_var_size_by_name (lexic, "value");
+      char *value = get_str_var_by_name (lexic, "value");
+      int len = get_var_size_by_name (lexic, "value");
 
       if (value == NULL)
         {
@@ -807,8 +807,8 @@ tree_cell *
 set_kb_item (lex_ctxt * lexic)
 {
   struct script_infos *script_infos = lexic->script_infos;
-  char *name = get_str_local_var_by_name (lexic, "name");
-  int type = get_local_var_type_by_name (lexic, "value");
+  char *name = get_str_var_by_name (lexic, "name");
+  int type = get_var_type_by_name (lexic, "value");
 
   if (name == NULL)
     {
@@ -819,7 +819,7 @@ set_kb_item (lex_ctxt * lexic)
 
   if (type == VAR2_INT)
     {
-      int value = get_int_local_var_by_name (lexic, "value", -1);
+      int value = get_int_var_by_name (lexic, "value", -1);
       if (value != -1)
         plug_set_key (script_infos, name, ARG_INT, GSIZE_TO_POINTER (value));
       else
@@ -829,8 +829,8 @@ set_kb_item (lex_ctxt * lexic)
     }
   else
     {
-      char *value = get_str_local_var_by_name (lexic, "value");
-      int len = get_local_var_size_by_name (lexic, "value");
+      char *value = get_str_var_by_name (lexic, "value");
+      int len = get_var_size_by_name (lexic, "value");
       if (value == NULL)
         {
           nasl_perror (lexic,
@@ -864,14 +864,14 @@ security_something (lex_ctxt * lexic, proto_post_something_t proto_post_func,
 {
   struct script_infos *script_infos = lexic->script_infos;
 
-  char *proto = get_str_local_var_by_name (lexic, "protocol");
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int port = get_int_local_var_by_name (lexic, "port", -1);
+  char *proto = get_str_var_by_name (lexic, "protocol");
+  char *data = get_str_var_by_name (lexic, "data");
+  int port = get_int_var_by_name (lexic, "port", -1);
   char *dup = NULL;
 
   if (data != NULL)
     {
-      int len = get_local_var_size_by_name (lexic, "data");
+      int len = get_var_size_by_name (lexic, "data");
       int i;
 
       dup = g_memdup (data, len + 1);
@@ -889,7 +889,7 @@ security_something (lex_ctxt * lexic, proto_post_something_t proto_post_func,
     }
 
   if (proto == NULL)
-    proto = get_str_local_var_by_name (lexic, "proto");
+    proto = get_str_var_by_name (lexic, "proto");
 
   if (port < 0)
     port = get_int_var_by_num (lexic, 0, -1);
@@ -1029,8 +1029,8 @@ nasl_scanner_add_port (lex_ctxt * lexic)
 {
   struct script_infos *script_infos = lexic->script_infos;
 
-  int port = get_int_local_var_by_name (lexic, "port", -1);
-  char *proto = get_str_local_var_by_name (lexic, "proto");
+  int port = get_int_var_by_name (lexic, "port", -1);
+  char *proto = get_str_var_by_name (lexic, "proto");
 
   if (port >= 0)
     {

--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -58,7 +58,7 @@
 #include "nasl_smb.h"
 #include "openvas_smb_interface.h"
 
-#define IMPORT(var) char *var = get_str_local_var_by_name(lexic, #var)
+#define IMPORT(var) char *var = get_str_var_by_name(lexic, #var)
 
 #undef G_LOG_DOMAIN
 /**
@@ -111,9 +111,9 @@ nasl_smb_connect (lex_ctxt * lexic)
   struct script_infos *script_infos = lexic->script_infos;
   struct in6_addr *host = plug_get_host_ip (script_infos);
   char *ip;
-  char *username = get_str_local_var_by_name (lexic, "username");
-  char *password = get_str_local_var_by_name (lexic, "password");
-  char *share = get_str_local_var_by_name (lexic, "share");
+  char *username = get_str_var_by_name (lexic, "username");
+  char *password = get_str_var_by_name (lexic, "password");
+  char *share = get_str_var_by_name (lexic, "share");
 
   tree_cell *retc;
   SMB_HANDLE handle;
@@ -165,7 +165,7 @@ tree_cell *
 nasl_smb_close (lex_ctxt * lexic)
 {
   SMB_HANDLE handle =
-    (SMB_HANDLE) get_int_local_var_by_name (lexic, "smb_handle", 0);
+    (SMB_HANDLE) get_int_var_by_name (lexic, "smb_handle", 0);
   int ret;
   tree_cell *retc;
 
@@ -197,8 +197,8 @@ tree_cell *
 nasl_smb_file_SDDL (lex_ctxt * lexic)
 {
   SMB_HANDLE handle =
-    (SMB_HANDLE) get_int_local_var_by_name (lexic, "smb_handle", 0);
-  char *filename = get_str_local_var_by_name (lexic, "filename");
+    (SMB_HANDLE) get_int_var_by_name (lexic, "smb_handle", 0);
+  char *filename = get_str_var_by_name (lexic, "filename");
 
   if (!filename)
     {
@@ -242,8 +242,8 @@ tree_cell *
 nasl_smb_file_owner_sid (lex_ctxt * lexic)
 {
   SMB_HANDLE handle =
-    (SMB_HANDLE) get_int_local_var_by_name (lexic, "smb_handle", 0);
-  char *filename = get_str_local_var_by_name (lexic, "filename");
+    (SMB_HANDLE) get_int_var_by_name (lexic, "smb_handle", 0);
+  char *filename = get_str_var_by_name (lexic, "filename");
 
   if (!filename)
     {
@@ -287,8 +287,8 @@ tree_cell *
 nasl_smb_file_group_sid (lex_ctxt * lexic)
 {
   SMB_HANDLE handle =
-    (SMB_HANDLE) get_int_local_var_by_name (lexic, "smb_handle", 0);
-  char *filename = get_str_local_var_by_name (lexic, "filename");
+    (SMB_HANDLE) get_int_var_by_name (lexic, "smb_handle", 0);
+  char *filename = get_str_var_by_name (lexic, "filename");
 
   if (!filename)
     {
@@ -333,8 +333,8 @@ tree_cell *
 nasl_smb_file_trustee_rights (lex_ctxt * lexic)
 {
   SMB_HANDLE handle =
-    (SMB_HANDLE) get_int_local_var_by_name (lexic, "smb_handle", 0);
-  char *filename = get_str_local_var_by_name (lexic, "filename");
+    (SMB_HANDLE) get_int_var_by_name (lexic, "smb_handle", 0);
+  char *filename = get_str_var_by_name (lexic, "filename");
 
   if (!filename)
     {

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -241,7 +241,7 @@ nasl_open_privileged_socket (lex_ctxt * lexic, int proto)
   struct sockaddr_in addr, daddr;
   struct sockaddr_in6 addr6, daddr6;
   struct in6_addr *p;
-  int to = get_int_local_var_by_name (lexic, "timeout", lexic->recv_timeout);
+  int to = get_int_var_by_name (lexic, "timeout", lexic->recv_timeout);
   tree_cell *retc;
   struct timeval tv;
   fd_set rd;
@@ -251,8 +251,8 @@ nasl_open_privileged_socket (lex_ctxt * lexic, int proto)
 
 
 
-  sport = get_int_local_var_by_name (lexic, "sport", -1);
-  dport = get_int_local_var_by_name (lexic, "dport", -1);
+  sport = get_int_var_by_name (lexic, "sport", -1);
+  dport = get_int_var_by_name (lexic, "dport", -1);
   if (dport <= 0)
     {
       nasl_perror (lexic,
@@ -445,19 +445,19 @@ nasl_open_sock_tcp_bufsz (lex_ctxt * lexic, int bufsz)
   const char *priority;
   tree_cell *retc;
 
-  to = get_int_local_var_by_name (lexic, "timeout", lexic->recv_timeout * 2);
+  to = get_int_var_by_name (lexic, "timeout", lexic->recv_timeout * 2);
   if (to < 0)
     to = 10;
 
-  transport = get_int_local_var_by_name (lexic, "transport", -1);
+  transport = get_int_var_by_name (lexic, "transport", -1);
 
   if (transport == OPENVAS_ENCAPS_TLScustom)
     {
       int type;
-      priority = get_str_local_var_by_name (lexic, "priority");
+      priority = get_str_var_by_name (lexic, "priority");
       if (!priority)
         priority = NULL;
-      type = get_local_var_type_by_name (lexic, "priority");
+      type = get_var_type_by_name (lexic, "priority");
       if (type != VAR2_STRING && type != VAR2_DATA)
         priority = NULL;
     }
@@ -465,7 +465,7 @@ nasl_open_sock_tcp_bufsz (lex_ctxt * lexic, int bufsz)
     priority = NULL;
 
   if (bufsz < 0)
-    bufsz = get_int_local_var_by_name (lexic, "bufsz", 0);
+    bufsz = get_int_var_by_name (lexic, "bufsz", 0);
 
   port = get_int_var_by_num (lexic, 0, -1);
   if (port < 0)
@@ -617,9 +617,9 @@ nasl_socket_negotiate_ssl (lex_ctxt * lexic)
   tree_cell *retc;
 
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
-  transport = get_int_local_var_by_name (lexic, "transport",
-                                         OPENVAS_ENCAPS_TLScustom);
+  soc = get_int_var_by_name (lexic, "socket", -1);
+  transport = get_int_var_by_name (lexic, "transport",
+                                   OPENVAS_ENCAPS_TLScustom);
   if (soc < 0)
     {
       nasl_perror (lexic, "socket_ssl_negotiate: Erroneous socket value %d\n",
@@ -651,7 +651,7 @@ nasl_socket_get_cert (lex_ctxt * lexic)
   tree_cell *retc;
   void *cert;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   if (soc < 0)
     {
       nasl_perror (lexic, "socket_get_cert: Erroneous socket value %d\n",
@@ -676,7 +676,7 @@ nasl_socket_get_ssl_session_id (lex_ctxt * lexic)
   tree_cell *retc;
   void *sid;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   if (soc < 0)
     {
       nasl_perror (lexic, "socket_get_cert: Erroneous socket value %d\n",
@@ -699,7 +699,7 @@ nasl_socket_get_ssl_compression (lex_ctxt * lexic)
   int soc;
   tree_cell *retc;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   if (soc < 0)
     {
       nasl_perror (lexic, "socket_get_cert: Erroneous socket value %d\n",
@@ -719,7 +719,7 @@ nasl_socket_get_ssl_version (lex_ctxt * lexic)
   int version;
   tree_cell *retc;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   version = socket_get_ssl_version (soc);
   if (version < 0)
     return NULL;
@@ -735,7 +735,7 @@ nasl_socket_get_ssl_ciphersuite (lex_ctxt * lexic)
   int soc, result;
   tree_cell *retc;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   result = socket_get_ssl_ciphersuite (soc);
   if (result < 0)
     return NULL;
@@ -751,10 +751,10 @@ tree_cell *
 nasl_recv (lex_ctxt * lexic)
 {
   char *data;
-  int len = get_int_local_var_by_name (lexic, "length", -1);
-  int min_len = get_int_local_var_by_name (lexic, "min", -1);
-  int soc = get_int_local_var_by_name (lexic, "socket", 0);
-  int to = get_int_local_var_by_name (lexic, "timeout", lexic->recv_timeout);
+  int len = get_int_var_by_name (lexic, "length", -1);
+  int min_len = get_int_var_by_name (lexic, "min", -1);
+  int soc = get_int_var_by_name (lexic, "socket", 0);
+  int to = get_int_var_by_name (lexic, "timeout", lexic->recv_timeout);
   fd_set rd;
   struct timeval tv;
   int new_len = 0;
@@ -847,9 +847,9 @@ nasl_recv (lex_ctxt * lexic)
 tree_cell *
 nasl_recv_line (lex_ctxt * lexic)
 {
-  int len = get_int_local_var_by_name (lexic, "length", -1);
-  int soc = get_int_local_var_by_name (lexic, "socket", 0);
-  int timeout = get_int_local_var_by_name (lexic, "timeout", -1);
+  int len = get_int_var_by_name (lexic, "length", -1);
+  int soc = get_int_var_by_name (lexic, "socket", 0);
+  int timeout = get_int_var_by_name (lexic, "timeout", -1);
   char *data;
   int new_len = 0;
   int n = 0;
@@ -918,10 +918,10 @@ nasl_recv_line (lex_ctxt * lexic)
 tree_cell *
 nasl_send (lex_ctxt * lexic)
 {
-  int soc = get_int_local_var_by_name (lexic, "socket", 0);
-  char *data = get_str_local_var_by_name (lexic, "data");
-  int option = get_int_local_var_by_name (lexic, "option", 0);
-  int length = get_int_local_var_by_name (lexic, "length", 0);
+  int soc = get_int_var_by_name (lexic, "socket", 0);
+  char *data = get_str_var_by_name (lexic, "data");
+  int option = get_int_var_by_name (lexic, "option", 0);
+  int length = get_int_var_by_name (lexic, "length", 0);
   int data_length = get_var_size_by_name (lexic, "data");
   int n;
   tree_cell *retc;
@@ -1287,7 +1287,7 @@ nasl_get_sock_info (lex_ctxt * lexic)
       return NULL;
     }
 
-  as_string = !!get_int_local_var_by_name (lexic, "asstring", 0);
+  as_string = !!get_int_var_by_name (lexic, "asstring", 0);
 
   transport = 0;
   strval = NULL;
@@ -1472,7 +1472,7 @@ nasl_socket_cert_verify (lex_ctxt *lexic)
   int transport;
   gnutls_session_t tls_session;
 
-  soc = get_int_local_var_by_name (lexic, "socket", -1);
+  soc = get_int_var_by_name (lexic, "socket", -1);
   if (soc < 0)
     {
       nasl_perror (lexic, "socket_get_cert: Erroneous socket value %d\n",

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -258,12 +258,12 @@ nasl_ssh_connect (lex_ctxt *lexic)
   int verbose = 0;
   int forced_sock = -1;
 
-  sock = get_int_local_var_by_name (lexic, "socket", 0);
+  sock = get_int_var_by_name (lexic, "socket", 0);
   if (sock)
     port = 0; /* The port is ignored if "socket" is given.  */
   else
     {
-      port = get_int_local_var_by_name (lexic, "port", 0);
+      port = get_int_var_by_name (lexic, "port", 0);
       if (port <= 0)
         port = get_ssh_port (lexic);
     }
@@ -303,7 +303,7 @@ nasl_ssh_connect (lex_ctxt *lexic)
       return NULL;
     }
 
-  key_type = get_str_local_var_by_name (lexic, "keytype");
+  key_type = get_str_var_by_name (lexic, "keytype");
 
   if (key_type && ssh_options_set (session, SSH_OPTIONS_HOSTKEYS, key_type))
     {
@@ -313,7 +313,7 @@ nasl_ssh_connect (lex_ctxt *lexic)
       return NULL;
     }
 
-  csciphers = get_str_local_var_by_name (lexic, "csciphers");
+  csciphers = get_str_var_by_name (lexic, "csciphers");
   if (csciphers && ssh_options_set (session, SSH_OPTIONS_CIPHERS_C_S, csciphers))
     {
       g_message ("Failed to set SSH client to server ciphers '%s': %s",
@@ -321,7 +321,7 @@ nasl_ssh_connect (lex_ctxt *lexic)
       ssh_free (session);
       return NULL;
     }
-  scciphers = get_str_local_var_by_name (lexic, "scciphers");
+  scciphers = get_str_var_by_name (lexic, "scciphers");
   if (scciphers && ssh_options_set (session, SSH_OPTIONS_CIPHERS_S_C, scciphers))
     {
       g_message ("Failed to set SSH server to client ciphers '%s': %s",
@@ -723,7 +723,7 @@ nasl_ssh_set_login (lex_ctxt *lexic)
       kb_t kb;
       char *username;
 
-      username = get_str_local_var_by_name (lexic, "login");
+      username = get_str_var_by_name (lexic, "login");
       if (!username)
         {
           kb = plug_get_kb (lexic->script_infos);
@@ -827,9 +827,9 @@ nasl_ssh_userauth (lex_ctxt *lexic)
     return NULL;
 
   kb = plug_get_kb (lexic->script_infos);
-  password = get_str_local_var_by_name (lexic, "password");
-  privkeystr = get_str_local_var_by_name (lexic, "privatekey");
-  privkeypass = get_str_local_var_by_name (lexic, "passphrase");
+  password = get_str_var_by_name (lexic, "password");
+  privkeystr = get_str_var_by_name (lexic, "privatekey");
+  privkeypass = get_str_var_by_name (lexic, "passphrase");
   if (!password && !privkeystr && !privkeypass)
     {
       password = kb_item_get_str (kb, "Secret/SSH/password");
@@ -1127,7 +1127,7 @@ nasl_ssh_login_interactive_pass (lex_ctxt *lexic)
   verbose = session_table[tbl_slot].verbose;
 
   /* A prompt is waiting for the password. */
-  if ((password = get_str_local_var_by_name (lexic, "password")) == NULL)
+  if ((password = get_str_var_by_name (lexic, "password")) == NULL)
     return NULL;
 
   rc = ssh_userauth_kbdint_setanswer (session, 0, password);
@@ -1343,15 +1343,15 @@ nasl_ssh_request_exec (lex_ctxt *lexic)
 
   verbose = session_table[tbl_slot].verbose;
 
-  cmd = get_str_local_var_by_name (lexic, "cmd");
+  cmd = get_str_var_by_name (lexic, "cmd");
   if (!cmd || !*cmd)
     {
       g_message ("No command passed to ssh_request_exec");
       return NULL;
     }
 
-  to_stdout = get_int_local_var_by_name (lexic, "stdout", -1);
-  to_stderr = get_int_local_var_by_name (lexic, "stderr", -1);
+  to_stdout = get_int_var_by_name (lexic, "stdout", -1);
+  to_stderr = get_int_var_by_name (lexic, "stderr", -1);
   compat_mode = 0;
   if (to_stdout == -1 && to_stderr == -1)
     {
@@ -1802,7 +1802,7 @@ nasl_ssh_shell_write (lex_ctxt *lexic)
       goto write_ret;
     }
 
-  cmd = get_str_local_var_by_name (lexic, "cmd");
+  cmd = get_str_var_by_name (lexic, "cmd");
   if (!cmd || !*cmd)
     {
       g_message ("ssh_shell_write: No command passed");

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -463,10 +463,10 @@ nasl_toupper (lex_ctxt * lexic)
 tree_cell *
 nasl_ereg (lex_ctxt * lexic)
 {
-  char *pattern = get_str_local_var_by_name (lexic, "pattern");
-  char *string = get_str_local_var_by_name (lexic, "string");
-  int icase = get_int_local_var_by_name (lexic, "icase", 0);
-  int multiline = get_int_local_var_by_name (lexic, "multiline", 0);
+  char *pattern = get_str_var_by_name (lexic, "pattern");
+  char *string = get_str_var_by_name (lexic, "string");
+  int icase = get_int_var_by_name (lexic, "icase", 0);
+  int multiline = get_int_var_by_name (lexic, "multiline", 0);
   char *s;
   int copt = 0;
   tree_cell *retc;
@@ -665,10 +665,10 @@ _regreplace (const char *pattern, const char *replace, const char *string,
 tree_cell *
 nasl_ereg_replace (lex_ctxt * lexic)
 {
-  char *pattern = get_str_local_var_by_name (lexic, "pattern");
-  char *replace = get_str_local_var_by_name (lexic, "replace");
-  char *string = get_str_local_var_by_name (lexic, "string");
-  int icase = get_int_local_var_by_name (lexic, "icase", 0);
+  char *pattern = get_str_var_by_name (lexic, "pattern");
+  char *replace = get_str_var_by_name (lexic, "replace");
+  char *string = get_str_var_by_name (lexic, "string");
+  int icase = get_int_var_by_name (lexic, "icase", 0);
   char *r;
   tree_cell *retc;
 
@@ -708,9 +708,9 @@ nasl_ereg_replace (lex_ctxt * lexic)
 tree_cell *
 nasl_egrep (lex_ctxt * lexic)
 {
-  char *pattern = get_str_local_var_by_name (lexic, "pattern");
-  char *string = get_str_local_var_by_name (lexic, "string");
-  int icase = get_int_local_var_by_name (lexic, "icase", 0);
+  char *pattern = get_str_var_by_name (lexic, "pattern");
+  char *string = get_str_var_by_name (lexic, "string");
+  int icase = get_int_var_by_name (lexic, "icase", 0);
   tree_cell *retc;
   regex_t re;
   regmatch_t subs[NS];
@@ -816,9 +816,9 @@ nasl_egrep (lex_ctxt * lexic)
 tree_cell *
 nasl_eregmatch (lex_ctxt * lexic)
 {
-  char *pattern = get_str_local_var_by_name (lexic, "pattern");
-  char *string = get_str_local_var_by_name (lexic, "string");
-  int icase = get_int_local_var_by_name (lexic, "icase", 0);
+  char *pattern = get_str_var_by_name (lexic, "pattern");
+  char *string = get_str_var_by_name (lexic, "string");
+  int icase = get_int_var_by_name (lexic, "icase", 0);
   int copt = 0, i;
   tree_cell *retc;
   regex_t re;
@@ -982,9 +982,9 @@ nasl_insstr (lex_ctxt * lexic)
 tree_cell *
 nasl_match (lex_ctxt * lexic)
 {
-  char *pattern = get_str_local_var_by_name (lexic, "pattern");
-  char *string = get_str_local_var_by_name (lexic, "string");
-  int icase = get_int_local_var_by_name (lexic, "icase", 0);
+  char *pattern = get_str_var_by_name (lexic, "pattern");
+  char *string = get_str_var_by_name (lexic, "string");
+  int icase = get_int_var_by_name (lexic, "icase", 0);
   tree_cell *retc;
 
   if (pattern == NULL)
@@ -1027,7 +1027,7 @@ nasl_split (lex_ctxt * lexic)
   if (len <= 0)
     return NULL;
 
-  sep = get_str_local_var_by_name (lexic, "sep");
+  sep = get_str_var_by_name (lexic, "sep");
   if (sep != NULL)
     {
       sep_len = get_var_size_by_name (lexic, "sep");
@@ -1040,7 +1040,7 @@ nasl_split (lex_ctxt * lexic)
         }
     }
 
-  keep = get_int_local_var_by_name (lexic, "keep", 1);
+  keep = get_int_var_by_name (lexic, "keep", 1);
 
   retc = alloc_tree_cell ();
   retc->type = DYN_ARRAY;
@@ -1146,9 +1146,9 @@ tree_cell *
 nasl_crap (lex_ctxt * lexic)
 {
   tree_cell *retc;
-  char *data = get_str_local_var_by_name (lexic, "data");
+  char *data = get_str_var_by_name (lexic, "data");
   int data_len = -1;
-  int len = get_int_local_var_by_name (lexic, "length", -1);
+  int len = get_int_var_by_name (lexic, "length", -1);
   int len2 = get_int_var_by_num (lexic, 0, -1);
 
   if (len < 0 && len2 < 0)
@@ -1290,13 +1290,13 @@ nasl_str_replace (lex_ctxt * lexic)
   tree_cell *retc = NULL;
 
 
-  a = get_str_local_var_by_name (lexic, "string");
-  b = get_str_local_var_by_name (lexic, "find");
-  r = get_str_local_var_by_name (lexic, "replace");
-  sz_a = get_local_var_size_by_name (lexic, "string");
-  sz_b = get_local_var_size_by_name (lexic, "find");
-  sz_r = get_local_var_size_by_name (lexic, "replace");
-  count = get_int_local_var_by_name (lexic, "count", 0);
+  a = get_str_var_by_name (lexic, "string");
+  b = get_str_var_by_name (lexic, "find");
+  r = get_str_var_by_name (lexic, "replace");
+  sz_a = get_var_size_by_name (lexic, "string");
+  sz_b = get_var_size_by_name (lexic, "find");
+  sz_r = get_var_size_by_name (lexic, "replace");
+  count = get_int_var_by_name (lexic, "count", 0);
 
   if (a == NULL || b == NULL)
     {

--- a/nasl/nasl_var.c
+++ b/nasl/nasl_var.c
@@ -1236,13 +1236,6 @@ get_int_var_by_num (lex_ctxt * lexic, int num, int defval)
 long int
 get_int_var_by_name (lex_ctxt * lexic, const char *name, int defval)
 {
-  named_nasl_var *v = get_var_ref_by_name (lexic, name, 1);
-  return var2int (&v->u, defval);
-}
-
-long int
-get_int_local_var_by_name (lex_ctxt * lexic, const char *name, int defval)
-{
   named_nasl_var *v = get_var_ref_by_name (lexic, name, 0);
   return var2int (&v->u, defval);
 }
@@ -1258,17 +1251,9 @@ get_str_var_by_num (lex_ctxt * lexic, int num)
 char *
 get_str_var_by_name (lex_ctxt * lexic, const char *name)
 {
-  named_nasl_var *v = get_var_ref_by_name (lexic, name, 1);
-  return (char *) var2str (&v->u);
-}
-
-char *
-get_str_local_var_by_name (lex_ctxt * lexic, const char *name)
-{
   named_nasl_var *v = get_var_ref_by_name (lexic, name, 0);
   return (char *) var2str (&v->u);
 }
-
 static int
 get_var_size (const anon_nasl_var * v)
 {
@@ -1294,13 +1279,6 @@ get_var_size (const anon_nasl_var * v)
 int
 get_var_size_by_name (lex_ctxt * lexic, const char *name)
 {
-  named_nasl_var *v = get_var_ref_by_name (lexic, name, 1);
-  return get_var_size (&v->u);
-}
-
-int
-get_local_var_size_by_name (lex_ctxt * lexic, const char *name)
-{
   named_nasl_var *v = get_var_ref_by_name (lexic, name, 0);
   return get_var_size (&v->u);
 }
@@ -1323,7 +1301,7 @@ get_var_type_by_num (lex_ctxt * lexic, int num)
 }
 
 int
-get_local_var_type_by_name (lex_ctxt * lexic, const char *name)
+get_var_type_by_name (lex_ctxt * lexic, const char *name)
 {
   named_nasl_var *v = get_var_ref_by_name (lexic, name, 0);
   return v == NULL ? VAR2_UNDEF : v->u.var_type;

--- a/nasl/nasl_wmi.c
+++ b/nasl/nasl_wmi.c
@@ -60,7 +60,7 @@
 #include "nasl_wmi.h"
 #include "openvas_wmi_interface.h"
 
-#define IMPORT(var) char *var = get_str_local_var_by_name(lexic, #var)
+#define IMPORT(var) char *var = get_str_var_by_name(lexic, #var)
 #define max 5
 
 #undef G_LOG_DOMAIN
@@ -222,7 +222,7 @@ tree_cell *
 nasl_wmi_close (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
   if (!handle)
     return NULL;
 
@@ -254,8 +254,8 @@ tree_cell *
 nasl_wmi_query (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
-  char *query = get_str_local_var_by_name (lexic, "query");
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
+  char *query = get_str_var_by_name (lexic, "query");
   char *res = NULL;
   int value;
 
@@ -363,11 +363,11 @@ tree_cell *
 nasl_wmi_query_rsop (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
   if (!handle)
     return NULL;
 
-  char *query = get_str_local_var_by_name (lexic, "query");     // WQL query
+  char *query = get_str_var_by_name (lexic, "query");     // WQL query
   char *res = NULL;
   int value;
   tree_cell *retc = alloc_tree_cell ();
@@ -470,14 +470,14 @@ tree_cell *
 nasl_wmi_reg_get_sz (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *key_name = get_str_local_var_by_name (lexic, "key_name");       // REGISTRY value name
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *key_name = get_str_var_by_name (lexic, "key_name");       // REGISTRY value name
 
   char *res = NULL;
   int value;
@@ -517,13 +517,13 @@ tree_cell *
 nasl_wmi_reg_enum_value (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
 
   char *res = NULL;
   int value;
@@ -563,13 +563,13 @@ tree_cell *
 nasl_wmi_reg_enum_key (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
 
   char *res = NULL;
   int value;
@@ -609,14 +609,14 @@ tree_cell *
 nasl_wmi_reg_get_bin_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
 
   char *res = NULL;
   int value;
@@ -656,14 +656,14 @@ tree_cell *
 nasl_wmi_reg_get_dword_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
 
   char *res = NULL;
   int value;
@@ -706,14 +706,14 @@ tree_cell *
 nasl_wmi_reg_get_ex_string_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
 
   char *res = NULL;
   int value;
@@ -753,14 +753,14 @@ tree_cell *
 nasl_wmi_reg_get_mul_string_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
 
   char *res = NULL;
   int value;
@@ -800,14 +800,14 @@ tree_cell *
 nasl_wmi_reg_get_qword_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  unsigned int hive = get_int_local_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  unsigned int hive = get_int_var_by_name (lexic, "hive", 0);     // REGISTRY Hive
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
 
   char *res = NULL;
   int value;
@@ -848,14 +848,14 @@ tree_cell *
 nasl_wmi_reg_set_dword_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
-  char *val = get_str_local_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  char *val = get_str_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
 
   uint32_t val1;
   int value;
@@ -900,14 +900,14 @@ tree_cell *
 nasl_wmi_reg_set_qword_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
-  char *val = get_str_local_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  char *val = get_str_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
 
   uint64_t val1;
   int value;
@@ -952,14 +952,14 @@ tree_cell *
 nasl_wmi_reg_set_ex_string_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
-  char *val = get_str_local_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  char *val = get_str_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
 
   int value;
 
@@ -995,14 +995,14 @@ tree_cell *
 nasl_wmi_reg_set_string_val (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
-  char *val_name = get_str_local_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
-  char *val = get_str_local_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *val_name = get_str_var_by_name (lexic, "val_name");       // REGISTRY VALUE NAME
+  char *val = get_str_var_by_name (lexic, "val");  //REGISTERY VALUE TO SET
 
   int value;
 
@@ -1037,12 +1037,12 @@ tree_cell *
 nasl_wmi_reg_create_key (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
 
   int value;
 
@@ -1079,12 +1079,12 @@ tree_cell *
 nasl_wmi_reg_delete_key (lex_ctxt * lexic)
 {
   WMI_HANDLE handle =
-    (WMI_HANDLE) get_int_local_var_by_name (lexic, "wmi_handle", 0);
+    (WMI_HANDLE) get_int_var_by_name (lexic, "wmi_handle", 0);
 
   if (!handle)
     return NULL;
 
-  char *key = get_str_local_var_by_name (lexic, "key"); // REGISTRY KEY
+  char *key = get_str_var_by_name (lexic, "key"); // REGISTRY KEY
 
   int value;
 


### PR DESCRIPTION
Some NASL functions use get_*_var_by_name() instead of
get_*_local_var_by_name(), which "climbs" in the context when searching
for a variable ie. if a parameter 'foo' is not provided, the function
would use the variable 'foo' if found.

Unify the behaviour by replacing all get_*_local_var_by_name()
with get_*_var_by_name() calls, and change the later to not climb
in the nasl context when searching for the variable.

To reproduce:
------------------------
hostname = 'foo';
source = 'bar';
add_host_name();
display(get_host_name() + '|' + get_host_name_source());
------------------------