### PR TITLE
Cleanup default prefs values.

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -213,8 +213,7 @@ plug_add_host_fqdn (struct script_infos *args, const char *hostname,
   GSList *vhosts;
   char **excluded;
 
-  if ((prefs_get ("expand_vhosts") && !prefs_get_bool ("expand_vhosts"))
-      || !hostname || !source)
+  if (!prefs_get_bool ("expand_vhosts") || !hostname || !source)
     return -1;
 
   /* Check for duplicate vhost value. */

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -80,7 +80,6 @@ init (struct in6_addr *ip, GSList *vhosts, kb_t kb)
 {
   struct script_infos *infos = g_malloc0 (sizeof (struct script_infos));
 
-  prefs_set ("checks_read_timeout", "5");
   infos->standalone = 1;
   infos->key = kb;
   infos->ip = ip;
@@ -341,7 +340,7 @@ main (int argc, char **argv)
       kb_t kb;
       int rc, i = 0;
 
-      if (!prefs_get ("expand_vhosts") || prefs_get_bool ("expand_vhosts"))
+      if (prefs_get_bool ("expand_vhosts"))
         gvm_host_add_reverse_lookup (host);
       gvm_vhosts_exclude (host, prefs_get ("exclude_hosts"));
       gvm_host_get_addr6 (host, &ip6);

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -127,28 +127,18 @@ static openvassd_option openvassd_defaults[] = {
   {"be_nice", "no"},
   {"log_whole_attack", "no"},
   {"log_plugins_name_at_load", "no"},
-  {"cgi_path", "/cgi-bin:/scripts"},
   {"optimize_test", "yes"},
-  {"checks_read_timeout", "5"},
   {"network_scan", "no"},
   {"non_simult_ports", "139, 445, 3389, Services/irc"},
   {"plugins_timeout", G_STRINGIFY (NVT_TIMEOUT)},
   {"scanner_plugins_timeout", G_STRINGIFY (SCANNER_NVT_TIMEOUT)},
   {"safe_checks", "yes"},
   {"auto_enable_dependencies", "yes"},
-  {"nasl_no_signature_check", "yes"},
   {"drop_privileges", "no"},
-  {"unscanned_closed", "yes"},
-  {"unscanned_closed_udp", "yes"},
   // Empty options must be "\0", not NULL, to match the behavior of
   // prefs_init.
   {"report_host_details", "yes"},
-  {"test_empty_vhost", "no"},
   {"db_address", KB_PATH_DEFAULT},
-  {"timeout_retry", "3"},
-  {"open_sock_max_attempts", "5"},
-  {"time_between_request", "0"},
-  {"expand_vhosts", "yes"},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
These are now set in prefs_init() to be shared by both openvassd and
openvas-nasl.

Depends on https://github.com/greenbone/gvm-libs/pull/135