### PR TITLE
Remove NASL get_ssl_compression().

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -882,41 +882,6 @@ socket_get_ssl_session_id (int fd, void **sid, size_t *ssize)
 }
 
 /*
- * @brief Get the compression method of an SSL/TLS connection.
- *
- * @param[in]   fd  Socket file descriptor.
- *
- * @return 0 if null compression, 1 if deflate, 2 if lzs, -1 if error.
- */
-int
-socket_get_ssl_compression (int fd)
-{
-  gnutls_session_t session;
-
-  if (!fd_is_stream (fd))
-    {
-      g_message ("Socket %d is not stream", fd);
-      return -1;
-    }
-  session = ovas_get_tlssession_from_connection (fd);
-  if (!session)
-    {
-      g_message ("Socket %d is not SSL/TLS encapsulated", fd);
-      return -1;
-    }
-
-  switch (gnutls_compression_get (session))
-    {
-      case GNUTLS_COMP_NULL:
-        return 0;
-      case GNUTLS_COMP_DEFLATE:
-        return 1;
-      default:
-        return -1;
-    }
-}
-
-/*
  * @brief Get the cipher suite used by a SSL/TLS connection.
  *
  * @param[in]   fd  Socket file descriptor.

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -114,7 +114,6 @@ static init_func libfuncs[] = {
   {"socket_get_ssl_version", nasl_socket_get_ssl_version},
   {"socket_get_ssl_ciphersuite", nasl_socket_get_ssl_ciphersuite},
   {"socket_get_ssl_session_id", nasl_socket_get_ssl_session_id},
-  {"socket_get_ssl_compression", nasl_socket_get_ssl_compression},
   {"socket_cert_verify", nasl_socket_cert_verify},
   {"close", nasl_close_socket},
   {"join_multicast_group", nasl_join_multicast_group},

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -694,25 +694,6 @@ nasl_socket_get_ssl_session_id (lex_ctxt * lexic)
 }
 
 tree_cell *
-nasl_socket_get_ssl_compression (lex_ctxt * lexic)
-{
-  int soc;
-  tree_cell *retc;
-
-  soc = get_int_var_by_name (lexic, "socket", -1);
-  if (soc < 0)
-    {
-      nasl_perror (lexic, "socket_get_cert: Erroneous socket value %d\n",
-                   soc);
-      return NULL;
-    }
-  retc = alloc_tree_cell ();
-  retc->type = CONST_INT;
-  retc->x.i_val = socket_get_ssl_compression (soc);
-  return retc;
-}
-
-tree_cell *
 nasl_socket_get_ssl_version (lex_ctxt * lexic)
 {
   int soc;
@@ -1231,9 +1212,6 @@ nasl_socket_get_error (lex_ctxt * lexic)
  * - @a tls-mac Return the message authentication algorithms used by
  *   the session.  Example output: "SHA1".
  *
- * - @a tls-comp Return the compression algorithms in use by the
- *   session.  Example output: "DEFLATE".
- *
  * - @a tls-auth Return the peer's authentication type.  Example
  *   output: "CERT".
  *
@@ -1352,15 +1330,6 @@ nasl_get_sock_info (lex_ctxt * lexic)
         s = "n/a";
       else
         s = gnutls_mac_get_name (gnutls_mac_get (tls_session));
-      strval = g_strdup (s?s:"");
-    }
-  else if (!strcmp (keyword, "tls-comp"))
-    {
-      if (!tls_session)
-        s = "n/a";
-      else
-        s = gnutls_compression_get_name
-          (gnutls_compression_get (tls_session));
       strval = g_strdup (s?s:"");
     }
   else if (!strcmp (keyword, "tls-auth"))

--- a/nasl/nasl_socket.h
+++ b/nasl/nasl_socket.h
@@ -45,7 +45,6 @@ tree_cell *nasl_recv_line (lex_ctxt *);
 tree_cell *nasl_socket_get_cert (lex_ctxt *);
 tree_cell *nasl_socket_get_ssl_session_id (lex_ctxt *);
 tree_cell *nasl_socket_get_ssl_version (lex_ctxt *);
-tree_cell *nasl_socket_get_ssl_compression (lex_ctxt *);
 tree_cell *nasl_socket_get_ssl_ciphersuite (lex_ctxt *);
 tree_cell *nasl_socket_cert_verify (lex_ctxt *);
 

--- a/nasl/tests/test_socket.nasl
+++ b/nasl/tests/test_socket.nasl
@@ -45,7 +45,6 @@ function test_open_sock_tcp_tlscustom()
                        transport:ENCAPS_TLScustom,
                        priority:strcat("NONE:+VERS-TLS1.0:",
                                        "+AES-256-CBC:+AES-128-CBC:",
-                                       "+COMP-DEFLATE:+COMP-NULL:",
                                        "+RSA:+DHE-RSA:+DHE-DSS:+SHA1"));
   if (sock > 0) {
       testcase_ok();


### PR DESCRIPTION
Support for compression was removed in TLS 1.3 and GnuTLS 3.6. The
related GnuTLS functions were deprecated. Also this NASL function was
never used.

Issue: https://github.com/greenbone/gvm-libs/issues/63