### PR TITLE
Fix various typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This is the Open Vulnerability Assessment System (OpenVAS) Scanner of the
 Greenbone Vulnerability Management (GVM) Solution. It is used for the Greenbone
 Security Manager appliances and is a full-featured scan engine that executes
-a continously updated and extended feed of Network Vulnerability Tests (NVTs).
+a continuously updated and extended feed of Network Vulnerability Tests (NVTs).
 
 For more information, please refer to the OpenVAS website available at
 http://www.openvas.org/.

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1642,8 +1642,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/Doxyfile_full.in
+++ b/doc/Doxyfile_full.in
@@ -1642,8 +1642,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/Doxyfile_xml.in
+++ b/doc/Doxyfile_xml.in
@@ -1642,8 +1642,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -7,7 +7,7 @@ openvassd \- The Scanner of the Greenbone Vulnerability Management
 
 .SH DESCRIPTION
 .B Greenbone Vulnerability Management (GVM)
-is a vulnerability auditing and mangement framework made up of several modules.
+is a vulnerability auditing and management framework made up of several modules.
 The OpenVAS Scanner,
 .BR openvassd
 is in charge of executing many security tests against many
@@ -95,7 +95,7 @@ Number of retries when a socket connection attempt timesout.
 When a port  is found as opened at the beginning of the scan, and for some reason the status changes to filtered/closed, it will not be possible to open a socket. This is the number of unsuccessful retries to open the socket before to set the port as closed. This avoids to launch plugins which need the opened port as a mandatory key, therefore it avoids an overlong scan duration. If the set value is 0 or a negative value, this option is disabled. It should be take in account that one unsuccessful attempt needs the number of retries set in "timeout_retry".
 
 .IP time_between_request
-Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in miliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
+Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in milliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
 
 .IP expand_vhosts
 Whether to expand the target host's list of vhosts with values gathered from sources such as reverse-lookup queries and VT checks for TLS/SSL certificates.

--- a/doc/redis_config_examples/redis_2_4.conf.in
+++ b/doc/redis_config_examples/redis_2_4.conf.in
@@ -1,6 +1,6 @@
 # Redis 2.4 configuration file example for OpenVAS
 
-# Note on units: when memory size is needed, it is possible to specifiy
+# Note on units: when memory size is needed, it is possible to specify
 # it in the usual form of 1k 5GB 4M and so forth:
 #
 # 1k => 1000 bytes
@@ -167,7 +167,7 @@ slave-serve-stale-data yes
 
 # Command renaming.
 #
-# It is possilbe to change the name of dangerous commands in a shared
+# It is possible to change the name of dangerous commands in a shared
 # environment. For instance the CONFIG command may be renamed into something
 # of hard to guess so that it will be still available for internal-use
 # tools but not available for general clients.
@@ -176,7 +176,7 @@ slave-serve-stale-data yes
 #
 # rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
 #
-# It is also possilbe to completely kill a command renaming it into
+# It is also possible to completely kill a command renaming it into
 # an empty string:
 #
 # rename-command CONFIG ""
@@ -328,7 +328,7 @@ no-appendfsync-on-rewrite no
 # is useful to avoid rewriting the AOF file even if the percentage increase
 # is reached but it is still pretty small.
 #
-# Specify a precentage of zero in order to disable the automatic AOF
+# Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
 auto-aof-rewrite-percentage 100
@@ -436,7 +436,7 @@ vm-max-threads 4
 ############################### ADVANCED CONFIG ###############################
 
 # Hashes are encoded in a special way (much more memory efficient) when they
-# have at max a given numer of elements, and the biggest element does not
+# have at max a given number of elements, and the biggest element does not
 # exceed a given threshold. You can configure this limits with the following
 # configuration directives.
 hash-max-zipmap-entries 512

--- a/doc/redis_config_examples/redis_2_6.conf.in
+++ b/doc/redis_config_examples/redis_2_6.conf.in
@@ -233,7 +233,7 @@ repl-disable-tcp-nodelay no
 #
 # A slave with a low priority number is considered better for promotion, so
 # for instance if there are three slaves with priority 10, 100, 25 Sentinel will
