### PR TITLE
Cleanup

### DIFF
--- a/doc/openvassd.8.in
+++ b/doc/openvassd.8.in
@@ -62,10 +62,6 @@ x
 .I max_hosts
 so you need to find a balance between these two options. Note that launching too many plugins at the same time may disable the remote host, either temporarily (ie: inetd closes its ports) or definitely (the remote host crash because it is asked to do too many things at the same time), so be careful.
 
-.IP be_nice
-If this option is set to 'yes', then each child forked by openvassd will
-nice(2) itself to a very low priority. This may speed up your scan as the main openvassd process will be able to continue to spew processes, and this guarantees that openvassd does not deprives other important processes from their resources.
-
 .IP log_whole_attack
 If this option is set to 'yes', openvassd will store the name, pid, date and target of each plugin launched. This is helpful for monitoring and debugging purpose, however this option might make openvassd fill your disk rather quickly. 
 

--- a/misc/network.c
+++ b/misc/network.c
@@ -138,27 +138,6 @@ static struct csc_hook_s *csc_hooks;
  */
 #define OVAS_CONNECTION_FROM_FD(fd) (connections + ((fd) - OPENVAS_FD_OFF))
 
-static void
-renice_myself (void)
-{
-  static pid_t pid = 0;
-  pid_t cpid = getpid ();
-
-  if (pid != cpid)
-    {
-      int renice_result;
-      if (nice (0) >= 10)
-        return;
-      pid = cpid;
-      errno = 0;
-      renice_result = nice (1);
-      if (renice_result == -1 && errno != 0)
-        {
-          g_message ("Unable to renice process: %d", errno);
-        }
-    }
-}
-
 /**
  * Same as perror(), but prefixes the data by our pid.
  */
@@ -1003,7 +982,6 @@ open_stream_connection_ext (struct script_infos *args, unsigned int port,
     case OPENVAS_ENCAPS_TLSv11:
     case OPENVAS_ENCAPS_TLSv12:
     case OPENVAS_ENCAPS_TLScustom:
-      renice_myself ();
       cert = kb_item_get_str (kb, "SSL/cert");
       key = kb_item_get_str (kb, "SSL/key");
       passwd = kb_item_get_str (kb, "SSL/password");

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -188,17 +188,6 @@ nasl_thread (struct script_infos *args)
   GError *error = NULL;
 
   nvticache_reset ();
-  if (prefs_get_bool ("be_nice"))
-    {
-      int nice_retval;
-      errno = 0;
-      nice_retval = nice (-5);
-      if (nice_retval == -1 && errno != 0)
-        {
-          g_debug ("Unable to renice process: %d", errno);
-        }
-    }
-
   kb = args->key;
   kb_lnk_reset (kb);
   addr6_to_str (args->ip, ip_str);

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -139,7 +139,6 @@ static openvassd_option openvassd_defaults[] = {
   {"drop_privileges", "no"},
   // Empty options must be "\0", not NULL, to match the behavior of
   // prefs_init.
-  {"report_host_details", "yes"},
   {"db_address", KB_PATH_DEFAULT},
   {NULL, NULL}
 };

--- a/src/openvassd.c
+++ b/src/openvassd.c
@@ -127,7 +127,6 @@ static openvassd_option openvassd_defaults[] = {
   {"include_folders", OPENVAS_NVT_DIR},
   {"max_hosts", "30"},
   {"max_checks", "10"},
-  {"be_nice", "no"},
   {"log_whole_attack", "no"},
   {"log_plugins_name_at_load", "no"},
   {"optimize_test", "yes"},
@@ -488,16 +487,6 @@ scanner_thread (struct scan_globals *globals)
     }
   else
     globals->scan_id = g_strdup (global_scan_id);
-
-  /* Everyone runs with a nicelevel of 10 */
-  if (prefs_get_bool ("be_nice"))
-    {
-      errno = 0;
-      if (nice(10) == -1 && errno != 0)
-        {
-          g_warning ("Unable to renice process: %d", errno);
-        }
-    }
 
   handle_client (globals);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -187,7 +187,6 @@ is_scanner_only_pref (const char *pref)
       || !strcmp (pref, "negot_timeout")
       || !strcmp (pref, "force_pubkey_auth")
       || !strcmp (pref, "log_whole_attack")
-      || !strcmp (pref, "be_nice")
       || !strcmp (pref, "log_plugins_name_at_load")
       || !strcmp (pref, "nasl_no_signature_check")
       /* Preferences starting with sys_ are scanner-side only. */


### PR DESCRIPTION
be_nice doesn't provide any flexibility, and nicing the scanner if needed is better done from outside.

report_host_details is to be moved to host_details.nasl as a script preference.