### PR TITLE
Advanced log

### DIFF
--- a/nasl/nasl_func.c
+++ b/nasl/nasl_func.c
@@ -17,7 +17,6 @@
  *
  */
 
-#include <search.h>             /* for qsort, lfind */
 #include <stdlib.h>             /* for free */
 #include <string.h>             /* for strcmp */
 
@@ -51,8 +50,6 @@ get_func (lex_ctxt * ctxt, const char *name)
 
   return func_is_internal (name);
 }
-
-typedef int(*qsortcmp)(const void *, const void *);
 
 nasl_func *
 insert_nasl_func (lex_ctxt * lexic, const char *fname, tree_cell * decl_node, int lint_mode)

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -145,6 +145,8 @@ _http_req (lex_ctxt * lexic, char *keyword)
         hostheader = g_strdup_printf ("%s:%d", hostname, port);
 
       url = build_encode_URL (keyword, NULL, item, "HTTP/1.1");
+      if (prefs_get_bool ("advanced_log"))
+        kb_item_add_str (kb, "log/http/short", url, 0);
       request = g_strdup_printf ("%s\r\n\
 Connection: Close\r\n\
 Host: %s\r\n\
@@ -160,7 +162,11 @@ Accept-Charset: iso-8859-1,*,utf-8\r\n", url, hostheader, ua);
       g_free (url);
     }
   else
-    request = build_encode_URL (keyword, NULL, item, "HTTP/1.0\r\n");
+    {
+      request = build_encode_URL (keyword, NULL, item, "HTTP/1.0\r\n");
+      if (prefs_get_bool ("advanced_log"))
+        kb_item_add_str (kb, "log/http/short", request, 0);
+    }
 
   if (auth)
     {
@@ -185,6 +191,8 @@ Accept-Charset: iso-8859-1,*,utf-8\r\n", url, hostheader, ua);
       request = tmp;
     }
 
+  if (prefs_get_bool ("advanced_log"))
+    kb_item_add_str (kb, "log/http/full", request, 0);
   retc = alloc_tree_cell ();
   retc->type = CONST_DATA;
   retc->size = strlen (request);

--- a/src/attack.c
+++ b/src/attack.c
@@ -330,6 +330,8 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
                     name, oid, ip_str, error);
           g_free (name);
         }
+      if (prefs_get_bool ("advanced_log"))
+        kb_item_add_str (kb, "log/notlaunched", oid, 0);
       return 0;
     }
 
@@ -349,6 +351,15 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
     {
       plugin->running_state = PLUGIN_STATUS_UNRUN;
       return ERR_CANT_FORK;
+    }
+  if (prefs_get_bool ("advanced_log"))
+    {
+      char buf[2048], buf2[2048];
+
+      kb_item_add_str (kb, "log/launched", oid, 0);
+      snprintf (buf, sizeof (buf), "log/launched/%s/start", oid);
+      snprintf (buf2, sizeof (buf2), "%lu", time (NULL));
+      kb_item_add_str (kb, buf, buf2, 0);
     }
 
   if (prefs_get_bool ("log_whole_attack"))

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -125,6 +125,13 @@ update_running_processes (kb_t kb)
             {
               char *oid = processes[i].plugin->oid;
 
+              if (prefs_get_bool ("advanced_log"))
+                {
+                  char buf[2048], buf2[2048];
+                  snprintf (buf, sizeof (buf), "log/launched/%s/end", oid);
+                  snprintf (buf2, sizeof (buf2), "%lu", time (NULL));
+                  kb_item_add_str (kb, buf, buf2, 0);
+                }
               if (processes[i].alive)
                 {
                   char msg[2048];
@@ -132,6 +139,8 @@ update_running_processes (kb_t kb)
                   if (log_whole)
                     g_message ("%s (pid %d) is slow to finish - killing it",
                                oid, processes[i].pid);
+                  if (prefs_get_bool ("advanced_log"))
+                    kb_item_add_str (kb, "log/timedout", oid, 0);
 
                   sprintf (msg,
                            "ERRMSG||| |||general/tcp|||%s|||"

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -183,10 +183,14 @@ plugin_add (plugins_scheduler_t sched, GHashTable *oids_table,
                            dep_name, dep_oid, oid);
             }
           else
-            g_warning ("There was a problem trying to load %s, a dependency "
-                       "of  %s. This may be due to a parse error, or it failed "
-                       "to find the dependency. Please check the path to the "
-                       "file.", dep_name, oid);
+            {
+              char *name = nvticache_get_name (oid);
+              g_warning ("There was a problem trying to load %s, a dependency "
+                         "of %s. This may be due to a parse error, or it failed "
+                         "to find the dependency. Please check the path to the "
+                         "file.", dep_name, name);
+              g_free (name);
+            }
           dep_name = strtok_r (NULL, ", ", &saveptr);
         }
     }


### PR DESCRIPTION
The scanner stores information about VTs (launched, not launched, timed-out, start time, end time...) in the KB.

Below, the example of a VT that reports such info:
------------------------------------
```
if(description)
{
  script_oid("1.3.6.1.4.1.25623.1.0.444444");
  script_version("$Revision: 11890 $");
  script_tag(name:"last_modification", value:"$Date: 2018-10-12 18:13:30 +0200 (Fri, 12 Oct 2018) $");
  script_tag(name:"creation_date", value:"2013-06-17 10:52:11 +0100 (Mon, 17 Jun 2013)");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"cvss_base", value:"0.0");
  script_name("Advanced Log");

  script_category(ACT_END);
  script_tag(name:"qod_type", value:"remote_banner");
  script_copyright("");
  script_family("General");
  script_tag(name:"summary", value:"Advanced Logging script");
  exit(0);
}

# log/launched: List of launched plugins
# log/launched/$OID/start: Start time
# log/launched/$OID/end: End time
# log/timedout: List of launched plugins that timedout.
# log/notlaunched: List of not launched plugins.
# log/http/full: List of HTTP requests.
# log/http/short: List of HTTP requests (Method, URL and Version.)

launched_list = get_kb_list("log/launched");
if (launched_list) {
  str = '\nLaunched:';
  foreach launched (launched_list) {
    start_time = get_kb_item("log/launched/" + launched + '/start');
    end_time = get_kb_item("log/launched/" + launched + '/end');
    str += '\n  ' + launched + ' ' + start_time + ' -> ' + end_time;
  }
  security_message(0, data:str);
}

timeout_list = get_kb_list("log/timedout");
if (timeout_list) {
  str = '\nTimed-out:';
  foreach timeout (timeout_list) {
    str += '\n  ' + timeout;
  }
  security_message(0, data:str);
}

nlaunched_list = get_kb_list("log/notlaunched");
if (nlaunched_list) {
  str = '\nNot launched:';
  foreach nlaunched (nlaunched_list) {
    str += '\n  ' + nlaunched;
  }
  security_message(0, data:str);
}

http_short_list = get_kb_list("log/http/short");
if (http_short_list) {
  str = '\nHTTP (short):';
  foreach http_short (http_short_list) {
    str += '\n  ' + http_short;
  }
  security_message(0, data:str);
}

http_full_list = get_kb_list("log/http/full");
if (http_full_list) {
  str = '\nHTTP (full):';
  foreach http_full (http_full_list) {
    str += '\n  ' + http_full;
  }
  security_message(0, data:str);
}

```
