### PR TITLE
Use SSL/TLS instead of TLS/SSL.

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -98,7 +98,7 @@ When a port  is found as opened at the beginning of the scan, and for some reaso
 Some devices do not appreciate quick connection establishment and termination neither quick request. This option allows you to set a wait time between two actions like to open a tcp socket, to send a request trought the open tcp socket, and to close the tcp socket. This value should be given in milliseconds. If the set value is 0 (default value), this option is disabled and there is no wait time between requests.
 
 .IP expand_vhosts
-Whether to expand the target host's list of vhosts with values gathered from sources such as reverse-lookup queries and VT checks for TLS/SSL certificates.
+Whether to expand the target host's list of vhosts with values gathered from sources such as reverse-lookup queries and VT checks for SSL/TLS certificates.
 
 .IP non_simult_ports
 Some services (in particular SMB) do not appreciate multiple connections at the same time coming from the same host. This option allows you to prevent openvassd to make two connections on the same given ports at the same time. The syntax of this option is "port1[, port2....]". Note that you can use the KB notation of openvassd to designate a service formally. Ex: "139, Services/www", will prevent openvassd from making two connections at the same time on port 139 and on every port which hosts a web server.


### PR DESCRIPTION
Other code-parts are also using SSL/TLS so changing this to use the same for consistency.

https://github.com/greenbone/openvas-scanner/search?q=%22SSL%2FTLS%22&unscoped_q=%22SSL%2FTLS%22

Settings was initially introduced in https://github.com/greenbone/openvas-scanner/pull/184