### PR TITLE
Fix nasl-lint.

### DIFF
--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
+#include <string.h>
 #include "nasl.h"
 #include "nasl_tree.h"
 #include "nasl_global_ctxt.h"
@@ -37,7 +37,40 @@
  */
 #define G_LOG_DOMAIN "lib  nasl"
 
-/* Add keywords to the varnames list*/
+/**
+ * @brief Define struct to store information about a called function.
+ */
+typedef struct st_func_info
+{
+  gchar *func_name;   /**< Function name */
+  gchar *caller_func; /**< Name of the function frome where it is called */
+  gchar *caller_file; /**< Name of the file frome where it is called */
+} func_info;
+
+
+char *nasl_name;
+
+/**
+ * @brief Free a func_info structure.
+ *
+ * @param[in] defined_var List with all defined variables
+ *
+ */
+void
+free_list_func(func_info *data)
+{
+  g_free (data->func_name);
+  g_free (data->caller_func);
+  g_free (data->caller_file);
+  memset (data, '\0', sizeof (func_info));
+}
+
+/**
+ * @brief Add keywords to the varnames list.
+ *
+ * @param[in,out] defined_var List with all defined variables
+ *
+ */
 void
 add_predef_varname (GSList **defined_var)
 {
@@ -51,24 +84,96 @@ add_predef_varname (GSList **defined_var)
   add_nasl_library (defined_var);
 }
 
+/**
+ * @brief This function is called by g_slist_find_custom.
+ *
+ * @param[in] lelem Element of GSList.
+ * @param[in] data func_info structure to be found.
+ *
+ * @return 0 on success, non 0 otherwise.
+ */
+gint
+list_cmp1 (gconstpointer lelem, gconstpointer data)
+{
+  if (data)
+    {
+      gchar *lala = g_strdup (((func_info*)lelem)->func_name);
+      return (g_strcmp0 (lala, data));
+    }
+  return -1;
+}
+
+/**
+ * @brief Check if an undefined called function is needed or not.
+ *        This is the case in which the function is called from a
+ *        neested and defined function but never called.
+ * @return 1 if the function is needed, 0 otherwise.
+*/
+gint
+reverse_search (GSList **def_func_three, GSList *finfo)
+{
+  func_info *fdata = finfo->data;
+  GSList *finfo_aux;
+
+  //The file name is the original file to be tested. It is not an include.
+  if (!g_strcmp0 (fdata->caller_file, nasl_name) && !g_str_has_suffix (nasl_name, ".inc"))
+    return 1;
+
+  //The function is it self.
+  if (!g_strcmp0 (fdata->func_name, fdata->caller_func))
+    return 0;
+
+  //I go up in the three of called and defined functions.
+  if ((finfo_aux = g_slist_find_custom (*def_func_three, fdata->caller_func,
+                                        (GCompareFunc) list_cmp1)) != NULL)
+    if (reverse_search (def_func_three, finfo_aux))
+      return 1;
+
+  return 0 ;
+}
+
+/**
+ * @brief This function is called by g_slist_find_custom.
+ *
+ * @param[in] lelem Element of GSList.
+ * @param[in] data str to be found in the list.
+ *
+ * @return 0 on success, non 0 otherwise.
+ */
 gint
 list_cmp (gconstpointer lelem, gconstpointer data)
 {
   if (data)
-    return (g_strcmp0 (lelem , data));
+    return (g_strcmp0 (lelem, data));
+
   return -1;
 }
 
-/* It adds to a list the inc files, which have never been called. */
+/**
+ * @brief This function is called by g_hash_table_foreach to check if
+ *        an include file was used or not. If the file is not used, it is added
+ *        to a list.
+ *
+ * @param[in] key Element key of GHashTable.
+ * @param[in] value Element value for a key of GHashTable.
+ * @param[in] unusedfiles List with unused .inc files.
+ *
+ */
 void
 check_called_files (gpointer key, gpointer value, GSList **unusedfiles)
 {
   if (key != NULL)
-    if (!g_strcmp0 (value,("NO")))
+    if (!g_strcmp0 (value, "NO"))
       *unusedfiles = g_slist_prepend (*unusedfiles, key);
 }
 
