### PR TITLE
Fallback to NVT_TIMEOUT and SCANNER_NVT_TIMEOUT on 0 timeout.

### DIFF
--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -330,6 +330,26 @@ pluginlaunch_stop (int soft_stop)
     }
 }
 
+static int
+plugin_timeout (nvti_t *nvti)
+{
+  int timeout;
+
+  assert (nvti);
+  timeout = prefs_nvt_timeout (nvti->oid);
+  if (timeout == 0)
+    timeout = nvti_timeout (nvti);
+  if (timeout == 0)
+    {
+      if (nvti_category (nvti) == ACT_SCANNER)
+        timeout = atoi (prefs_get ("scanner_plugins_timeout"))
+                   ?: SCANNER_NVT_TIMEOUT;
+      else
+        timeout = atoi (prefs_get ("plugins_timeout")) ?: NVT_TIMEOUT;
+    }
+  return timeout;
+}
+
 /**
  * @return PID of process that is connected to the plugin as returned by plugin
  *         classes pl_launch function (<=0 means there was a problem).
@@ -346,19 +366,7 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   if (p < 0)
     return -1;
   processes[p].plugin = plugin;
-  processes[p].timeout = prefs_nvt_timeout (plugin->oid);
-  if (processes[p].timeout == 0)
-    processes[p].timeout = nvti_timeout (nvti);
-
-  if (processes[p].timeout == 0)
-    {
-      if (nvti_category (nvti) == ACT_SCANNER)
-        processes[p].timeout =
-          atoi (prefs_get ("scanner_plugins_timeout") ?: "-1");
-      else
-        processes[p].timeout = atoi (prefs_get ("plugins_timeout") ?: "-1");
-    }
-
+  processes[p].timeout = plugin_timeout (nvti);
   gettimeofday (&(processes[p].start), NULL);
   processes[p].pid = nasl_plugin_launch (globals, ip, vhosts, kb, plugin->oid);
 


### PR DESCRIPTION
This would happen when a plugin has no provided timeout, and the scan
config has no or 0 scanner_plugins_timeout/plugins_timeout.

Backport of https://github.com/greenbone/openvas-scanner/pull/329