### PR TITLE
Exclude hosts

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -205,7 +205,7 @@ host_get_port_state_udp (struct script_infos *plugdata, int portnum)
   return (host_get_port_state_proto (plugdata, portnum, "udp"));
 }
 
-void
+int
 plug_add_host_fqdn (struct script_infos *args, const char *hostname,
                     const char *source)
 {
@@ -213,7 +213,7 @@ plug_add_host_fqdn (struct script_infos *args, const char *hostname,
   GSList *vhosts;
 
   if (!hostname || !source)
-    return;
+    return -1;
 
   vhosts = args->vhosts;
   while (vhosts)
@@ -223,12 +223,13 @@ plug_add_host_fqdn (struct script_infos *args, const char *hostname,
       if (!strcmp (tmp->value, hostname))
         {
           g_warning ("%s: Value '%s' exists already", __FUNCTION__, hostname);
-          return;
+          return -1;
         }
       vhosts = vhosts->next;
     }
   vhost = gvm_vhost_new (g_strdup (hostname), g_strdup (source));
   args->vhosts = g_slist_prepend (args->vhosts, vhost);
+  return 0;
 }
 
 char *

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -56,7 +56,7 @@ plug_current_vhost (void);
 char *
 plug_get_host_fqdn (struct script_infos *);
 
-void
+int
 plug_add_host_fqdn (struct script_infos *, const char *, const char *);
 
 GSList *

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -343,6 +343,7 @@ main (int argc, char **argv)
 
       if (prefs_get_bool ("expand_vhosts"))
         gvm_host_add_reverse_lookup (host);
+      gvm_vhosts_exclude (host, prefs_get ("exclude_hosts"));
       gvm_host_get_addr6 (host, &ip6);
       rc = kb_new (&kb, prefs_get ("db_address") ?: KB_PATH_DEFAULT);
       if (rc)

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -135,6 +135,10 @@ add_hostname (lex_ctxt * lexic)
   if (!source || !*source)
     source = "NASL";
 
+  /* Add to current process' vhosts list. */
+  if (plug_add_host_fqdn (lexic->script_infos, value, source))
+    return NULL;
+
   /* Push to KB. Signal host process to fetch it. */
   kb_item_push_str (lexic->script_infos->key, "internal/vhosts", value);
   snprintf (buffer, sizeof (buffer), "internal/source/%s", value);
@@ -143,8 +147,6 @@ add_hostname (lex_ctxt * lexic)
   if (host_pid > 0)
     kill (host_pid, SIGUSR2);
 
-  /* Add to current process' vhosts list. */
-  plug_add_host_fqdn (lexic->script_infos, value, source);
   return NULL;
 }
 

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -34,7 +34,6 @@
 #include <unistd.h>             /* for gethostname */
 
 #include <gvm/base/networking.h>
-#include <gvm/base/prefs.h>
 #include <gvm/util/kb.h>
 
 #include "../misc/network.h"
@@ -125,8 +124,6 @@ add_hostname (lex_ctxt * lexic)
   char *value = get_str_var_by_name (lexic, "hostname");
   char *source = get_str_var_by_name (lexic, "source");
 
-  if (!prefs_get_bool ("expand_vhosts"))
-    return NULL;
   if (!value)
     {
       nasl_perror (lexic, "%s: Empty hostname\n", __FUNCTION__);

--- a/src/attack.c
+++ b/src/attack.c
@@ -667,6 +667,7 @@ attack_start (struct attack_start_args *args)
    * main scan process eg. case of target with big range of IP addresses. */
   if (prefs_get_bool ("expand_vhosts"))
     gvm_host_add_reverse_lookup (args->host);
+  gvm_vhosts_exclude (args->host, prefs_get ("exclude_hosts"));
   gvm_host_get_addr6 (args->host, &hostip);
   addr6_to_str (&hostip, ip_str);
   /* Do we have the right to test this host ? */
@@ -758,7 +759,7 @@ apply_hosts_preferences (gvm_hosts_t *hosts)
   if (exclude_hosts)
     {
       /* Exclude hosts, resolving hostnames. */
-      int ret = gvm_hosts_exclude (hosts, exclude_hosts, 1);
+      int ret = gvm_hosts_exclude (hosts, exclude_hosts);
 
       if (ret >= 0)
         g_message ("exclude_hosts: Skipped %d host(s).", ret);


### PR DESCRIPTION
Depends on https://github.com/greenbone/gvm-libs/pull/131

exclude_hosts now handles excluding vhosts values from different sources (targets list, reverse-lookup, add_host_name())

Example:
_____________
/etc/hosts
192.168.1.33    foo4
192.168.1.33    foo1
192.168.1.33    foo2
192.168.1.33    foo3
192.168.1.33    foo5
_____________
/usr/etc/openvas/openvassd.conf
exclude_hosts = foo1, foo3, foo5
_____________
test.nasl
add_host_name(hostname:'foo5', source:'bar');
display('got ', get_host_name());
_____________
$ openvas-nasl -X -t "foo1,foo2,foo3,foo4,foo5" test.nasl

lib  nasl-Message: 15:39:27.909: got foo4
lib  nasl-Message: 15:39:27.914: got foo2
