### PR TITLE
Improve message log.

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -1001,7 +1001,7 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
 
     default:
       g_message ("open_stream_connection_ext(): unsupported transport"
-                 " layer %d", transport);
+                 " layer %d passed by %s", transport, args->name);
       errno = EINVAL;
       return -1;
     }


### PR DESCRIPTION
Print the nvt name in case of "unsupported transport layer".