-/* It shows a msg for unused included files. */
+/**
+ * @brief It shows a msg for unused included files.
+ *
+ * @param[in] filename Filename of the not used inc file.
+ * @param[in] lexic nasl context.
+ *
+ */
 void
 print_uncall_files (gpointer filename, gpointer lexic)
 {
@@ -80,16 +185,22 @@ print_uncall_files (gpointer filename, gpointer lexic)
     }
 }
 
+/**
+ * @brief Loads all defined functions. Also, It constructs a three of called
+ *        functions to help recognize a not defined function which is never
+ *        called (nested functions).
+ */
 tree_cell *
 nasl_lint_def (lex_ctxt * lexic, tree_cell * st, int lint_mode,
                GHashTable **include_files, GHashTable **func_fnames_tab,
-               gchar *err_fname, GSList **called_funcs)
+               gchar *err_fname, GSList **called_funcs, GSList **def_func_three)
 {
   int i;
   tree_cell *ret = FAKE_CELL;
   char *incname = NULL;
   gchar *tmp_filename = NULL;
   nasl_func *pf;
+  static gchar *current_fun_def = NULL;
 
   if (st->type == NODE_FUN_CALL)
     {
@@ -99,7 +210,18 @@ nasl_lint_def (lex_ctxt * lexic, tree_cell * st, int lint_mode,
           g_hash_table_insert (*func_fnames_tab, g_strdup (st->x.str_val),
                                g_strdup (err_fname));
         }
+
+      /* Save in a list the name of the called function, the file where it
+         is called from, and the function where it is called from. This will
+         help to know if a called function is really needed, or it was just
+         called by another defined function which is never called. */
+      func_info *finfo = g_malloc0 (sizeof (func_info));
+      finfo->func_name = g_strdup (st->x.str_val);
+      finfo->caller_file = g_strdup (err_fname? err_fname : nasl_name);
+      finfo->caller_func =  g_strdup (current_fun_def);
+      *def_func_three = g_slist_prepend (*def_func_three, finfo);
     }
+
   switch (st->type)
     {
     case NODE_FUN_DEF:
@@ -110,17 +232,18 @@ nasl_lint_def (lex_ctxt * lexic, tree_cell * st, int lint_mode,
             ret = NULL;
           return ret;
         }
-
+      /* Check if it was already added */
       if (!g_slist_find_custom (*called_funcs, st->x.str_val,
-                         (GCompareFunc) list_cmp))
+                                (GCompareFunc) list_cmp))
         {
           return FAKE_CELL;
         }
 
       /* x.str_val = function name, [0] = argdecl, [1] = block */
       decl_nasl_func (lexic, st, lint_mode);
+      current_fun_def = g_strdup (st->x.str_val);
       incname = g_strdup (nasl_get_filename (st->x.str_val));
-      g_hash_table_replace (*include_files, incname, g_strdup("NO"));
+      g_hash_table_replace (*include_files, incname, g_strdup ("NO"));
       tmp_filename = g_strdup (nasl_get_filename (NULL));
       err_fname = g_strdup (incname);
       /* fallthrough */
@@ -130,7 +253,8 @@ nasl_lint_def (lex_ctxt * lexic, tree_cell * st, int lint_mode,
         if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
           if ((ret = nasl_lint_def (lexic, st->link[i], lint_mode,
                                     include_files, func_fnames_tab,
-                                    err_fname, called_funcs)) == NULL)
+                                    err_fname, called_funcs,
+                                    def_func_three)) == NULL)
             return NULL;
 
       if (st->type == NODE_FUN_DEF)
@@ -143,10 +267,13 @@ nasl_lint_def (lex_ctxt * lexic, tree_cell * st, int lint_mode,
     }
 }
 