-# pick the one wtih priority 10, that is the lowest.
+# pick the one with priority 10, that is the lowest.
 #
 # However a special priority of 0 marks the slave as not able to perform the
 # role of master, so a slave with priority of 0 will never be selected by
@@ -535,7 +535,7 @@ activerehashing yes
 #
 # normal -> normal clients
 # slave  -> slave clients and MONITOR clients
-# pubsub -> clients subcribed to at least one pubsub channel or pattern
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
 #
 # The syntax of every client-output-buffer-limit directive is the following:
 #

--- a/doc/redis_config_examples/redis_2_8.conf.in
+++ b/doc/redis_config_examples/redis_2_8.conf.in
@@ -660,7 +660,7 @@ slowlog-max-len 128
 # By default latency monitoring is disabled since it is mostly not needed
 # if you don't have latency issues, and collecting data has a performance
 # impact, that while very small, can be measured under big load. Latency
-# monitoring can easily be enalbed at runtime using the command
+# monitoring can easily be enabled at runtime using the command
 # "CONFIG SET latency-monitor-threshold <milliseconds>" if needed.
 latency-monitor-threshold 0
 

--- a/doc/redis_config_examples/redis_4_0.conf.in
+++ b/doc/redis_config_examples/redis_4_0.conf.in
@@ -637,7 +637,7 @@ maxclients 10000
 #    it with the specified string.
 # 4) During replication, when a slave performs a full resynchronization with
 #    its master, the content of the whole database is removed in order to
-#    load the RDB file just transfered.
+#    load the RDB file just transferred.
 #
 # In all the above cases the default is to delete objects in a blocking way,
 # like if DEL was called. However you can configure each case specifically
@@ -1173,7 +1173,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 # client-query-buffer-limit 1gb
 
 # In the Redis protocol, bulk requests, that are, elements representing single
-# strings, are normally limited ot 512 mb. However you can change this limit
+# strings, are normally limited to 512 mb. However you can change this limit
 # here.
 #
 # proto-max-bulk-len 512mb

--- a/misc/ftp_funcs.c
+++ b/misc/ftp_funcs.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 
 /* this works for libc6 systems, unclear
- * wether it will not work on other systems */
+ * whether it will not work on other systems */
 #include <netinet/in.h>
 
 #include "network.h"

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -812,7 +812,7 @@ getipv6routes (struct myroute *myroutes, int *numroutes)
  *  destination should be routed through.
  *
  * It returns NULL if no appropriate
- *  interface is found, oterwise it returns the device name and fills in the
+ *  interface is found, otherwise it returns the device name and fills in the
  *   source parameter.   Some of the stuff is
  *  from Stevens' Unix Network Programming V2.  He had an easier suggestion
  *  for doing this (in the book), but it isn't portable :(
@@ -998,7 +998,7 @@ v6_routethrough (struct in6_addr *dest, struct in6_addr *source)
  *  destination should be routed through.
  *
  * It returns NULL if no appropriate
