### PR TITLE
Rework readme

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 License information about openvas-scanner
 ------------------------------------------
 
-Th effective license of the modules as a whole
+The effective license of the modules as a whole
 is the GNU General Public License Version 2 (GNU GPL-2).
 
 Single files, however, are licensed either

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ INSTALLATION INSTRUCTIONS FOR OPENVAS-SCANNER
 =============================================
 
 Please note: The reference system used by most of the developers is Debian
-GNU/Linux 'Stretch' 9. The build might fail on any other system. Also it is
+GNU/Linux 'Stretch' 9. The build might fail on any other system. Also, it is
 necessary to install dependent development packages.
 
 Prerequisites for openvas-scanner
@@ -40,46 +40,47 @@ Recommended to have improved SNMP support:
 * netsnmp
 
 Install prerequisites on Debian GNU/Linux 'Stretch' 9:
-# apt-get install gcc pkg-config libssh-gcrypt-dev libgnutls28-dev libglib2.0-dev \
-  libpcap-dev libgpgme-dev bison libksba-dev libsnmp-dev libgcrypt20-dev
+
+    apt-get install gcc pkg-config libssh-gcrypt-dev libgnutls28-dev libglib2.0-dev \
+    libpcap-dev libgpgme-dev bison libksba-dev libsnmp-dev libgcrypt20-dev
 
 
 Compiling openvas-scanner
 -------------------------
 
 If you have installed required libraries to a non-standard location, remember to
-set the PKG_CONFIG_PATH environment variable to the location of you pkg-config
+set the `PKG_CONFIG_PATH` environment variable to the location of you pkg-config
 files before configuring:
 
-    $ export PKG_CONFIG_PATH=/your/location/lib/pkgconfig:$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH=/your/location/lib/pkgconfig:$PKG_CONFIG_PATH
 
-Create a build directory and change into it with
+Create a build directory and change into it with:
 
-    $ mkdir build
-    $ cd build
+    mkdir build
+    cd build
 
-Then configure the build with
+Then configure the build with:
 
-    $ cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
+    cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
 
-or (if you want to use the default installation path /usr/local)
+Or (if you want to use the default installation path /usr/local):
 
-    $ cmake ..
+    cmake ..
 
 This only needs to be done once.
 
-Thereafter, the following commands are useful.
+Thereafter, the following commands are useful:
 
-    $ make                # build the scanner
-    $ make doc            # build the documentation
-    $ make doc-full       # build more developer-oriented documentation
-    $ make install        # install the build
-    $ make rebuild_cache  # rebuild the cmake cache
+    make                # build the scanner
+    make doc            # build the documentation
+    make doc-full       # build more developer-oriented documentation
+    make install        # install the build
+    make rebuild_cache  # rebuild the cmake cache
 
-Please note that you may have to execute "make install" as root, especially if
+Please note that you may have to execute `make install` as root, especially if
 you have specified a prefix for which your user does not have full permissions.
 
-To clean up the build environment, simply remove the contents of the "build"
+To clean up the build environment, simply remove the contents of the `build`
 directory you created above.
 
 
@@ -91,14 +92,14 @@ enable very strict error checking and asks the compiler to abort should it detec
 any errors in the code. This is to ensure a maximum of code quality and
 security.
 
-Some (especially newer) compilers can be more strict than others when it comes
+Some (especially newer) compilers can be stricter than others when it comes
 to error checking. While this is a good thing and the developers aim to address
 all compiler warnings, it may lead the build process to abort on your system.
 
-Should you notice error messages causing your build process to abort,
-do not hesitate to contact the developers using the mailing lists or IRC
-chat. Don't forget to include the name and version of your compiler and
-distribution in your message.
+Should you notice error messages causing your build process to abort, do not
+hesitate to contact the developers using the [Greenbone Community
+Portal](https://community.greenbone.net/c/gse). Don't forget to include the
+name and version of your compiler and distribution in your message.
 
 
 Setting up openvas-scanner
@@ -106,22 +107,22 @@ Setting up openvas-scanner
 
 Setting up an openvas-scanner requires the following steps:
 
-1) (optional) You may decide to change the default scanner preferences
-   by setting them in the file $prefix/etc/openvassd.conf. If that file does
+1. (optional) You may decide to change the default scanner preferences
+   by setting them in the file `$prefix/etc/openvassd.conf`. If that file does
    not exist (default), then the default settings are used. You can view
-   them with "openvassd -s". The output of that command is a valid configuration
-   file. The man page ("man openvassd") provides details about the available
+   them with `openvassd -s`. The output of that command is a valid configuration
+   file. The man page (`man openvassd`) provides details about the available
    settings, among these opportunities to restrict access of scanner regarding
    scan targets and interfaces.
 