+/**
+ * @brief Check if a called function was defined.
+ */
 tree_cell *
 nasl_lint_call (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
                 GHashTable **func_fnames_tab, gchar *err_fname,
-                GSList **called_funcs)
+                GSList **called_funcs, GSList **def_func_three)
 {
   int i;
   tree_cell *ret = FAKE_CELL;
@@ -156,12 +283,12 @@ nasl_lint_call (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
 
 
   /** This checks if a defined function is called. If it is never called
-    * it does not go deeper.
-    */
+   * it does not go deeper.
+   */
   if (st->type == NODE_FUN_DEF)
     {
       if (!g_slist_find_custom (*called_funcs, st->x.str_val,
-                         (GCompareFunc) list_cmp))
+                                (GCompareFunc) list_cmp))
         {
           return FAKE_CELL;
         }
@@ -185,19 +312,27 @@ nasl_lint_call (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
           incname = g_hash_table_lookup (*func_fnames_tab, st->x.str_val);
           incname ? nasl_set_filename (incname) : "unknown";
           lexic->line_nb = st->line_nb;
-          nasl_perror (lexic, "Undefined function '%s'\n", st->x.str_val);
-          return NULL;
+
+          GSList *called_f_aux;
+          called_f_aux = g_slist_find_custom (*def_func_three, st->x.str_val,
+                                              (GCompareFunc) list_cmp1);
+          if (called_f_aux != NULL)
+            if (reverse_search (def_func_three, called_f_aux))
+              {
+                nasl_perror (lexic, "Undefined function '%s'\n", st->x.str_val);
+                return NULL;
+              }
         }
       if (*include_files && st->x.str_val)
-       {
-         if (g_hash_table_lookup (*include_files,
-                                  nasl_get_filename (st->x.str_val)))
-           {
-             incname = g_strdup (nasl_get_filename (st->x.str_val));
-             g_hash_table_replace (*include_files, incname,
-                                   g_strdup("YES"));
-           }
-       }
+        {
+          if (g_hash_table_lookup (*include_files,
+                                   nasl_get_filename (st->x.str_val)))
+            {
+              incname = g_strdup (nasl_get_filename (st->x.str_val));
+              g_hash_table_replace (*include_files, incname,
+                                    g_strdup("YES"));
+            }
+        }
       if (g_strcmp0 (st->x.str_val, "defined_func") == 0)
         defined_flag = 1;
       /* fallthrough */
@@ -207,14 +342,16 @@ nasl_lint_call (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
         if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
           if ((ret = nasl_lint_call (lexic, st->link[i], include_files,
                                      func_fnames_tab, err_fname,
-                                     called_funcs)) == NULL)
+                                     called_funcs, def_func_three)) == NULL)
             return NULL;
       return ret;
     }
 }
 
-/* Consider all cases in which a variable is set, and add it to a list. If
- * a variable is read, it checks if it was previously added to the list.
+/**
+ * @brief Consider all cases in which a variable is set, and add it to a list.
+ *        If a variable is read, it checks if it was previously added to the
+ *        list.
  */
 tree_cell *
 nasl_lint_defvar (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
@@ -229,19 +366,19 @@ nasl_lint_defvar (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
   static GSList *local_var_list = NULL;
 
   /** This checks if a defined function is called. If it is never called
-    * it does not go deeper.
-    */
+   * it does not go deeper.
+   */
   if (st->type == NODE_FUN_DEF)
     {
       if (!g_slist_find_custom (*called_funcs, st->x.str_val,
-                         (GCompareFunc) list_cmp))
+                                (GCompareFunc) list_cmp))
         {
           return FAKE_CELL;
         }
     }
 
   if ((defined_fn_mode == 1 || def_glob_var) &&
-       st->type != NODE_DECL)
+      st->type != NODE_DECL)
     {
       defined_fn_mode = 0;
       def_glob_var = 0;
@@ -307,7 +444,7 @@ nasl_lint_defvar (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
   for (i = 0; i < 4; i++)
     if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
       if ((ret = nasl_lint_defvar (lexic, st->link[i],
-                                 include_files, func_fnames_tab,
+                                   include_files, func_fnames_tab,
                                    err_fname, defined_var,
                                    called_funcs)) == NULL)
         return NULL;
@@ -324,7 +461,9 @@ nasl_lint_defvar (lex_ctxt * lexic, tree_cell * st, GHashTable **include_files,
   return ret;
 
 }
-
+/**
+ * @brief Make a list of all called functions.
+*/
 tree_cell *
 make_call_func_list (lex_ctxt *lexic, tree_cell *st,
                      GSList **called_funcs)
@@ -340,7 +479,7 @@ make_call_func_list (lex_ctxt *lexic, tree_cell *st,
       if (st->x.str_val && !pf )
         {
           *called_funcs = g_slist_prepend (*called_funcs,
-                                           g_strdup (st->x.str_val));
+                                           g_strdup(st->x.str_val));
         }
       /* fallthrough */
 
@@ -348,12 +487,20 @@ make_call_func_list (lex_ctxt *lexic, tree_cell *st,
       for (i = 0; i < 4; i++)
         if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
           if ((ret = make_call_func_list (lexic, st->link[i],
-                                     called_funcs)) == NULL)
+                                          called_funcs)) == NULL)
             return NULL;
       return ret;
     }
 }
 