- *  interface is found, oterwise it returns the device name and fills in the
+ *  interface is found, otherwise it returns the device name and fills in the
  *   source parameter.   Some of the stuff is
  *  from Stevens' Unix Network Programming V2.  He had an easier suggestion
  *  for doing this (in the book), but it isn't portable :(

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -212,7 +212,7 @@ set_target_properties (openvas_nasl_shared PROPERTIES OUTPUT_NAME "openvas_nasl"
 set_target_properties (openvas_nasl_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 set_target_properties (openvas_nasl_shared PROPERTIES SOVERSION "${NASL_VERSION_MAJOR}")
 set_target_properties (openvas_nasl_shared PROPERTIES VERSION "${NASL_PACKAGE_VERSION}")
-# line bellow is needed so it also works with no-undefined which is e.g. used by Mandriva
+# line below is needed so it also works with no-undefined which is e.g. used by Mandriva
 target_link_libraries (openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS}
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m
                          ${LIBGVM_BASE_LDFLAGS}

--- a/nasl/iconv.c
+++ b/nasl/iconv.c
@@ -50,7 +50,7 @@ static struct charset_functions_ntlmssp *find_charset_functions_ntlmssp(const ch
 }
 
 /**
- * This is a simple portable iconv() implementaion.
+ * This is a simple portable iconv() implementation.
  *
  * It only knows about a very small number of character sets - just
  * enough that Samba works on systems that don't have iconv.

--- a/nasl/nasl_builtin_openvas_tcp_scanner.c
+++ b/nasl/nasl_builtin_openvas_tcp_scanner.c
@@ -132,7 +132,7 @@ my_socket_close(int s)
 static int std_port(int port)
 {
   (void) port;
-  return 0; /** @todo: We are not able anymore to judge wether a port is a standard
+  return 0; /** @todo: We are not able anymore to judge whether a port is a standard
              * port. Previously a port was believed to be a standard port
              * when it occurred in the currently configured list of ports.
              * This needs to be resolved.

--- a/nasl/nasl_builtin_synscan.c
+++ b/nasl/nasl_builtin_synscan.c
@@ -3,7 +3,7 @@
 * Description: Port scanner Synscan
 *
 * Authors:
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 *
 * Copyright:
 * Based on work Copyright (C) 1998 - 2006 Tenable Network Security, Inc.

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -21,7 +21,7 @@
  * This file contains all the cryptographic functions NASL has.
  */
 
-/* MODIFICATION: added definitions for implemention NTLMSSP features */
+/* MODIFICATION: added definitions for implementing NTLMSSP features */
 
 #include <gcrypt.h>
 #include <glib.h>

--- a/nasl/nasl_crypto.h
+++ b/nasl/nasl_crypto.h
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * MODIFICATION: added definitions for implemention NTLMSSP features
+ * MODIFICATION: added definitions for implementing NTLMSSP features
  */
 #ifndef NASL_CRYPTO_H
 #define NASL_CRYPTO_H

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -430,7 +430,7 @@ nasl_make_list (lex_ctxt * lexic)
  * This function takes any _even_ number of arguments and makes
  * an array from them. In each pair, the 1st argument is the index, the
  * 2nd the value.
- * Illegal types are droped with a warning
+ * Illegal types are dropped with a warning
  */
 
 tree_cell *

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -29,7 +29,7 @@
  *
  * @brief Implementation of an API for SSH functions.
  *
- * This file contains the implementaion of the Secure Shell related
+ * This file contains the implementation of the Secure Shell related
  * NASL builtin functions.  They are only available if build with
  * libssh support.
  */
@@ -215,7 +215,7 @@ extern int lowest_socket;
  * If the named argument "socket" is given, that socket will be used
  * instead of a creating a new TCP connection.  If socket is not given
  * or 0, the port is looked up in the preferences and the KB unless
- * overriden by the named parameter "port".
+ * overridden by the named parameter "port".
  *
  * On success an ssh session to the host has been established; the
  * caller may then run an authentication function.  If the connection
@@ -686,8 +686,8 @@ get_authmethods (int tbl_slot)
  * This is an optional function and usuallay not required.  However,
  * if you want to get the banner before starting the authentication,
  * you need to tell libssh the user because it is often not possible
- * to chnage the user after the first call to an authentication
- * methods - getting the banner usees an authntication function.
+ * to change the user after the first call to an authentication
+ * methods - getting the banner uses an authentication function.
  *
  * The named argument "login" is used for the login name; it defaults
  * the KB entry "Secret/SSH/login".  It should contain the user name

--- a/nasl/smb_crypt.c
+++ b/nasl/smb_crypt.c
@@ -453,7 +453,7 @@ bool E_deshash_ntlmssp (const char *passwd, uint8_t pass_len, uchar p16[16])
   memcpy (dospwd, dpass, pass_len);
   g_free (dpass);
 
-  /* Only the fisrt 14 chars are considered, password need not be null terminated. */
+  /* Only the first 14 chars are considered, password need not be null terminated. */
   E_P16((unsigned char *)dospwd, p16);
 
   if (strlen(dospwd) > 14) {

--- a/nasl/smb_interface_stub.c
+++ b/nasl/smb_interface_stub.c
@@ -26,7 +26,7 @@
 
 /**
  * @file smb_interface_stub.c
- * @brief Stub implementatin for SMB interface.
+ * @brief Stub implementation for SMB interface.
  *
  * This file contains an empty implementation that
  * fulfills the SMB interface specfified in \ref openvas_smb_interface.h
@@ -40,7 +40,7 @@
 /**
  * @brief Return version info for SMB implementation.
  *
- * @return NULL if this the impementation is a non-functional stub,
+ * @return NULL if this the implementation is a non-functional stub,
  *         else a arbitrary string that explains the version of the
  *         implementation.
  */

--- a/nasl/smb_signing.c
+++ b/nasl/smb_signing.c
@@ -47,7 +47,7 @@ void simple_packet_signature_ntlmssp(uint8_t *mac_key, const uchar *buf, uint32 
    	*/
 	MD5Init(&md5_ctx);
 
-	/* intialise with the key */
+	/* initialise with the key */
 	MD5Update(&md5_ctx, mac_key, 16);
 
 	/* copy in the first bit of the SMB header */

--- a/nasl/strutils.c
+++ b/nasl/strutils.c
@@ -24,7 +24,7 @@
  *       be moved (e.g. to misc).
  */
 
-/** @todo In parts replacable by g_pattern_match function (when not icase) */
+/** @todo In parts replaceable by g_pattern_match function (when not icase) */
 int
 str_match (const char *string, const char *pattern, int icase)
 {

--- a/nasl/wmi_interface_stub.c
+++ b/nasl/wmi_interface_stub.c
@@ -26,7 +26,7 @@
 
 /**
  * @file wmi_interface_stub.c
- * @brief Stub implementatin for a wmi interface.
+ * @brief Stub implementation for a wmi interface.
  *
  * This file contains an empty implementation that
  * fulfills the wmi interface specfified in \ref openvas_wmi_interface.h
@@ -40,7 +40,7 @@
 /**
  * @brief Return version info for WMI implementation.
  *
- * @return NULL if this the impementation is a non-functional stub,
+ * @return NULL if this the implementation is a non-functional stub,
  *         else a arbitrary string that explains the version of the
  *         implementation.
  */

--- a/src/attack.c
+++ b/src/attack.c
@@ -3,7 +3,7 @@
 * Description: Launches the plugins, and manages multithreading.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)
@@ -67,7 +67,7 @@
 #define MAX_FORK_RETRIES 10
 
 /**
- * It switchs progress bar styles.
+ * It switches progress bar styles.
  * If set to 1, time oriented style and it take into account only alive host.
  * If set to 0, it not reflect progress adequately in case of dead host,
  * which will take into account with 0% processed, producing jumps in the
@@ -842,7 +842,7 @@ iface_authorized (const char *iface)
   ifaces_list = prefs_get ("ifaces_allow");
   if (ifaces_list && !str_in_comma_list (iface, ifaces_list))
     return -1;
-  /* sys_* preferences are similar, but can't be overriden by the client. */
+  /* sys_* preferences are similar, but can't be overridden by the client. */
   ifaces_list = prefs_get ("sys_ifaces_deny");
   if (ifaces_list && str_in_comma_list (iface, ifaces_list))
     return -2;

--- a/src/attack.h
+++ b/src/attack.h
@@ -3,7 +3,7 @@
 * Description: attack.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/comm.c
+++ b/src/comm.c
@@ -3,7 +3,7 @@
   * Description: Communication manager; it manages the NTP Protocol version 1.0 and 1.1.
   *
   * Authors: 
-  * Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+  * Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
   * Tim Brown (Initial fork)
   * Laban Mwangi (Renaming work)
   * Tarik El-Yassem (Headers section)

--- a/src/comm.h
+++ b/src/comm.h
@@ -3,7 +3,7 @@
 * Description: comm.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -3,7 +3,7 @@
 * Description: Basically creates a new process for each tested host.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -3,7 +3,7 @@
 * Description: hosts.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -3,7 +3,7 @@
 * Description: Launches NASL plugins.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/ntp.c
+++ b/src/ntp.c
@@ -3,7 +3,7 @@
 * Description: OpenVAS Transfer Protocol handling.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/ntp.h
+++ b/src/ntp.h
@@ -3,7 +3,7 @@
 * Description: Header for ntp.c.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -3,7 +3,7 @@
 * Description: Runs the OpenVAS-scanner.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)
@@ -972,7 +972,7 @@ main (int argc, char *argv[])
     {"listen-mode", '\0', 0, G_OPTION_ARG_STRING, &listen_mode,
      "File mode of the unix socket", "<string>"},
     {"scan-start", '\0', 0, G_OPTION_ARG_STRING, &scan_id,
-     "ID for this scan taks", "<string>"},
+     "ID for this scan task", "<string>"},
     {NULL, 0, 0, 0, NULL, NULL, NULL}
   };
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -3,7 +3,7 @@
 * Description: Manages the launching of plugins within processes.
 *
 * Authors:
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -3,7 +3,7 @@
 * Description: pluginlaunch.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -3,7 +3,7 @@
 * Description: Loads plugins from disk into memory.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -3,7 +3,7 @@
 * Description: pluginload.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -3,7 +3,7 @@
 * Description: Tells openvassd which plugin should be executed next.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/pluginscheduler.h
+++ b/src/pluginscheduler.h
@@ -3,7 +3,7 @@
 * Description: header for pluginscheduler.c
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/plugs_req.c
+++ b/src/plugs_req.c
@@ -3,7 +3,7 @@
 * Description: Performs various checks for requirements set in a given plugin.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)
