### PR TITLE
Fix issues reported by clang analyzer

### DIFF
--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -150,7 +150,6 @@ nasl_pread (lex_ctxt * lexic)
         {
           strcat (newdir, "/");
           strcat (newdir, cmd);
-          cmd = newdir;
         }
     }
 

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -1256,7 +1256,6 @@ exec_ssh_cmd (ssh_session session, char *cmd, int verbose, int compat_mode,
       if ((rc = ssh_channel_read_timeout (channel, buffer, sizeof (buffer), 0,
                                           15000)) > 0)
         {
-          compat_mode = 0;
           if (to_stdout)
             g_string_append_len (response, buffer, rc);
         }


### PR DESCRIPTION
Clang static analyzer has been reporting two issues during the "ci/circleci: scan_build" test.