### PR TITLE
Add expand_vhosts preference.

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -97,6 +97,9 @@ When a port  is found as opened at the beginning of the scan, and for some reaso
 .IP time_between_request
 Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in miliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
 
+.IP expand_vhosts
+Whether to expand the target host's list of vhosts with values gathered from sources such as reverse-lookup queries and VT checks for TLS/SSL certificates.
+
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvassd to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvassd to designate a service formally. Ex: "139, Services/www", will prevent openvassd from making two connections at the same time on port 139 and on every port which hosts a web server.
 

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -341,7 +341,8 @@ main (int argc, char **argv)
       kb_t kb;
       int rc, i = 0;
 
-      gvm_host_add_reverse_lookup (host);
+      if (prefs_get_bool ("expand_vhosts"))
+        gvm_host_add_reverse_lookup (host);
       gvm_host_get_addr6 (host, &ip6);
       rc = kb_new (&kb, prefs_get ("db_address") ?: KB_PATH_DEFAULT);
       if (rc)

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -34,6 +34,7 @@
 #include <unistd.h>             /* for gethostname */
 
 #include <gvm/base/networking.h>
+#include <gvm/base/prefs.h>
 #include <gvm/util/kb.h>
 
 #include "../misc/network.h"
@@ -124,6 +125,8 @@ add_hostname (lex_ctxt * lexic)
   char *value = get_str_var_by_name (lexic, "hostname");
   char *source = get_str_var_by_name (lexic, "source");
 
+  if (!prefs_get_bool ("expand_vhosts"))
+    return NULL;
   if (!value)
     {
       nasl_perror (lexic, "%s: Empty hostname\n", __FUNCTION__);

--- a/src/attack.c
+++ b/src/attack.c
@@ -640,7 +640,8 @@ attack_start (struct attack_start_args *args)
 
   /* The reverse lookup is delayed to this step in order to not slow down the
    * main scan process eg. case of target with big range of IP addresses. */
-  gvm_host_add_reverse_lookup (args->host);
+  if (prefs_get_bool ("expand_vhosts"))
+    gvm_host_add_reverse_lookup (args->host);
   gvm_host_get_addr6 (args->host, &hostip);
   addr6_to_str (&hostip, ip_str);
   /* Do we have the right to test this host ? */

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -148,6 +148,7 @@ static openvassd_option openvassd_defaults[] = {
   {"timeout_retry", "3"},
   {"open_sock_max_attempts", "5"},
   {"time_between_request", "0"},
+  {"expand_vhosts", "yes"},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
In order to control whether the target host's vhosts list is expanded
through reverse-lookups and nasl add_host_name() calls.