### PR TITLE
Change NVT prefs format

### DIFF
--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -436,15 +436,28 @@ script_add_preference (lex_ctxt * lexic)
   char *type = get_str_var_by_name (lexic, "type");
   char *value = get_str_var_by_name (lexic, "value");
   struct script_infos *script_infos = lexic->script_infos;
+  GSList *tmp;
 
-  if (name == NULL || type == NULL || value == NULL)
+  if (!script_infos->nvti)
+    return FAKE_CELL;
+  if (!name || !type || !value)
     {
       nasl_perror (lexic,
                    "Argument error in the call to script_add_preference()\n");
+      return FAKE_CELL;
     }
-  else
-    add_plugin_preference (script_infos, name, type, value);
+  tmp = script_infos->nvti->prefs;
+  while (tmp)
+    {
+      if (!strcmp (name, ((nvtpref_t *) tmp->data)->name))
+        {
+          nasl_perror (lexic, "Preference '%s' already exists\n", name);
+          return FAKE_CELL;
+        }
+      tmp = tmp->next;
+    }
 
+  add_plugin_preference (script_infos, name, type, value);
   return FAKE_CELL;
 }
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -259,20 +259,17 @@ send_plugins_preferences (int soc, GSList *oids)
       if (nprefs || (timeout > 0))
         {
           GSList *tmp = nprefs;
-          char *name = nvticache_get_name (oid);
 
           if (timeout > 0)
-            send_printf (soc, "%s[%s]:%s <|> %d\n", name, "entry", "Timeout",
-                         timeout);
+            send_printf (soc, "%s:entry:Timeout <|> %d\n", oid, timeout);
           while (tmp)
             {
               nvtpref_t *pref = tmp->data;
-              send_printf (soc, "%s[%s]:%s <|> %s\n", name, nvtpref_type (pref),
+              send_printf (soc, "%s:%s:%s <|> %s\n", oid, nvtpref_type (pref),
                            g_strchomp (nvtpref_name (pref)),
                            nvtpref_default (pref));
               tmp = tmp->next;
             }
-          g_free (name);
         }
       g_slist_free_full (nprefs, (void (*) (void *)) nvtpref_free);
       oids = oids->next;


### PR DESCRIPTION
Send and receive NVT preferences in OID:PrefType:PrefName instead of NVTName[PrefType]:PrefName.

This allows NVT plugins to change their names without breaking existing scan configs.

Relevant gvmd PR https://github.com/greenbone/gvmd/pull/394