+/**
+ * @brief Search for erros in a nasl script
+ *
+ * @param[in] lexic nasl context.
+ * @param[in] st structure three of a nasl script.
+ *
+ * @return FAKE_CELL if no error was found, NULL otherwise.
+ */
 tree_cell *
 nasl_lint (lex_ctxt * lexic, tree_cell * st)
 {
@@ -364,10 +511,12 @@ nasl_lint (lex_ctxt * lexic, tree_cell * st)
   GHashTable *func_fnames_tab = NULL;
   GSList *unusedfiles = NULL;
   GSList *called_funcs = NULL;
+  GSList *def_func_three = NULL;
   gchar *err_fname = NULL;
 
-  include_files = g_hash_table_new_full
-    (g_str_hash, g_str_equal, g_free, g_free);
+  nasl_name = g_strdup (nasl_get_filename(st->x.str_val));
+  include_files = g_hash_table_new_full (g_str_hash,
+                                         g_str_equal, g_free, g_free);
   func_fnames_tab = g_hash_table_new_full
     (g_str_hash, g_str_equal, g_free, g_free);
 
@@ -375,18 +524,19 @@ nasl_lint (lex_ctxt * lexic, tree_cell * st)
   lexic_aux->script_infos = lexic->script_infos;
   lexic_aux->oid = lexic->oid;
 
+
   /* Make a list of all called functions */
   make_call_func_list (lexic_aux, st, &called_funcs);
 
   /* Loads all defined functions. */
   if ((ret = nasl_lint_def (lexic_aux, st, lint_mode, &include_files,
                             &func_fnames_tab, err_fname,
-                            &called_funcs)) == NULL)
+                            &called_funcs, &def_func_three)) == NULL)
     goto fail;
   /* Check if a called function was defined. */
   if ((ret = nasl_lint_call (lexic_aux, st, &include_files,
                              &func_fnames_tab, err_fname,
-                             &called_funcs)) == NULL)
+                             &called_funcs, &def_func_three)) == NULL)
     goto fail;
 
   /* Check if the included files are used or not. */
@@ -404,8 +554,8 @@ nasl_lint (lex_ctxt * lexic, tree_cell * st)
   lint_mode = 0;
   if ((ret = nasl_lint_def (lexic, st, lint_mode, &include_files,
                             &func_fnames_tab, err_fname,
-                            &called_funcs)) == NULL)
-      goto fail;
+                            &called_funcs, &def_func_three)) == NULL)
+    goto fail;
 
   /* Check if a variable was declared. */
   GSList *defined_var = NULL;
@@ -419,6 +569,8 @@ nasl_lint (lex_ctxt * lexic, tree_cell * st)
  fail:
   g_slist_free (called_funcs);
   called_funcs = NULL;
+  g_slist_free_full (def_func_three, (GDestroyNotify)free_list_func);
+  def_func_three = NULL;
   g_hash_table_destroy (include_files);
   include_files = NULL;
   g_hash_table_destroy (func_fnames_tab);


### PR DESCRIPTION
In some cases in which an undefined function foo() was called from inside another function bar(),
and function bar() was never called, nasl-lint gave an unexpected error for foo().
This PR solves this problem: Since bar() is not called, it does not matters if foo() is defined or not.