### PR TITLE
Fix crash when a plugin is missing during a scan.

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -258,6 +258,14 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
   addr6_to_str (ip, ip_str);
   oid = plugin->oid;
   nvti = nvticache_get_nvt (oid);
+
+  /* eg. When NVT was moved/removed by a feed update during the scan. */
+  if (!nvti)
+    {
+      g_message ("Plugin '%s' missing from nvticache.", oid);
+      plugin->running_state = PLUGIN_STATUS_DONE;
+      goto finish_launch_plugin;
+    }
   if (scan_is_stopped () || all_scans_are_stopped ())
     {
       if (nvti->category != ACT_END)

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -75,7 +75,7 @@ plugin_add (plugins_scheduler_t sched, GHashTable *oids_table,
         {
           char *name = nvticache_get_filename (oid);
           g_message ("Plugin %s is deprecated. "
-                     "It will neither loaded nor launched.",
+                     "It will neither be loaded nor launched.",
                      name);
           g_free (name);
         }


### PR DESCRIPTION
Backport of https://github.com/greenbone/openvas-scanner/pull/295