### PR TITLE
[5.1] Remove OPENVAS_CACHE_DIR / cache_folder.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,6 @@ endif (NOT OPENVAS_RUN_DIR)
 set (OPENVAS_DATA_DIR    "${DATADIR}/openvas")
 set (OPENVAS_STATE_DIR   "${LOCALSTATEDIR}/lib/openvas")
 set (OPENVAS_LOG_DIR     "${LOCALSTATEDIR}/log/openvas")
-set (OPENVAS_CACHE_DIR   "${LOCALSTATEDIR}/cache/openvas")
 set (OPENVAS_SYSCONF_DIR "${SYSCONFDIR}/openvas")
 
 if (NOT OPENVAS_NVT_DIR)
@@ -265,7 +264,6 @@ install (FILES ${CMAKE_BINARY_DIR}/doc/example_redis_2_4.conf
          DESTINATION ${DATADIR}/doc/openvas-scanner/ )
 
 install (DIRECTORY DESTINATION ${OPENVAS_NVT_DIR})
-install (DIRECTORY DESTINATION ${OPENVAS_CACHE_DIR})
 
 ## Tests
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,10 +68,6 @@ if (OPENVAS_NVT_DIR)
   add_definitions (-DOPENVAS_NVT_DIR=\\\"${OPENVAS_NVT_DIR}\\\")
 endif (OPENVAS_NVT_DIR)
 
-if (OPENVAS_CACHE_DIR)
-  add_definitions (-DOPENVAS_CACHE_DIR=\\\"${OPENVAS_CACHE_DIR}\\\")
-endif (OPENVAS_CACHE_DIR)
-
 if (OPENVAS_LOG_DIR)
   add_definitions (-DOPENVAS_LOG_DIR=\\\"${OPENVAS_LOG_DIR}\\\")
 endif (OPENVAS_LOG_DIR)

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -103,7 +103,6 @@ typedef struct
  */
 static openvassd_option openvassd_defaults[] = {
   {"plugins_folder", OPENVAS_NVT_DIR},
-  {"cache_folder", OPENVAS_CACHE_DIR},
   {"include_folders", OPENVAS_NVT_DIR},
   {"max_hosts", "30"},
   {"max_checks", "10"},


### PR DESCRIPTION
Backport of #69 to the openvas-scanner-5.1 branch (openvas-libraries-9.0 part in https://github.com/greenbone/gvm-libs/pull/125).

https://github.com/greenbone/openvas-scanner/pull/15 (https://github.com/greenbone/openvas-scanner/commit/358628c11bfafbe40cef096629927bde9c482582 for master) and https://github.com/greenbone/gvm-libs/pull/25 (https://github.com/greenbone/gvm-libs/commit/3cb79063b3b1b56376c6846868e97d9982b94c3a for master) had moved the full nvticache to Redis leaving this now unused definitions left behind.