-2) In order to run vulnerability scans, you will need a collection of Network
+2. In order to run vulnerability scans, you will need a collection of Network
    Vulnerability Tests (NVTs) that can be run by openvas-scanner. Initially,
    your NVT collection will be empty. It is recommended that you synchronize
    with an NVT feed service before starting openvas-scanner for the first time.
 
-   Simply execute the following command. It will retrieve over 50,000 NVTs.
+   Simply execute the following command to retrieve the initial NVT collection:
 
-   $ greenbone-nvt-sync
+       greenbone-nvt-sync
 
    This tool will use the Greenbone Security Feed in case a Greenbone
    subscription key is present. Else, the Community Feed will be used.
@@ -129,47 +130,47 @@ Setting up an openvas-scanner requires the following steps:
    Please note that you will need at least one of the following tools for a
    successful synchronization:
 
-   * rsync
-   * wget
-   * curl
+   * `rsync`
+   * `wget`
+   * `curl`
 
    NVT feeds are updated on a regular basis. Be sure to update your NVT collection
    regularly to detect the latest threats.
 
-3) The scanner needs a running redis server to temporarily store information
+3. The scanner needs a running Redis server to temporarily store information
    gathered on the scanned hosts. Redis 2.4 and newer is supported but 2.6
-   is recommended. See doc/redis_config.txt to see how to setup and run a redis
-   server.
+   is recommended. See `doc/redis_config.txt` to see how to set up and run a
+   Redis server.
 
    Multiple examples for various Redis versions are installed which you may use
    directly for a quick start:
 
-   $ redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_2_4.conf
+       redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_2_4.conf
 
    or
 
-   $ redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_2_6.conf
+       redis-server <install-prefix>/share/doc/openvas-scanner/redis_config_examples/redis_2_6.conf
 
    or copy the example to another location, edit and use the copy instead.
 
-4) You can launch openvas-scanner using the following command:
+4. You can launch openvas-scanner using the following command:
 
-   $ openvassd
+       openvassd
 
-   Sending SIGHUP to the scanner main process will initiate a reload of the
+   Sending `SIGHUP` to the scanner main process will initiate a reload of the
    feed content and of the scanner preferences. This will not affect running
    scans.
 
-   Please note that although you can start openvassd as a user without elevated
-   privileges, it is recommended that you start openvassd as root since a number
+   Please note that although you can start `openvassd` as a user without elevated
+   privileges, it is recommended that you start `openvassd` as `root` since a number
    of Network Vulnerability Tests (NVTs) require root privileges to perform
-   certain operations like packet forgery. If you run openvassd as a user
+   certain operations like packet forgery. If you run `openvassd` as a user
    without permission to perform these operations, your scan results are likely
    to be incomplete.
 
-5) Once the scanner has started, gvmd can act as a client and control
+5. Once the scanner has started, `gvmd` can act as a client and control
    the scanner. The actual user interfaces (for example GSA or GVM-Tools)
-   will only interact with gvmd, not the scanner.
+   will only interact with `gvmd`, not the scanner.
 
 Logging Configuration
 ---------------------
@@ -182,8 +183,8 @@ It may contain useful information.The exact location of this file may differ
 depending on your distribution and installation method. Please have this file
 ready when contacting the GVM developers through the OpenVAS mailing list
 or the online chat or submitting bug reports at
-  https://github.com/greenbone/openvas-scanner/issues
-as they may help to pinpoint the source of your issue.
+<https://github.com/greenbone/openvas-scanner/issues> as they may help to
+pinpoint the source of your issue.
 
 Logging is configured entirely by the file
 
@@ -197,8 +198,8 @@ The configuration is divided into domains like this one
     file=/var/log/gvm/openvassd.log
     level=128
 
-The "level" field controls the amount of logging that is written.
-The value of "level" can be
+The `level` field controls the amount of logging that is written.
+The value of `level` can be
 
       4  Errors.
       8  Critical situation.
@@ -213,7 +214,7 @@ will include Warnings, Critical situations and Errors.
 To get absolutely all logging, set the level to 128 for all domains in the
 configuration file.
 
-Logging to "syslog" can be enabled in each domain like:
+Logging to `syslog` can be enabled in each domain like:
 
     [sd   main]
     prepend=%t %p
@@ -225,21 +226,14 @@ Logging to "syslog" can be enabled in each domain like:
 Static code analysis with the Clang Static Analyzer
 ---------------------------------------------------
 
