### PR TITLE
openvas-nasl: Defaults to expand_vhosts = yes if no preference was given

### DIFF
--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -341,7 +341,7 @@ main (int argc, char **argv)
       kb_t kb;
       int rc, i = 0;
 
-      if (prefs_get_bool ("expand_vhosts"))
+      if (!prefs_get ("expand_vhosts") || prefs_get_bool ("expand_vhosts"))
         gvm_host_add_reverse_lookup (host);
       gvm_vhosts_exclude (host, prefs_get ("exclude_hosts"));
       gvm_host_get_addr6 (host, &ip6);


### PR DESCRIPTION
Follow-up change of https://github.com/greenbone/openvas-scanner/pull/184 to make openvas-nasl defaults to expand_vhosts = yes if this directive doesn't exist within the openvassd.conf:

no expand_vhosts in openvassd.conf -> vhosts are expanded
expand_vhosts = yes in openvassd.conf -> vhosts are expanded
expand_vhosts = no in openvassd.conf -> vhosts are not expaned

Test-script:

display(get_host_name() + '|' + get_host_ip() + '|' + get_host_name_source());