### PR TITLE
Add documentation coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Code Documentation Coverage](https://codecov.io/gh/greenbone/openvas-scanner/branch/master/graphs/badge.svg?flag=documentation)](https://codecov.io/gh/greenbone/openvas-scanner)`(Documentation Coverage)`
 [![CircleCI](https://circleci.com/gh/greenbone/openvas-scanner/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/openvas-scanner/tree/master)
 
 # openvas-scanner


### PR DESCRIPTION
This commit adds a badge for the documentation coverage as determined by
`coverxygen` and submitted to `codecov.io`, similar to the badge
displayed in the `README` of the `gvm-libs` module.