### PR TITLE
New NVT cross references data handling

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -72,21 +72,6 @@ plug_current_vhost (void)
 static int plug_fork_child (kb_t);
 
 void
-plug_set_xref (struct script_infos *args, char *name, char *value)
-{
-  nvti_t *n = args->nvti;
-  char *new;
-
-  if (nvti_xref (n))
-    new = g_strconcat (nvti_xref (n), ", ", name, ":", value, NULL);
-  else
-    new = g_strconcat (name, ":", value, NULL);
-
-  nvti_set_xref (n, new);
-  g_free (new);
-}
-
-void
 plug_set_tag (struct script_infos *args, char *name, char *value)
 {
   nvti_t *n = args->nvti;

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -44,9 +44,6 @@ void
 plug_set_dep (struct script_infos *, const char *);
 
 void
-plug_set_xref (struct script_infos *, char *, char *);
-
-void
 plug_set_tag (struct script_infos *, char *, char *);
 
 void

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -102,9 +102,6 @@ script_oid (lex_ctxt *lexic)
   return FAKE_CELL;
 }
 
-/*
- * TODO: support multiple CVE entries
- */
 tree_cell *
 script_cve_id (lex_ctxt *lexic)
 {
@@ -121,9 +118,6 @@ script_cve_id (lex_ctxt *lexic)
   return FAKE_CELL;
 }
 
-/*
- * TODO: support multiple bugtraq entries
- */
 tree_cell *
 script_bugtraq_id (lex_ctxt *lexic)
 {
@@ -140,17 +134,48 @@ script_bugtraq_id (lex_ctxt *lexic)
   return FAKE_CELL;
 }
 
+/**
+ * @brief Add a cross reference to the meta data.
+ *
+ * The parameter "name" of the command defines actually
+ * the type, for example "URL" or "OSVDB".
+ * The parameter "value" is the actual reference.
+ * Alternative to "value", "csv" can be used with a
+ * list of comma-separated values.
+ *
+ * In fact, if name is "cve" or "bid", it is equivalent
+ * to call script_cve_id() or script_bugtraq_id(), for example
+ * script_cve_id ("CVE-2019-12345");
+ * is identical to
+ * script_xref (name: "cve", value: "CVE-2019-12345");
+ *
+ * And also:
+ * script_bugtraq_id (12345);
+ * is identical to
+ * script_xref (name: "bid", value: "12345");
+ * (watch out that the number now needs to be a string).
+ *
+ * This even works with multiple comma-separated elements like
+ * script_xref (name: "cve", csv: "CVE-2019-12345,CVE-2019-54321");
+ *
+ * @param lexic The parser context.
+ *
+ * @return Always FAKE_CELL.
+ */
 tree_cell *
 script_xref (lex_ctxt *lexic)
 {
   struct script_infos *script_infos = lexic->script_infos;
   char *name = get_str_var_by_name (lexic, "name");
   char *value = get_str_var_by_name (lexic, "value");
+  char *csv = get_str_var_by_name (lexic, "csv");
 
-  if (value == NULL || name == NULL)
+  if (((value == NULL) && (csv == NULL)) || name == NULL)
     {
       nasl_perror (lexic, "script_xref() syntax error - should be"
-                          " script_xref(name:<name>, value:<value>)\n");
+                          " script_xref(name:<name>, value:<value>) or"
+                          " script_xref(name:<name>, value:<value>, csv:<CSVs>) or"
+                          " script_xref(name:<name>, csv:<CSVs>)\n");
       if (name == NULL)
         {
           nasl_perror (lexic, "  <name> is empty\n");
@@ -159,18 +184,23 @@ script_xref (lex_ctxt *lexic)
         {
           nasl_perror (lexic, "  <name> is %s\n", name);
         }
-      if (value == NULL)
+      if ((value == NULL) && (csv == NULL))
         {
-          nasl_perror (lexic, "  <value> is empty)\n");
+          nasl_perror (lexic, "  <value> and <csv> is empty)\n");
         }
       else
         {
           nasl_perror (lexic, "  <value> is %s\n)", value);
+          nasl_perror (lexic, "  <csv> is %s\n)", csv);
         }
       return FAKE_CELL;
     }
 
-  nvti_add_ref (script_infos->nvti, vtref_new (name, value, ""));
+  if (csv)
+    nvti_add_refs_from_csv (script_infos->nvti, name, csv, "");
+
+  if (value)
+    nvti_add_ref (script_infos->nvti, vtref_new (name, value, ""));
 
   return FAKE_CELL;
 }

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -111,7 +111,7 @@ script_cve_id (lex_ctxt *lexic)
 
   for (i = 0; cve != NULL; i++)
     {
-      nvti_add_ref (script_infos->nvti, vtref_new ("cve", cve, ""));
+      nvti_add_vtref (script_infos->nvti, vtref_new ("cve", cve, ""));
       cve = get_str_var_by_num (lexic, i + 1);
     }
 
