### PR TITLE
Check for wrong names or values in the script_xrefs parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.08.2] (unreleased)
 
 ### Added
+- Check for wrong names or values in the script_xrefs params. [#650](https://github.com/greenbone/openvas/pull/650)
+
 ### Changed
 ### Fixed
 ### Removed

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -549,7 +549,7 @@ check_description_block_xref (lex_ctxt *lexic, tree_cell *st)
 
 /**
  * @brief Sanity check of the description block
- * @return FAKE_CELL if success, NULL otherwhise.
+ * @return FAKE_CELL if success, NULL otherwise.
  */
 tree_cell *
 check_description_block (lex_ctxt *lexic, tree_cell *st)
@@ -636,12 +636,12 @@ nasl_lint (lex_ctxt *lexic, tree_cell *st)
   lexic_aux->script_infos = lexic->script_infos;
   lexic_aux->oid = lexic->oid;
 
-  /* Check description block sanity. Limite the search to the description
+  /* Check description block sanity. Limit the search to the description
    * block only. Include files don't have a description block and won't be
    * checked */
   desc_block = find_description_block (lexic_aux, st);
   if (desc_block != NULL && desc_block != FAKE_CELL)
-    /* FAKE_CELL if success, NULL otherwhise which counts as error */
+    /* FAKE_CELL if success, NULL otherwise which counts as error */
     if ((ret = check_description_block (lexic_aux, desc_block)) == NULL)
       goto fail;
 

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -1,4 +1,5 @@
-/* Copyright (C) 2004 Michel Arboi
+/* Portions Copyright (C) 2009-2021 Greenbone Networks GmbH
+ * Base on work Copyright (C) 2004 Michel Arboi
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *
@@ -26,6 +27,7 @@
 #include "nasl_var.h"
 
 #include <string.h>
+#include <unistd.h>
 
 #undef G_LOG_DOMAIN
 /**
@@ -517,6 +519,92 @@ make_call_func_list (lex_ctxt *lexic, tree_cell *st, GSList **called_funcs)
 }
 
 /**
+ * @brief Sanity check of the script_xref parameters in the description block
+ */
+tree_cell *
+check_description_block_xref (lex_ctxt *lexic, tree_cell *st)
+{
+  int i;
+  tree_cell *ret = FAKE_CELL;
+
+  switch (st->type)
+    {
+    case CONST_STR:
+      if (g_strrstr (st->x.str_val, ",") != NULL)
+        {
+          g_message ("%s: An error in script_xrefs function was found. "
+                     "Comma is not allow in xrefs names or values: '%s'",
+                     nasl_get_filename (st->x.str_val), st->x.str_val);
+          return NULL;
+        }
+      /* fallthrough */
+    default:
+      for (i = 0; i < 4; i++)
+        if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
+          if ((ret = check_description_block_xref (lexic, st->link[i])) == NULL)
+            return NULL;
+    }
+  return ret;
+}
+
+/**
+ * @brief Sanity check of the description block
+ * @return FAKE_CELL if success, NULL otherwhise.
+ */
+tree_cell *
+check_description_block (lex_ctxt *lexic, tree_cell *st)
+{
+  int i;
+  tree_cell *ret = FAKE_CELL;
+
+  if (st->type == NODE_FUN_CALL)
+    if (!g_strcmp0 (st->x.str_val, "script_xref"))
+      if ((ret = check_description_block_xref (lexic, st)) == NULL)
+        return NULL;
+
+  for (i = 0; i < 4; i++)
+    if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
+      if ((ret = check_description_block (lexic, st->link[i])) == NULL)
+        return NULL;
+
+  return ret;
+}
+
+/**
+ * @brief Sanity check of the description block
+ *
+ * @return pointer to the description block tree cell.
+ */
+tree_cell *
+find_description_block (lex_ctxt *lexic, tree_cell *st)
+{
+  int i;
+  tree_cell *ret = FAKE_CELL;
+  tree_cell *st_aux = NULL;
+
+  if (st && st->type == NODE_IF_ELSE)
+    {
+      for (i = 0; i < 4; i++)
+        if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
+          {
+            st_aux = st->link[i];
+            if (st_aux->type == NODE_VAR
+                && !g_strcmp0 (st_aux->x.str_val, "description"))
+              return st;
+          }
+    }
+  else
+    for (i = 0; i < 4; i++)
+      {
+        if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
+          if ((ret = find_description_block (lexic, st->link[i])) == NULL)
+            return NULL;
+        return ret;
+      }
+  return NULL;
+}
+
+/**
  * @brief Search for errors in a nasl script
  *
  * @param[in] lexic nasl context.
@@ -536,6 +624,7 @@ nasl_lint (lex_ctxt *lexic, tree_cell *st)
   GSList *called_funcs = NULL;
   GSList *def_func_tree = NULL;
   gchar *err_fname = NULL;
+  tree_cell *desc_block = FAKE_CELL;
 
   nasl_name = g_strdup (nasl_get_filename (st->x.str_val));
   include_files =
@@ -546,6 +635,13 @@ nasl_lint (lex_ctxt *lexic, tree_cell *st)
   lexic_aux = init_empty_lex_ctxt ();
   lexic_aux->script_infos = lexic->script_infos;
   lexic_aux->oid = lexic->oid;
+
+  /* Check description block sanity. Limite the search to the description
+   * block only */
+  desc_block = find_description_block (lexic_aux, st);
+  /* FAKE_CELL if success, NULL otherwhise */
+  if ((ret = check_description_block (lexic_aux, desc_block)) == NULL)
+    goto fail;
 
   /* Make a list of all called functions */
   make_call_func_list (lexic_aux, st, &called_funcs);

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -637,11 +637,13 @@ nasl_lint (lex_ctxt *lexic, tree_cell *st)
   lexic_aux->oid = lexic->oid;
 
   /* Check description block sanity. Limite the search to the description
-   * block only */
+   * block only. Include files don't have a description block and won't be
+   * checked */
   desc_block = find_description_block (lexic_aux, st);
-  /* FAKE_CELL if success, NULL otherwhise */
-  if ((ret = check_description_block (lexic_aux, desc_block)) == NULL)
-    goto fail;
+  if (desc_block != NULL && desc_block != FAKE_CELL)
+    /* FAKE_CELL if success, NULL otherwhise which counts as error */
+    if ((ret = check_description_block (lexic_aux, desc_block)) == NULL)
+      goto fail;
 
   /* Make a list of all called functions */
   make_call_func_list (lexic_aux, st, &called_funcs);


### PR DESCRIPTION
**What**:
Check for wrong names or values in the script_xrefs parameters.

**Why**:
Comma is not allowed and should be checked.

<!-- Why are these changes necessary? -->

**How**:
Add a comma in an xrefs in the description block and check it with openvas-nasl-lint

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
