### PR TITLE
Add function to set and get the current launched/running plugin.

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -49,6 +49,8 @@
 #include <gvm/util/serverutils.h> /* for load_gnutls_file */
 #include <gvm/util/kb.h>          /* for kb_item_get_str() */
 
+#include "../nasl/nasl_debug.h"          /* for nasl_*_filename */
+
 #ifdef __FreeBSD__
 #include <netinet/in.h>
 #define s6_addr32 __u6_addr.__u6_addr32
@@ -737,7 +739,8 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
   if (open_SSL_connection (fp, cert, key, passwd, cafile, hostname) <= 0)
     {
       g_free (hostname);
-      g_message ("socket_negotiate_ssl: SSL connection failed.");
+      g_message ("%s: socket_negotiate_ssl: SSL connection failed.",
+                 nasl_get_plugin_filename ());
       release_connection_fd (fd, 0);
       return -1;
     }
@@ -1220,8 +1223,10 @@ read_stream_connection_unbuffered (int fd, void *buf0, int min_len, int max_len)
 
     default:
       if (fp->transport || fp->fd != 0)
-        g_message ("Severe bug! Unhandled transport layer %d (fd=%d)",
-                   fp->transport, fd);
+        g_message ("Severe bug! Unhandled transport layer %d (fd=%d). "
+                   "Function %s called from %s.",
+                   fp->transport, fd, nasl_get_plugin_filename (),
+                   nasl_get_function_name ());
       else
         g_message ("read_stream_connection_unbuffered: "
                    "fd=%d is closed",
@@ -1399,8 +1404,10 @@ write_stream_connection4 (int fd, void *buf0, int n, int i_opt)
 
     default:
       if (fp->transport || fp->fd != 0)
-        g_message ("Severe bug! Unhandled transport layer %d (fd=%d)",
-                   fp->transport, fd);
+        g_message ("Severe bug! Unhandled transport layer %d (fd=%d). "
+                   "Function %s called from %s.",
+                   fp->transport, fd, nasl_get_plugin_filename (),
+                   nasl_get_function_name ());
       else
         g_message ("read_stream_connection_unbuffered: fd=%d is "
                    "closed", fd);

--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1635,6 +1635,10 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   gchar *newdir;
   tree_cell tc;
   const char *str, *name = script_infos->name, *oid = script_infos->oid;
+  gchar *short_name = g_path_get_basename (name);
+
+  nasl_set_plugin_filename (short_name);
+  g_free (short_name);
 
   srand48 (getpid () + getppid () + (long) time (NULL));
 

--- a/nasl/nasl_debug.c
+++ b/nasl/nasl_debug.c
@@ -18,6 +18,7 @@
 
 #include <stdarg.h>
 #include <unistd.h>
+#include <string.h> /* for str() */
 
 #include <gvm/base/logging.h>
 
@@ -40,8 +41,31 @@ extern FILE *nasl_trace_fp;
 
 static char *debug_filename = NULL;
 static char *debug_funname = NULL;
+static char debug_plugin_filename[PATH_MAX];
 
 static GHashTable *functions_filenames = NULL;
+
+/**
+ * @brief Get the current launched plugin filename.
+ *
+ * @return Filename of the current running plugin.
+ */
+const char *
+nasl_get_plugin_filename ()
+{
+  return debug_plugin_filename;
+}
+
+/**
+ * @brief Set the current launched plugin filename.
+ *
+ * @param[in] filename Filename of the current plugin.
+ */
+void
+nasl_set_plugin_filename (const char *filename)
+{
+  strncpy (debug_plugin_filename, filename, sizeof (debug_plugin_filename));
+}
 
 const char *
 nasl_get_filename (const char *function)

--- a/nasl/nasl_debug.h
+++ b/nasl/nasl_debug.h
@@ -19,9 +19,17 @@
 #ifndef NASL_DEBUG_H__
 #define NASL_DEBUG_H__
 
+#include "nasl_lex_ctxt.h"
+
 void nasl_perror (lex_ctxt *, char *, ...);
 void nasl_trace (lex_ctxt *, char *, ...);
 int nasl_trace_enabled (void);
+
+const char *
+nasl_get_plugin_filename (void);
+
+void
+nasl_set_plugin_filename (const char *);
 
 void
 nasl_set_filename (const char *);

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -264,7 +264,8 @@ nasl_ssh_connect (lex_ctxt *lexic)
   session = ssh_new ();
   if (!session)
     {
-      g_message ("Failed to allocate a new SSH session");
+      g_message ("%s: Failed to allocate a new SSH session",
+                 nasl_get_plugin_filename ());
       return NULL;
     }
 
@@ -281,7 +282,8 @@ nasl_ssh_connect (lex_ctxt *lexic)
 
   if (ssh_options_set (session, SSH_OPTIONS_HOST, ip_str))
     {
-      g_message ("Failed to set SSH hostname '%s': %s",
+      g_message ("%s: Failed to set SSH hostname '%s': %s",
+                 nasl_get_plugin_filename (),
                  ip_str, ssh_get_error (session));
       ssh_free (session);
       return NULL;
@@ -289,7 +291,8 @@ nasl_ssh_connect (lex_ctxt *lexic)
 
   if (ssh_options_set (session, SSH_OPTIONS_KNOWNHOSTS, "/dev/null"))
     {
-      g_message ("Failed to disable SSH known_hosts: %s",
+      g_message ("%s: Failed to disable SSH known_hosts: %s",
+                 nasl_get_plugin_filename (),
                  ssh_get_error (session));
       ssh_free (session);
       return NULL;
@@ -299,8 +302,9 @@ nasl_ssh_connect (lex_ctxt *lexic)
 
   if (key_type && ssh_options_set (session, SSH_OPTIONS_HOSTKEYS, key_type))
     {
-      g_message ("Failed to set SSH key type '%s': %s",
-                 key_type, ssh_get_error (session));
+      g_message ("%s: Failed to set SSH key type '%s': %s",
+                 nasl_get_plugin_filename (), key_type,
+                 ssh_get_error (session));
       ssh_free (session);
       return NULL;
     }
@@ -308,16 +312,18 @@ nasl_ssh_connect (lex_ctxt *lexic)
   csciphers = get_str_var_by_name (lexic, "csciphers");
   if (csciphers && ssh_options_set (session, SSH_OPTIONS_CIPHERS_C_S, csciphers))
     {
-      g_message ("Failed to set SSH client to server ciphers '%s': %s",
-                 csciphers, ssh_get_error (session));
+      g_message ("%s: Failed to set SSH client to server ciphers '%s': %s",
+                 nasl_get_plugin_filename (), csciphers,
+                 ssh_get_error (session));
       ssh_free (session);
       return NULL;
     }
   scciphers = get_str_var_by_name (lexic, "scciphers");
   if (scciphers && ssh_options_set (session, SSH_OPTIONS_CIPHERS_S_C, scciphers))
     {
-      g_message ("Failed to set SSH server to client ciphers '%s': %s",
-                 scciphers, ssh_get_error (session));
+      g_message ("%s: Failed to set SSH server to client ciphers '%s': %s",
+                 nasl_get_plugin_filename (), scciphers,
+                 ssh_get_error (session));
       ssh_free (session);
       return NULL;
     }
@@ -328,8 +334,9 @@ nasl_ssh_connect (lex_ctxt *lexic)
 
       if (ssh_options_set (session, SSH_OPTIONS_PORT, &my_port))
         {
-          g_message ("Failed to set SSH port for '%s' to %d: %s",
-                     ip_str, port, ssh_get_error (session));
+          g_message ("%s: Failed to set SSH port for '%s' to %d: %s",
+                 nasl_get_plugin_filename (), ip_str, port,
+                     ssh_get_error (session));
           ssh_free (session);
           return NULL;
         }
@@ -344,8 +351,9 @@ nasl_ssh_connect (lex_ctxt *lexic)
       if (ssh_options_set (session, SSH_OPTIONS_FD, &my_fd))
         {
           g_message
-            ("Failed to set SSH fd for '%s' to %d (NASL sock=%d): %s",
-             ip_str, my_fd, sock, ssh_get_error (session));
+            ("%s: Failed to set SSH fd for '%s' to %d (NASL sock=%d): %s",
+             nasl_get_plugin_filename (), ip_str, my_fd, sock,
+             ssh_get_error (session));
           ssh_free (session);
           return NULL;
         }
@@ -724,8 +732,9 @@ nasl_ssh_set_login (lex_ctxt *lexic)
       if (username && *username &&
           ssh_options_set (session, SSH_OPTIONS_USER, username))
         {
-          g_message ("Failed to set SSH username '%s': %s",
-                     username, ssh_get_error (session));
+          g_message ("%s: Failed to set SSH username '%s': %s",
+                     username, ssh_get_error (session),
+                     nasl_get_plugin_filename ());
           return NULL; /* Ooops.  */
         }
       /* In any case mark the user has set.  */
@@ -1200,7 +1209,8 @@ exec_ssh_cmd (ssh_session session, char *cmd, int verbose, int compat_mode,
   alarm (30);
   if ((channel = ssh_channel_new (session)) == NULL)
     {
-      g_message ("ssh_channel_new failed: %s",
+      g_message ("%s: ssh_channel_new failed: %s",
+                 nasl_get_plugin_filename (),
                  ssh_get_error (session));
       return SSH_ERROR;
     }
@@ -1337,7 +1347,8 @@ nasl_ssh_request_exec (lex_ctxt *lexic)
   cmd = get_str_var_by_name (lexic, "cmd");
   if (!cmd || !*cmd)
     {
-      g_message ("No command passed to ssh_request_exec");
+      g_message ("%s: No command passed to ssh_request_exec",
+                 nasl_get_plugin_filename ());
       return NULL;
     }
 
@@ -1402,7 +1413,8 @@ nasl_ssh_request_exec (lex_ctxt *lexic)
   p = g_string_free (response, FALSE);
   if (!p)
     {
-      g_message ("ssh_request_exec memory problem: %s", strerror (-1));
+      g_message ("%s: ssh_request_exec memory problem: %s",
+                 nasl_get_plugin_filename (), strerror (-1));
       return NULL;
     }
 
@@ -1674,15 +1686,16 @@ nasl_ssh_shell_open (lex_ctxt *lexic)
     return NULL;
   if (ssh_channel_open_session (channel))
     {
-      g_message ("ssh_channel_open_session: %s",
-                 ssh_get_error (session));
+      g_message ("%s: ssh_channel_open_session: %s",
+                 nasl_get_plugin_filename (), ssh_get_error (session));
       ssh_channel_free (channel);
       return NULL;
     }
 
   if (request_ssh_shell (channel))
     {
-      g_message ("request_ssh_shell: %s", ssh_get_error (session));
+      g_message ("%s: request_ssh_shell: %s",
+                 nasl_get_plugin_filename (), ssh_get_error (session));
       ssh_channel_free (channel);
       return NULL;
     }
@@ -1796,13 +1809,15 @@ nasl_ssh_shell_write (lex_ctxt *lexic)
   cmd = get_str_var_by_name (lexic, "cmd");
   if (!cmd || !*cmd)
     {
-      g_message ("ssh_shell_write: No command passed");
+      g_message ("%s: ssh_shell_write: No command passed",
+                 nasl_get_plugin_filename ());
       goto write_ret;
     }
   len = strlen (cmd);
   if (ssh_channel_write (channel, cmd, len) != len)
     {
-      g_message ("ssh_shell_write: %s",
+      g_message ("%s: ssh_shell_write: %s",
+                 nasl_get_plugin_filename (),
                  ssh_get_error (session_table[tbl_slot].session));
       goto write_ret;
     }

--- a/src/attack.c
+++ b/src/attack.c
@@ -44,6 +44,7 @@
 #include "../misc/nvt_categories.h" /* for ACT_INIT */
 #include "../misc/pcap_openvas.h"   /* for v6_is_local_ip */
 #include "../misc/scanneraux.h"
+#include "../nasl/nasl_debug.h"          /* for nasl_*_filename */
 
 #include "attack.h"
 #include "comm.h"


### PR DESCRIPTION
Some functions do not have access to the current running plugin,
what makes it hard to find the source of the error message during
a scan. With this PR it is possible to set and get the nasl
script filename to improve the error message.

Set the plugin name for each launched plugin.
This is useful to improve log messages, where the plugin name is unknown to be logged.

Improve error message in network.c ("Severe bug! Unhandled transport layer ...")
Add the filename of the plugin and the function name.