### PR TITLE
Have greenbone-nvt-sync not run as root

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2018 Greenbone Networks GmbH
+# Copyright (C) 2011-2019 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -183,7 +183,7 @@ install (FILES ${CMAKE_BINARY_DIR}/src/openvassd_log.conf
          DESTINATION ${OPENVAS_SYSCONF_DIR})
 
 install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-nvt-sync
-         DESTINATION ${SBINDIR}
+         DESTINATION ${BINDIR}
          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -20,6 +20,16 @@
 # This script updates the local Network Vulnerability Tests (NVTs) from the
 # Greenbone Security Feed (GSF) or the Greenbone Community Feed (GCF). 
 
+if [ "`id -u`" -eq "0" ]
+then
+  echo "$0 must not be executed as privileged user root"
+  echo
+  echo "Unlike the actual scanner the sync routine does not need privileges."
+  echo "Accidental executation as root would prevent later overwriting of"
+  echo "files with a non-privileged user."
+  exit 1
+fi
+
 VERSION=@OPENVASSD_VERSION@
 
 # SETTINGS

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -20,16 +20,6 @@
 # This script updates the local Network Vulnerability Tests (NVTs) from the
 # Greenbone Security Feed (GSF) or the Greenbone Community Feed (GCF). 
 
-if [ "`id -u`" -eq "0" ]
-then
-  echo "$0 must not be executed as privileged user root"
-  echo
-  echo "Unlike the actual scanner the sync routine does not need privileges."
-  echo "Accidental executation as root would prevent later overwriting of"
-  echo "files with a non-privileged user."
-  exit 1
-fi
-
 VERSION=@OPENVASSD_VERSION@
 
 # SETTINGS
@@ -169,6 +159,19 @@ get_feed_info ()
     FEED_HOME="Unidentified Feed Homepage"
   fi
 }
+
+# Prevent that root executes this script
+if [ "`id -u`" -eq "0" ]
+then
+  stderr_write "$0 must not be executed as privileged user root"
+  stderr_write
+  stderr_write "Unlike the actual scanner the sync routine does not need privileges."
+  stderr_write "Accidental executation as root would prevent later overwriting of"
+  stderr_write "files with a non-privileged user."
+
+  log_err "Denied to run as root"
+  exit 1
+fi
 
 # Always try to get the information when started.
 # This also ensures variables like FEED_PRESENT are set.


### PR DESCRIPTION
The script greenbone-nvt-sync does not require anymore
root privileges to run. Therefore it is now installed
in the "bin" directory rather than the "sbin" directory.

Furthermore the script will now deny to run with "root"
privileges. This is to prevent accidental change of
file permissions that can later not be fixed by
non-priviledged user anymore.

If migrating from an older version, the owner and permissions
in the feed directory need to be fixed: 

    # cd <prefix>/var/lib/openvas/plugins
    # chown -R <myuser>:<mygroup> *

where the user that runs the sync needs to be <myuser>
or belong to group <mygroup>.
