### PR TITLE
Make the term NASL a backronym.

### DIFF
--- a/doc/openvas-nasl.1
+++ b/doc/openvas-nasl.1
@@ -1,6 +1,6 @@
-.TH NASL 1 "October 2018" "Greenbone Vulnerability Management" "Nessus Attack Scripting Language"
+.TH NASL 1 "October 2018" "Greenbone Vulnerability Management" "NASL Attack Scripting Language"
 .SH NAME
-openvas-nasl \- Nessus Attack Scripting Language
+openvas-nasl \- NASL Attack Scripting Language
 .SH SYNOPSIS
 .B openvas-nasl
 .I <[-vh] [-T tracefile] [-s] [-t target] [-c config_file] [-d] [-sX] > files...
@@ -69,7 +69,7 @@ Set KB key to value. Can be used multiple times.
 .SH SEE ALSO
 .BR openvassd (8).
 .SH HISTORY
-NASL comes from a private project called 'pkt_forge', which was written in late 1998 by Renaud Deraison and which was an interactive shell to forge and send raw IP packets (this pre-dates Perl's Net::RawIP by a couple of weeks). It was then extended to do a wide range of network-related operations and integrated into Nessus as 'NASL'. 
+NASL comes from a private project called 'pkt_forge', which was written in late 1998 by Renaud Deraison and which was an interactive shell to forge and send raw IP packets (this pre-dates Perl's Net::RawIP by a couple of weeks). It was then extended to do a wide range of network-related operations and integrated into the scanner as 'NASL'. 
 
 The parser was completely hand-written and a pain to work with. In Mid-2002, Michel Arboi wrote a bison parser for NASL, and he and Renaud Deraison re-wrote NASL from scratch. Although the "new" NASL was nearly working as early as 
 August 2002, Michel's laziness made us wait for early 2003 to have it working completely.

--- a/nasl/capture_packet.c
+++ b/nasl/capture_packet.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/capture_packet.h
+++ b/nasl/capture_packet.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/exec.h
+++ b/nasl/exec.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language "lint"
+/* NASL Attack Scripting Language "lint"
  *
  * Copyright (C) 2004 Michel Arboi
  *

--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language Linter
+/* NASL Attack Scripting Language Linter
  *
  * Copyright (C) 2013 Greenbone Networks GmbH
  *

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2005 Tenable Network Security
  *

--- a/nasl/nasl.h
+++ b/nasl/nasl.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2005 Tenable Network Security
  *

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -788,7 +788,7 @@ mark_whois_plus2_server (struct script_infos *desc, int port, char *buffer, int 
  * (http://www.kernel.org/software/mon/)
  *
  * An unknown server is running on this port. If you know what it is, please
- * send this banner to the Nessus team: 00: 35 32 30 20 63 6f 6d 6d 61 6e 64
+ * send this banner to the development team: 00: 35 32 30 20 63 6f 6d 6d 61 6e 64
  * 20 63 6f 75 6c 520 command coul 10: 64 20 6e 6f 74 20 62 65 20 65 78 65 63
  * 75 74 65 d not be execute 20: 64 0a d.
  */

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_cmd_exec.h
+++ b/nasl/nasl_cmd_exec.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_crypto.h
+++ b/nasl/nasl_crypto.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_crypto2.h
+++ b/nasl/nasl_crypto2.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_debug.c
+++ b/nasl/nasl_debug.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_debug.h
+++ b/nasl/nasl_debug.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_func.c
+++ b/nasl/nasl_func.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_func.h
+++ b/nasl/nasl_func.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -3,7 +3,7 @@
 %lex-param {naslctxt * parm}
 %expect 1
 %{
-/* Nessus Attack Scripting Language version 2
+/* NASL Attack Scripting Language version 2
  *
  * Copyright (C) 2002 - 2004 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_host.h
+++ b/nasl/nasl_host.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_http.h
+++ b/nasl/nasl_http.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_init.h
+++ b/nasl/nasl_init.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_lex_ctxt.c
+++ b/nasl/nasl_lex_ctxt.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_lex_ctxt.h
+++ b/nasl/nasl_lex_ctxt.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_misc_funcs.h
+++ b/nasl/nasl_misc_funcs.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_packet_forgery.h
+++ b/nasl/nasl_packet_forgery.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_packet_forgery_v6.h
+++ b/nasl/nasl_packet_forgery_v6.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_raw.h
+++ b/nasl/nasl_raw.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_socket.h
+++ b/nasl/nasl_socket.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  * Copyright (C) 2009 Greenbone Networks GmbH

--- a/nasl/nasl_text_utils.h
+++ b/nasl/nasl_text_utils.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_tree.c
+++ b/nasl/nasl_tree.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_tree.h
+++ b/nasl/nasl_tree.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/nasl_var.c
+++ b/nasl/nasl_var.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/nasl_var.h
+++ b/nasl/nasl_var.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *

--- a/nasl/strutils.c
+++ b/nasl/strutils.c
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2004 Tenable Network Security
  *

--- a/nasl/strutils.h
+++ b/nasl/strutils.h
@@ -1,4 +1,4 @@
-/* Nessus Attack Scripting Language
+/* NASL Attack Scripting Language
  *
  * Copyright (C) 2002 - 2003 Michel Arboi and Renaud Deraison
  *


### PR DESCRIPTION
Renaming NASL=Nessus Attack Scripting Language to NASL=NASL Scripting
Language.

This is to not suggest that the NASL of OpenVAS could be compatible with
Nessus. Actually the two are incompatible since many years.