### PR TITLE
Update greenbone-nvt-sync.in

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -500,6 +500,9 @@ sync_nvts(){
     return
   fi
 
+  # Sleep for ten seconds to prevent IP blocking.
+  sleep 10
+  
   if [ -e $ACCESS_KEY ]
   then
     if [ -n "$FIXED_METHOD" ] && [ "rsync" != "$FIXED_METHOD" ]


### PR DESCRIPTION
The synchronization scripts do two rsyncs in quick succession, this leads to frequent IP blocking by the rsync server.

Fixed by adding a short sleep before the second (synchronization) rsync.
