### PR TITLE
Use enum for NVT categories.

### DIFF
--- a/misc/nvt_categories.h
+++ b/misc/nvt_categories.h
@@ -32,26 +32,20 @@
 
 /**
  * @brief NVT 'Categories', influence execution order of NVTs.
- *
- * @todo Consider creation of an enumeration.
  */
-
-/** Last plugins actions type. */
-#define ACT_LAST                ACT_END
-/** First plugins actions type. */
-#define ACT_FIRST               ACT_INIT
-
-#define ACT_UNKNOWN             11
-#define ACT_END                 10
-#define ACT_FLOOD               9
-#define ACT_KILL_HOST           8
-#define ACT_DENIAL              7
-#define ACT_DESTRUCTIVE_ATTACK  6
-#define ACT_MIXED_ATTACK        5
-#define ACT_ATTACK              4
-#define ACT_GATHER_INFO         3
-#define ACT_SETTINGS            2
-#define ACT_SCANNER             1
-#define ACT_INIT                0
+typedef enum
+{
+  ACT_INIT = 0,
+  ACT_SCANNER,
+  ACT_SETTINGS,
+  ACT_GATHER_INFO,
+  ACT_ATTACK,
+  ACT_MIXED_ATTACK,
+  ACT_DESTRUCTIVE_ATTACK,
+  ACT_DENIAL,
+  ACT_KILL_HOST,
+  ACT_FLOOD,
+  ACT_END,
+} nvt_category;
 
 #endif /* _NVT_CATEGORIES_H */

--- a/src/attack.c
+++ b/src/attack.c
@@ -263,7 +263,7 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
   nvti = nvticache_get_nvt (oid);
   if (scan_is_stopped () || all_scans_are_stopped ())
     {
-      if (nvti->category != ACT_LAST)
+      if (nvti->category != ACT_END)
         {
           plugin->running_state = PLUGIN_STATUS_DONE;
           return 0;

--- a/src/comm.c
+++ b/src/comm.c
@@ -34,7 +34,7 @@
 #include <gvm/base/prefs.h>         /* for preferences_get() */
 #include <gvm/util/nvticache.h>     /* for nvticache_t */
 
-#include "../misc/nvt_categories.h"/* for ACT_FIRST */
+#include "../misc/nvt_categories.h"/* for ACT_INIT */
 #include "../misc/plugutils.h"
 #include "../misc/network.h"       /* for recv_line */
 
@@ -184,9 +184,7 @@ send_plug_info (int soc, const char *oid)
     }
 
   category = nvti_category (nvti);
-  if (category >= ACT_UNKNOWN || category < ACT_FIRST)
-    category = ACT_UNKNOWN;
-
+  assert (category >= ACT_INIT && category <= ACT_END);
   name = nvti_name (nvti);
   if (!name || strchr (name, '\n'))
     {

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -50,7 +50,7 @@
 
 struct plugins_scheduler
 {
-  GSList *list[ACT_LAST + 1]; /**< Per-category linked-lists of the plugins. */
+  GSList *list[ACT_END + 1]; /**< Per-category linked-lists of the plugins. */
   int stopped;
 };
 
@@ -135,13 +135,12 @@ plugin_add (plugins_scheduler_t sched, GHashTable *oids_table,
     }
 
   category = nvti_category (nvti);
-  assert (category >= 0);
+  assert (category >= ACT_INIT && category <= ACT_END);
   plugin = g_malloc0 (sizeof (struct scheduler_plugin));
   plugin->running_state = PLUGIN_STATUS_UNRUN;
   plugin->oid = g_strdup (oid);
   g_hash_table_insert (oids_table, plugin->oid, plugin);
 
-  assert (category <= ACT_LAST);
   sched->list[category] = g_slist_prepend
                            (sched->list[category], plugin);
 
@@ -199,7 +198,7 @@ plugins_scheduler_fill_deps (plugins_scheduler_t sched, GHashTable *oids_table)
 {
   int category;
 
-  for (category = ACT_FIRST; category <= ACT_LAST; category++)
+  for (category = ACT_INIT; category <= ACT_END; category++)
     {
       GSList *element = sched->list[category];
 
@@ -301,7 +300,7 @@ check_dependency_cycles (plugins_scheduler_t sched)
   GHashTable *checked;
 
   checked = g_hash_table_new_full (g_str_hash, g_direct_equal, NULL, NULL);
-  for (i = ACT_FIRST; i <= ACT_LAST; i++)
+  for (i = ACT_INIT; i <= ACT_END; i++)
     {
       GSList *element = sched->list[i];
 
@@ -345,7 +344,7 @@ plugins_scheduler_init (const char *plugins_list, int autoload, int only_network
 
   if (only_network)
     {
-      for (i = ACT_GATHER_INFO; i <= ACT_LAST; i++)
+      for (i = ACT_GATHER_INFO; i <= ACT_END; i++)
         {
           ret->list[i] = NULL;
         }
@@ -366,7 +365,7 @@ plugins_scheduler_count_active (plugins_scheduler_t sched)
   int ret = 0, i;
   assert (sched);
 
-  for (i = ACT_FIRST; i <= ACT_LAST; i++)
+  for (i = ACT_INIT; i <= ACT_END; i++)
     ret += g_slist_length (sched->list[i]);
   return ret;
 }
@@ -536,7 +535,7 @@ plugins_scheduler_stop (plugins_scheduler_t sched)
 
   if (sched->stopped)
     return;
-  for (category = ACT_FIRST; category < ACT_END; category++)
+  for (category = ACT_INIT; category < ACT_END; category++)
     {
       GSList *element = sched->list[category];
 
@@ -569,7 +568,7 @@ plugins_scheduler_free (plugins_scheduler_t sched)
 {
   int i;
 
-  for (i = ACT_FIRST; i <= ACT_LAST; i++)
+  for (i = ACT_INIT; i <= ACT_END; i++)
     g_slist_free_full (sched->list[i], scheduler_plugin_free);
   g_free (sched);
 }


### PR DESCRIPTION
Also remove ACT_FIRST and ACT_LAST which were used interchangeably with
ACT_INIT and ACT_END. Remove ACT_UNKNOWN.