@@ -270,7 +270,7 @@ requirements_plugin (kb_t kb, nvti_t *nvti)
   const char *opti = prefs_get ("optimization_level");
 
   /*
-   * Check wether the good ports are open
+   * Check whether the good ports are open
    */
   error[sizeof (error) - 1] = '\0';
   tcp = nvti_required_ports (nvti);
@@ -293,7 +293,7 @@ requirements_plugin (kb_t kb, nvti_t *nvti)
     return NULL;
 
   /*
-   * Check wether a key we wanted is missing
+   * Check whether a key we wanted is missing
    */
   keys = nvti_required_keys (nvti);
   if (kb_missing_keyname_of_namelist (kb, keys, &errkey))
@@ -307,7 +307,7 @@ requirements_plugin (kb_t kb, nvti_t *nvti)
     return NULL;
 
   /*
-   * Check wether a key we do not want is present
+   * Check whether a key we do not want is present
    */
   keys = nvti_excluded_keys (nvti);
   if (kb_present_keyname_of_namelist (kb, keys, &errkey))

--- a/src/plugs_req.h
+++ b/src/plugs_req.h
@@ -3,7 +3,7 @@
 * Description: plugs_req.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/processes.c
+++ b/src/processes.c
@@ -3,7 +3,7 @@
 * Description: Creates new threads.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/processes.h