@@ -127,7 +127,7 @@ script_bugtraq_id (lex_ctxt *lexic)
 
   for (i = 0; bid != NULL; i++)
     {
-      nvti_add_ref (script_infos->nvti, vtref_new ("bid", bid, ""));
+      nvti_add_vtref (script_infos->nvti, vtref_new ("bid", bid, ""));
       bid = get_str_var_by_num (lexic, i + 1);
     }
 
@@ -200,7 +200,7 @@ script_xref (lex_ctxt *lexic)
     nvti_add_refs (script_infos->nvti, name, csv, "");
 
   if (value)
-    nvti_add_ref (script_infos->nvti, vtref_new (name, value, ""));
+    nvti_add_vtref (script_infos->nvti, vtref_new (name, value, ""));
 
   return FAKE_CELL;
 }

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -170,7 +170,7 @@ script_xref (lex_ctxt *lexic)
       return FAKE_CELL;
     }
 
-  plug_set_xref (script_infos, name, value);
+  nvti_add_ref (script_infos->nvti, vtref_new (name, value, ""));
 
   return FAKE_CELL;
 }

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -114,7 +114,7 @@ script_cve_id (lex_ctxt *lexic)
 
   for (i = 0; cve != NULL; i++)
     {
-      nvti_add_cve (script_infos->nvti, cve);
+      nvti_add_ref (script_infos->nvti, vtref_new ("cve", cve, ""));
       cve = get_str_var_by_num (lexic, i + 1);
     }
 
@@ -133,7 +133,7 @@ script_bugtraq_id (lex_ctxt *lexic)
 
   for (i = 0; bid != NULL; i++)
     {
-      nvti_add_bid (script_infos->nvti, bid);
+      nvti_add_ref (script_infos->nvti, vtref_new ("bid", bid, ""));
       bid = get_str_var_by_num (lexic, i + 1);
     }
 

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -197,7 +197,7 @@ script_xref (lex_ctxt *lexic)
     }
 
   if (csv)
-    nvti_add_refs_from_csv (script_infos->nvti, name, csv, "");
+    nvti_add_refs (script_infos->nvti, name, csv, "");
 
   if (value)
     nvti_add_ref (script_infos->nvti, vtref_new (name, value, ""));

--- a/src/comm.c
+++ b/src/comm.c
@@ -195,8 +195,8 @@ send_plug_info (int soc, const char *oid)
       goto send_cleanup;
     }
 
-  cve_id = nvti_cve (nvti);
-  bid = nvti_bid (nvti);
+  cve_id = nvti_refs (nvti, "cve");
+  bid = nvti_refs (nvti, "bid");
   xref = nvti_xref (nvti);
   tag = nvti_tag (nvti);
   if (tag)
@@ -215,6 +215,9 @@ send_plug_info (int soc, const char *oid)
                (cve_id && *cve_id) ? cve_id : "NOCVE",
                (bid && *bid) ? bid : "NOBID", (xref && *xref) ? xref : "NOXREF",
                (tag && *tag) ? tag : "NOTAG");
+
+  g_free (cve_id);
+  g_free (bid);
 
 send_cleanup:
   nvti_free (nvti);

--- a/src/comm.c
+++ b/src/comm.c
@@ -195,9 +195,9 @@ send_plug_info (int soc, const char *oid)
       goto send_cleanup;
     }
 
-  cve_id = nvti_refs (nvti, "cve");
-  bid = nvti_refs (nvti, "bid");
-  xref = nvti_xref (nvti);
+  cve_id = nvti_refs (nvti, "cve", "", 0);
+  bid = nvti_refs (nvti, "bid", "", 0);
+  xref = nvti_refs (nvti, NULL, "bid,cve", 1);
   tag = nvti_tag (nvti);
   if (tag)
     {
@@ -218,6 +218,7 @@ send_plug_info (int soc, const char *oid)
 
   g_free (cve_id);
   g_free (bid);
+  g_free (xref);
 
 send_cleanup:
   nvti_free (nvti);


### PR DESCRIPTION
The unified handling of cross references (CVE, BID, XREF) allows
* some simplifications
* resolving the long-standing TODO about multiple references
* an empowerment of script_xref to cover any sort of reference specification

Ultimately it allows to get rid of script_cve_id() and script_bugtraq_id() in favor
of using only script_xref().

This PR requires and corresponds with https://github.com/greenbone/gvm-libs/pull/225