-If you want to use the Clang Static Analyzer (http://clang-analyzer.llvm.org/)
-to do a static code analysis, you can do so by adding the following parameter
-when configuring the build:
+If you want to use the Clang Static Analyzer (https://clang-analyzer.llvm.org/)
+to do a static code analysis, you can do so by prefixing the configuration and
+build commands with `scan-build`:
 
-  -DCMAKE_C_COMPILER=/usr/share/clang/scan-build/ccc-analyzer
-
-Note that the example above uses the default location of ccc-analyzer in Debian
-GNU/Linux and may be different in other environments.
-
-To have the analysis results aggregated into a set of HTML files, use the
-following command:
-
-    $ scan-build make
+    scan-build cmake ..
+    scan-build make
 
 The tool will provide a hint on how to launch a web browser with the results.
 
 It is recommended to do this analysis in a separate, empty build directory and
-to empty the build directory before "scan-build" call.
+to empty the build directory before `scan-build` call.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This module can be configured, built and installed with following commands:
     make install
 
 For detailed installation requirements and instructions, please see the file
-[INSTALL](INSTALL). The file also contains instructions for setting up
+[INSTALL.md](INSTALL.md). The file also contains instructions for setting up
 `openvas-scanner` and for making the scanner available to other GVM modules.
 
 If you are not familiar or comfortable building from source code, we recommend

--- a/README.md
+++ b/README.md
@@ -1,28 +1,57 @@
+![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_logo_resilience_horizontal.png)
+
+# OpenVAS Scanner
+
+[![GitHub releases](https://img.shields.io/github/release/greenbone/openvas-scanner.svg)](https://github.com/greenbone/openvas-scanner/releases)
 [![Code Documentation Coverage](https://codecov.io/gh/greenbone/openvas-scanner/branch/master/graphs/badge.svg?flag=documentation)](https://codecov.io/gh/greenbone/openvas-scanner)`(Documentation Coverage)`
 [![CircleCI](https://circleci.com/gh/greenbone/openvas-scanner/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/openvas-scanner/tree/master)
 
-# openvas-scanner
-
 This is the Open Vulnerability Assessment System (OpenVAS) Scanner of the
-Greenbone Vulnerability Management (GVM) Solution. It is used for the Greenbone
-Security Manager appliances and is a full-featured scan engine that executes
-a continuously updated and extended feed of Network Vulnerability Tests (NVTs).
+Greenbone Vulnerability Management (GVM) Solution.
 
-For more information, please refer to the OpenVAS website available at
-http://www.openvas.org/.
+It is used for the Greenbone Security Manager appliances and is a full-featured
+scan engine that executes a continuously updated and extended feed of Network
+Vulnerability Tests (NVTs).
 
-Please see the file [COPYING](COPYING) for the license information.
+## Installation
 
-Please refer to the instructions provided in the file [INSTALL](INSTALL) if you
-want to install and configure openvas-scanner. If you are not familiar or
-comfortable with building from source code, you may alternatively install the
-virtual machine image [Greenbone Community Edition](https://www.greenbone.net/en/install_use_gce/).
+This module can be configured, built and installed with following commands:
 
-Note that you will need the [gvm-libs](https://github.com/greenbone/gvm-libs)
-modules to compile openvas-scanner.
+    cmake .
+    make install
 
-If you have any question or suggestions, please feel free to join the 
-[community portal](https://community.greenbone.net).
+For detailed installation requirements and instructions, please see the file
+[INSTALL](INSTALL). The file also contains instructions for setting up
+`openvas-scanner` and for making the scanner available to other GVM modules.
 
-Please use the bug tracker located at
-https://github.com/greenbone/openvas-scanner/issues to report bugs.
+If you are not familiar or comfortable building from source code, we recommend
+that you use the Greenbone Community Edition, a prepared virtual machine with a
+readily available setup. Information regarding the virtual machine is available
+at <https://www.greenbone.net/en/community-edition/>.
+
+## Support
+
+For any question on the usage of `openvas-scanner` please use the [Greenbone
+Community Portal](https://community.greenbone.net/c/gse). If you found a problem
+with the software, please [create an
+issue](https://github.com/greenbone/openvas-scanner/issues) on GitHub. If you
+are a Greenbone customer you may alternatively or additionally forward your
+issue to the Greenbone Support Portal.
+
+## Maintainer
+
+This project is maintained by [Greenbone Networks GmbH](https://www.greenbone.net/).
+
+## Contributing
+
+Your contributions are highly appreciated. Please [create a pull
+request](https://github.com/greenbone/openvas-scanner/pulls) on GitHub. Bigger
+changes need to be discussed with the development team via the [issues section
+at GitHub](https://github.com/greenbone/openvas-scanner/issues) first.
+
+## License
+
+This module is licensed under the [GNU General Public License v2.0
+only](COPYING.GPLv2). Single files, however, are licensed either the GNU General
+Public License v2.0 only or under GNU General Public License v2.0 or later,
+please see the [COPYING](COPYING) file for details.


### PR DESCRIPTION
The commits adjust layout and content of the `README` file to match the template provided by the `greenbone/templates` repository. Also, the `INSTALL` file format is switched to Markdown, with an update of relevant sections.

This makes `openvas-scanner` consistent with the changes from greenbone/gvm-libs#147.