### PR TITLE
Enable GnuTLS RC4 + COMPAT in set_gnutls_protocol().

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -450,19 +450,19 @@ set_gnutls_protocol (gnutls_session_t session, openvas_encaps_t encaps,
   switch (encaps)
     {
       case OPENVAS_ENCAPS_SSLv3:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-SSL3.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-SSL3.0:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv1:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv11:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.1";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.1:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_TLSv12:
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.2:+ARCFOUR-128:%COMPAT";
         break;
       case OPENVAS_ENCAPS_SSLv23:        /* Compatibility mode */
-        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0";
+        priorities = "NORMAL:-VERS-TLS-ALL:+VERS-TLS1.0:+VERS-SSL3.0:+ARCFOUR-128:%COMPAT";
         break;
       default:
 #if DEBUG_SSL > 0


### PR DESCRIPTION
Apply https://github.com/greenbone/openvas-scanner/pull/205 and https://github.com/greenbone/openvas-scanner/commit/74fbe045f1291e571772efd425505eab49dd4907#diff-64ce50726f78928d23e49278333dba9a to set_gnutls_protocol().

Closes #206

Backport to openvas-libraries-9.0 in https://github.com/greenbone/gvm-libs/pull/149