### PR TITLE
 Add definition for NVTICACHE_STR. 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,12 @@ pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=1.0.0)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=1.0.0)
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 
+# set NVTICACHE_STR with version.
+if (LIBGVM_UTIL_VERSION)
+  set (NVTICACHE_STR "nvticache${LIBGVM_UTIL_VERSION}")
+  add_definitions (-DNVTICACHE_STR="${NVTICACHE_STR}")
+endif (LIBGVM_UTIL_VERSION)
+
 message (STATUS "Looking for libgcrypt...")
 find_library (GCRYPT gcrypt)
 if (NOT GCRYPT)

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -138,6 +138,7 @@ plugin_add (plugins_scheduler_t sched, GHashTable *oids_table,
     }
 
   category = nvti_category (nvti);
+  assert (category >= 0);
   plugin = g_malloc0 (sizeof (struct scheduler_plugin));
   plugin->running_state = PLUGIN_STATUS_UNRUN;
   plugin->oid = g_strdup (oid);


### PR DESCRIPTION
Depends on greenbone/gvm-libs#124

Assert if a plugin doesn't have a valid category.

Use the gvm-libs release version in the name of the nvticache.
This avoid to use an old nvticache structure stored in redis if a
new gvm-libs version is installed, cleaning the old one and loading up
the NVTs acording to the new structure.