+++ b/src/processes.h
@@ -3,7 +3,7 @@
 * Description: processes.c header.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/sighand.c
+++ b/src/sighand.c
@@ -3,7 +3,7 @@
 * Description: Provides signal handling functions.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/sighand.h
+++ b/src/sighand.h
@@ -3,7 +3,7 @@
 * Description: headerfile for sighand.c.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,7 +3,7 @@
 * Description: A bunch of miscellaneous functions, mostly file conversions.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,7 +3,7 @@
 * Description: utils.c headerfile.
 *
 * Authors: 
-* Renaud Deraison <deraison@nessus.org> (Original pre-fork develoment)
+* Renaud Deraison <deraison@nessus.org> (Original pre-fork development)
 * Tim Brown (Initial fork)
 * Laban Mwangi (Renaming work)
 * Tarik El-Yassem (Headers section)


### PR DESCRIPTION
Fix various typos found by [codespell](https://github.com/codespell-project/codespell) 1.14

```
codespell . -S ".git,build" | egrep -v "(Tim|therefor|Sorce)"
```

(For some words the -S parameter doesn't work correctly)

There are still a few typos left (e.g. https://github.com/greenbone/openvas-scanner/blob/9d4479c34c3aacc2e53b40922d0aee470a658e1e/misc/plugutils.c#L532-L535) which i havn't touched yet.