### PR TITLE
Enable compatibility mode in GnuTLS priority string

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -1041,7 +1041,7 @@ open_stream_connection (struct script_infos *args, unsigned int port,
                         int transport, int timeout)
 {
   return open_stream_connection_ext (args, port, transport, timeout,
-                                     "NORMAL:+ARCFOUR-128");
+                                     "NORMAL:+ARCFOUR-128:%COMPAT");
 }
 
 /* Same as open_stream_auto_encaps but allows to force auto detection


### PR DESCRIPTION
The scanner is currently failing to connect to mis-configured devices via a SSL/TLS connection:

https://censys.io/ipv4?q=%22Energy+management%22+and+cisco

```
openvas-nasl -X -B -d -t $ find_service.nasl --kb="Ports/tcp/443=1" --debug-tls=10

[30215] (1) Peer's certificate does not allow digital signatures. Key usage violation detected.
*snip*
lib  misc-Message: 07:56:16.516: set key Transports/TCP/443 -> 1
lib  misc-Message: 07:56:16.551: replace key FindService/tcp/443/get_http -> HTTP/1.1 400 Bad Request
```

Running gnutls-cli shows the same reason:

```
gnutls-cli -p 443 $IP --insecure

|<1>| Peer's certificate does not allow digital signatures. Key usage violation detected.
*** Fatal error: Key usage violation in certificate has been detected.
*** handshake has failed: Key usage violation in certificate has been detected.
```

Specifying the %COMPAT keyword described below makes this to work:

```
gnutls-cli -p 443 80.193.70.19 --insecure --priority "NORMAL:%COMPAT"

- Handshake was completed

- Simple Client Mode:
```


> will enable compatibility mode. It might mean that violations of the protocols are allowed as long as maximum compatibility with problematic clients and servers is achieved. More specifically this string will tolerate packets over the maximum allowed TLS record, and add a padding to TLS Client Hello packet to prevent it being in the 256-512 range which is known to be causing issues with a commonly used firewall (see the %DUMBFW option).
> https://gnutls.org/manual/html_node/Priority-Strings.html