### PR TITLE
Use SIGUSR2 to check for new vhosts.

### DIFF
--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -141,7 +141,7 @@ add_hostname (lex_ctxt * lexic)
   kb_item_push_str (lexic->script_infos->key, buffer, source);
   host_pid = kb_item_get_int (lexic->script_infos->key, "internal/hostpid");
   if (host_pid > 0)
-    kill (host_pid, SIGUSR1);
+    kill (host_pid, SIGUSR2);
 
   /* Add to current process' vhosts list. */
   plug_add_host_fqdn (lexic->script_infos, value, source);

--- a/src/attack.c
+++ b/src/attack.c
@@ -477,7 +477,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip,
   char ip_str[INET6_ADDRSTRLEN];
 
   addr6_to_str (ip, ip_str);
-  openvas_signal (SIGUSR1, check_new_vhosts);
+  openvas_signal (SIGUSR2, check_new_vhosts);
   host_kb = kb;
   host_vhosts = vhosts;
   kb_item_set_str (kb, "internal/ip", ip_str, 0);
@@ -517,7 +517,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip,
           static int last_status = 0, cur_plug = 0;
 
         again:
-          e = launch_plugin (globals, plugin, ip, vhosts, kb);
+          e = launch_plugin (globals, plugin, ip, host_vhosts, kb);
           if (e < 0)
             {
               /*


### PR DESCRIPTION
Instead of SIGUSR1, which is also used to stop scan host processes. SIGUSR2
is used for main scan processes only. Also use updated vhosts list adequately.