### PR TITLE
Handle case in which there is no nvt category set for an NVT.

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -996,6 +996,14 @@ attack_network (struct arglist *globals, kb_t *network_kb)
   sched = plugins_scheduler_init
            (prefs_get ("plugin_set"), prefs_get_bool ("auto_enable_dependencies"),
             network_phase);
+  if (sched == NULL)
+    {
+      error_message_to_client (global_socket,
+                               "Failed to initialize the plugins scheduler.",
+                               NULL, NULL);
+      return;
+    }
+
 
   max_hosts = get_max_hosts_number ();
   max_checks = get_max_checks_number ();


### PR DESCRIPTION
This can happen only with corrupted nvti cache. Therefore this error
is considered fatal and stop the running scan. Also, send an error message
to the manager.

Depends on greenbone/gvm-libs#151