### PR TITLE
Fix build with gcc8

### DIFF
--- a/src/ntp.c
+++ b/src/ntp.c
@@ -391,7 +391,7 @@ __ntp_timestamp_scan (int soc, char *msg)
 static int
 __ntp_timestamp_scan_host (int soc, char *msg, char *host)
 {
-  char timestr[1024];
+  char timestr[64];
   char *tmp;
   time_t t;
   int len;

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -250,7 +250,7 @@ cleanup_leftovers (int num_files)
   g_slist_free_full (oids, g_free);
 }
 
-static int
+static void
 plugins_reload_from_dir (void *folder)
 {
   GSList *files = NULL, *f;

--- a/src/processes.h
+++ b/src/processes.h
@@ -28,7 +28,7 @@
 #ifndef _OPENVAS_THREADS_H
 #define _OPENVAS_THREADS_H
 
-typedef int (*process_func_t) (void *);
+typedef void (*process_func_t) (void *);
 pid_t create_process (process_func_t, void *);
 int terminate_process (pid_t);
 


### PR DESCRIPTION
Resolve #233 and other build problem.

Backport PR #183: Compile warning generated by -Werror=cast-function-type.
Also, fix build with GCC 8: Compile warning generated by -Werror=format-truncation=