### PR TITLE
Switch advanced log to use host details.

### DIFF
--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -147,8 +147,6 @@ _http_req (lex_ctxt * lexic, char *keyword)
         hostheader = g_strdup_printf ("%s:%d", hostname, port);
 
       url = build_encode_URL (keyword, NULL, item, "HTTP/1.1");
-      if (prefs_get_bool ("advanced_log"))
-        kb_item_add_str (kb, "log/http/short", url, 0);
       request = g_strdup_printf ("%s\r\n\
 Connection: Close\r\n\
 Host: %s\r\n\
@@ -164,11 +162,7 @@ Accept-Charset: iso-8859-1,*,utf-8\r\n", url, hostheader, ua);
       g_free (url);
     }
   else
-    {
-      request = build_encode_URL (keyword, NULL, item, "HTTP/1.0\r\n");
-      if (prefs_get_bool ("advanced_log"))
-        kb_item_add_str (kb, "log/http/short", request, 0);
-    }
+    request = build_encode_URL (keyword, NULL, item, "HTTP/1.0\r\n");
 
   if (auth)
     {
@@ -193,8 +187,6 @@ Accept-Charset: iso-8859-1,*,utf-8\r\n", url, hostheader, ua);
       request = tmp;
     }
 
-  if (prefs_get_bool ("advanced_log"))
-    kb_item_add_str (kb, "log/http/full", request, 0);
   retc = alloc_tree_cell ();
   retc->type = CONST_DATA;
   retc->size = strlen (request);

--- a/src/attack.c
+++ b/src/attack.c
@@ -327,8 +327,6 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
                     name, oid, ip_str, error);
           g_free (name);
         }
-      if (prefs_get_bool ("advanced_log"))
-        kb_item_add_str (kb, "log/notlaunched", oid, 0);
       return 0;
     }
 
@@ -351,12 +349,14 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
     }
   if (prefs_get_bool ("advanced_log"))
     {
-      char buf[2048], buf2[2048];
+      char buffer[2048];
 
-      kb_item_add_str (kb, "log/launched", oid, 0);
-      snprintf (buf, sizeof (buf), "log/launched/%s/start", oid);
-      snprintf (buf2, sizeof (buf2), "%lu", time (NULL));
-      kb_item_add_str (kb, buf, buf2, 0);
+      snprintf (buffer, sizeof (buffer),
+                "LOG||| |||general/Host_Details||| |||<host><detail>"
+                "<name>nvt_start_time</name><value>%lu</value><source>"
+                "<description/><type>nvt</type><name>%s</name></source>"
+                "</detail></host>", time (NULL), oid);
+      kb_item_push_str (kb, "internal/results", buffer);
     }
 
   if (prefs_get_bool ("log_whole_attack"))

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -122,10 +122,14 @@ update_running_processes (kb_t kb)
 
               if (prefs_get_bool ("advanced_log"))
                 {
-                  char buf[2048], buf2[2048];
-                  snprintf (buf, sizeof (buf), "log/launched/%s/end", oid);
-                  snprintf (buf2, sizeof (buf2), "%lu", time (NULL));
-                  kb_item_add_str (kb, buf, buf2, 0);
+                  char buffer[2048];
+
+                  snprintf (buffer, sizeof (buffer),
+                            "LOG||| |||general/Host_Details||| |||<host><detail>"
+                            "<name>nvt_end_time</name><value>%lu</value><source>"
+                            "<description/><type>nvt</type><name>%s</name></source>"
+                            "</detail></host>", time (NULL), oid);
+                  kb_item_push_str (kb, "internal/results", buffer);
                 }
               if (processes[i].alive)
                 {
@@ -135,7 +139,17 @@ update_running_processes (kb_t kb)
                     g_message ("%s (pid %d) is slow to finish - killing it",
                                oid, processes[i].pid);
                   if (prefs_get_bool ("advanced_log"))
-                    kb_item_add_str (kb, "log/timedout", oid, 0);
+                    {
+                      char buffer[2048];
+
+                      snprintf (buffer, sizeof (buffer),
+                                "LOG||| |||general/Host_Details||| |||<host>"
+                                "<detail><name>nvt_end_time</name><value>"
+                                "<source><description/><type>nvt</type>"
+                                "<name>%s</name></source></detail></host>",
+                                oid);
+                      kb_item_push_str (kb, "internal/results", buffer);
+                    }
 
                   sprintf (msg,
                            "ERRMSG||| |||general/tcp|||%s|||"


### PR DESCRIPTION
Remove http and not-launched entries, as they dramatically increase the
amout of logging, without providing much value.