### PR TITLE
Fix gcc-9 adn gcc-10 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 ### Fixed
+- Fix gcc-9 adn gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)
+
 ### Removed
 
 [20.08.2]: https://github.com/greenbone/openvas/compare/v20.8.0...openvas-20.08

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -47,9 +47,14 @@
  */
 #define G_LOG_DOMAIN "lib  misc"
 
+/**
+ * @brief Maximum length of an interface's name
+ */
+#define MAX_IFACE_NAME_LEN 64
+
 struct interface_info
 {
-  char name[64];
+  char name[MAX_IFACE_NAME_LEN];
   struct in_addr addr;
   struct in6_addr addr6;
   struct in6_addr mask;
@@ -458,8 +463,14 @@ getinterfaces (int *howmany)
       /* In case it is a stinkin' alias */
       if ((p = strchr (ifr->ifr_name, ':')))
         *p = '\0';
-      strncpy (mydevs[numinterfaces].name, ifr->ifr_name, 63);
-      mydevs[numinterfaces].name[63] = '\0';
+
+      memset (mydevs[numinterfaces].name, '\0', MAX_IFACE_NAME_LEN);
+      if (strlen (ifr->ifr_name) < MAX_IFACE_NAME_LEN)
+        memcpy (mydevs[numinterfaces].name, ifr->ifr_name,
+                strlen (ifr->ifr_name));
+      else
+        memcpy (mydevs[numinterfaces].name, ifr->ifr_name,
+                MAX_IFACE_NAME_LEN - 1);
       numinterfaces++;
       if (numinterfaces == 1023)
         {
@@ -589,7 +600,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
   int numinterfaces;
   char buf[1024];
   char *p, *endptr;
-  char iface[64];
+  char iface[MAX_IFACE_NAME_LEN];
   FILE *routez;
   unsigned long dest;
   struct in_addr inaddr;
@@ -623,6 +634,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
               continue;
             }
           strncpy (iface, p, sizeof (iface));
+          iface[MAX_IFACE_NAME_LEN - 1] = '\0';
           if ((p = strchr (iface, ':')))
             {
               *p = '\0'; /* To support IP aliasing */
@@ -1075,7 +1087,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
   } myroutes[MAXROUTES];
   int numinterfaces = 0;
   char *p, *endptr;
-  char iface[64];
+  char iface[MAX_IFACE_NAME_LEN];
   static int numroutes = 0;
   FILE *routez;
   long best_match = -1;
@@ -1115,6 +1127,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
                   continue;
                 }
               strncpy (iface, p, sizeof (iface));
+              iface[MAX_IFACE_NAME_LEN - 1] = '\0';
               if ((p = strchr (iface, ':')))
                 {
                   *p = '\0'; /* To support IP aliasing */

--- a/nasl/nasl_debug.c
+++ b/nasl/nasl_debug.c
@@ -63,6 +63,7 @@ void
 nasl_set_plugin_filename (const char *filename)
 {
   strncpy (debug_plugin_filename, filename, sizeof (debug_plugin_filename));
+  debug_plugin_filename[PATH_MAX - 1] = '\0';
 }
 
 const char *


### PR DESCRIPTION
**What**:
Add the '\0' after the strncpy call.
For one case, despite the '\0' char is added after strncpy, the compiler raises a warning.
Therefore strncpy is replace with memcpy.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Fix gcc-9 adn gcc-10 warnings

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
