### PR TITLE
Use a stored user agent instead of getting it from redis.

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -89,7 +89,7 @@ include_directories (${GLIB_INCLUDE_DIRS}
 
 # Library
 
-set (FILES bpf_share.c ftp_funcs.c vendorversion.c network.c plugutils.c pcap.c)
+set (FILES bpf_share.c ftp_funcs.c vendorversion.c network.c plugutils.c pcap.c useragent.c)
 
 
 # On windows we are always PIC and stack-protector is replaces by DEP

--- a/misc/useragent.c
+++ b/misc/useragent.c
@@ -1,0 +1,55 @@
+/* openvas-scanner/misc
+ * $Id$
+ * Description: Functions to set and get the vendor version.
+ *
+ * Authors:
+ * Juan Jose Nicola <juan.nicola@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2017 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <glib.h>
+#include "useragent.h"
+
+/**
+ * @brief User Agent, or NULL.
+ */
+gchar *user_agent = NULL;
+
+/**
+ * @brief Set user agent
+ *
+ * @param[in]  ua user agent.
+ */
+void
+user_agent_set (const gchar *ua)
+{
+  g_free (user_agent);
+  user_agent = g_strdup (ua);
+}
+
+/**
+ * @brief Get user agent.
+ *
+ * @return Set user agent or NULL.
+ */
+const gchar *
+user_agent_get ()
+{
+  return user_agent ? user_agent : NULL;
+}

--- a/misc/useragent.h
+++ b/misc/useragent.h
@@ -1,0 +1,37 @@
+/* openvas-scanner/misc
+ * $Id$
+ * Description: Header file: user agent functions prototypes.
+ *
+ * Authors:
+ * Juan Jose Nicola <juan.nicola@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2017 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _OPENVAS_USERAGENT_H
+#define _OPENVAS_USERAGENT_H
+
+#include <glib.h>
+
+const gchar *
+user_agent_get (void);
+
+void
+user_agent_set (const gchar*);
+
+#endif /* not _OPENVAS_USERAGENT_H */

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -197,6 +197,7 @@ set_source_files_properties (nasl_grammar.tab.c GENERATED)
 add_definitions (-DOPENVAS_STATE_DIR="${OPENVAS_STATE_DIR}")
 add_definitions (-DOPENVASLIB_VERSION="${OPENVASLIB_VERSION}")
 add_definitions (-DOPENVAS_SYSCONF_DIR="${OPENVAS_SYSCONF_DIR}")
+add_definitions (-DOPENVAS_NASL_VERSION="${NASL_VERSION}")
 
 include_directories (${GLIB_INCLUDE_DIRS}
                      ${GPGME_INCLUDE_DIRS}

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -26,6 +26,7 @@
 
 #include "../misc/plugutils.h"  /* plug_get_host_fqdn */
 #include "../misc/vendorversion.h" /* for vendor_version_get */
+#include "../misc/useragent.h" /* for user_agent_get */
 
 #include "nasl_tree.h"
 #include "nasl_global_ctxt.h"
@@ -142,7 +143,7 @@ _http_req (lex_ctxt * lexic, char *keyword)
       hostname = plug_get_host_fqdn (script_infos);
       if (hostname == NULL)
         return NULL;
-      ua = kb_item_get_str (kb, "http/user-agent");
+
       vendor = g_strdup (vendor_version_get ());
       if (!vendor || *vendor == '\0')
         ua_vendor = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; OpenVAS-VT %s)",
@@ -151,13 +152,14 @@ _http_req (lex_ctxt * lexic, char *keyword)
         ua_vendor = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; %s)", vendor);
       g_free (vendor);
 
-      if (ua == NULL)
+      if (user_agent_get () == NULL)
         {
           ua = g_strdup (ua_vendor);
           g_free (ua_vendor);
         }
       else
         {
+          ua = g_strdup (user_agent_get ());
           while (isspace (*ua))
             ua++;
           if (*ua == '\0')


### PR DESCRIPTION
The user agent does not change during a scan. It stores a global user agent (if there is one already set in redis kb). This is done just once after the ACT_SETTING VTs, location of the global_settings.nasl. 
If no user agent is set in the redis kb, it uses an user agent depending on
the vendor, or if there is no vendor set a default OpenVAS with the current
nasl lib version.