### PR TITLE
Separate each scan plugin process into its own process group.

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -793,9 +793,7 @@ static int
 plug_fork_child (kb_t kb)
 {
   pid_t pid;
-  char key[128];
 
-  snprintf (key, sizeof (key), "internal/child/%d", getpid ());
   if ((pid = fork ()) == 0)
     {
       sig_term (_exit);
@@ -810,11 +808,7 @@ plug_fork_child (kb_t kb)
       return -1;
     }
   else
-    {
-      kb_item_set_int (kb, key, pid);
-      waitpid (pid, NULL, 0);
-      kb_del_items (kb, key);
-    }
+    waitpid (pid, NULL, 0);
   return 1;
 }
 

--- a/nasl/nasl_cmd_exec.c
+++ b/nasl/nasl_cmd_exec.c
@@ -102,7 +102,7 @@ nasl_pread (lex_ctxt *lexic)
   nasl_array *av;
   int i, j, n, cd, fdout = 0, fderr = 0;
   char **args = NULL, *cmd, *str;
-  char cwd[MAXPATHLEN], newdir[MAXPATHLEN], key[128];
+  char cwd[MAXPATHLEN], newdir[MAXPATHLEN];
   GError *error = NULL;
 
   if (pid != 0)
@@ -197,8 +197,6 @@ nasl_pread (lex_ctxt *lexic)
       goto finish_pread;
     }
 
-  snprintf (key, sizeof (key), "internal/child/%d", getpid ());
-  kb_item_set_int (lexic->script_infos->key, key, pid);
   str = pread_streams (fdout, fderr);
   if (str)
     {
@@ -221,7 +219,6 @@ finish_pread:
 
   g_spawn_close_pid (pid);
   pid = 0;
-  kb_del_items (lexic->script_infos->key, key);
 
   return retc;
 }

--- a/src/attack.c
+++ b/src/attack.c
@@ -340,7 +340,7 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
   if (kb_item_get_int (kb, "Host/dead") > 0)
     {
       g_message ("The remote host %s is dead", ip_str);
-      pluginlaunch_stop (1);
+      pluginlaunch_stop ();
       plugin->running_state = PLUGIN_STATUS_DONE;
       ret = ERR_HOST_DEAD;
       goto finish_launch_plugin;
@@ -512,7 +512,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
       parent = getppid ();
       if (parent <= 1 || process_alive (parent) == 0)
         {
-          pluginlaunch_stop (1);
+          pluginlaunch_stop ();
           return;
         }
 
@@ -572,7 +572,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
               last_status = (cur_plug * 100) / num_plugs + 2;
               if (comm_send_status (kb, ip_str, cur_plug, num_plugs) < 0)
                 {
-                  pluginlaunch_stop (1);
+                  pluginlaunch_stop ();
                   goto host_died;
                 }
             }
@@ -588,7 +588,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
     comm_send_status (kb, ip_str, num_plugs, num_plugs);
 
 host_died:
-  pluginlaunch_stop (1);
+  pluginlaunch_stop ();
   plugins_scheduler_free (sched);
 }
 
@@ -948,7 +948,7 @@ check_kb_access (int soc)
 static void
 handle_scan_stop_signal ()
 {
-  pluginlaunch_stop (0);
+  pluginlaunch_stop ();
   global_scan_stop = 1;
 }
 

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -175,6 +175,9 @@ nasl_thread (struct script_infos *args)
   kb_t kb;
   GError *error = NULL;
 
+  /* Make plugin process a group leader, to make it easier to cleanup forked
+   * processes & their children. */
+  setpgid (0, 0);
   nvticache_reset ();
   if (prefs_get_bool ("be_nice"))
     {

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -288,25 +288,15 @@ pluginlaunch_enable_parallel_checks (void)
 }
 
 void
-pluginlaunch_stop (int soft_stop)
+pluginlaunch_stop ()
 {
   int i;
-
-  if (soft_stop)
-    {
-      for (i = 0; i < MAX_PROCESSES; i++)
-        {
-          if (processes[i].pid > 0)
-            kill (processes[i].pid, SIGTERM);
-        }
-      usleep (20000);
-    }
 
   for (i = 0; i < MAX_PROCESSES; i++)
     {
       if (processes[i].pid > 0)
         {
-          kill (processes[i].pid, SIGKILL);
+          terminate_process (processes[i].pid * -1);
           num_running_processes--;
           processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
           bzero (&(processes[i]), sizeof (struct running));

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -75,20 +75,6 @@ static int old_max_running_processes;
 static GSList *non_simult_ports = NULL;
 const char *hostname = NULL;
 
-static void
-cleanup_process_children (kb_t kb, pid_t pid)
-{
-  char key[128];
-  pid_t child;
-
-  snprintf (key, sizeof (key), "internal/child/%d", pid);
-  child = kb_item_get_int (kb, key);
-  if (child > 0)
-    {
-      g_warning ("Terminating leftover child process %d", child);
-      terminate_process (child);
-    }
-}
 /**
  *
  */
@@ -161,7 +147,6 @@ update_running_processes (kb_t kb)
               terminate_process (processes[i].pid * -1);
               num_running_processes--;
               processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
-              cleanup_process_children (kb, processes[i].pid);
               bzero (&(processes[i]), sizeof (processes[i]));
             }
         }

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -130,8 +130,6 @@ update_running_processes (kb_t kb)
                            "NVT timed out after %d seconds.",
                            oid ?: " ", processes[i].timeout);
                   kb_item_push_str (kb, "internal/results", msg);
-
-                  terminate_process (processes[i].pid);
                 }
               else
                 {
@@ -160,6 +158,7 @@ update_running_processes (kb_t kb)
                     }
                   while (e < 0 && errno == EINTR);
                 }
+              terminate_process (processes[i].pid * -1);
               num_running_processes--;
               processes[i].plugin->running_state = PLUGIN_STATUS_DONE;
               cleanup_process_children (kb, processes[i].pid);

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -33,8 +33,10 @@ void
 pluginlaunch_init (const char *);
 void pluginlaunch_wait (kb_t);
 void pluginlaunch_wait_for_free_process (kb_t);
+
 void
-pluginlaunch_stop (int);
+pluginlaunch_stop ();
+
 int
 plugin_launch (struct scan_globals *, struct scheduler_plugin *,
                struct in6_addr *, GSList *, kb_t, nvti_t *);

--- a/src/processes.c
+++ b/src/processes.c
@@ -48,7 +48,7 @@ terminate_process (pid_t pid)
 {
   int ret;
 
-  if (pid <= 0)
+  if (pid == 0)
     return 0;
 
   ret = kill (pid, SIGTERM);


### PR DESCRIPTION
This makes cleaning-up children easier, and fixes issue of forgotten children of children.