### PR TITLE
Fix double free in cert query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix issues discovered with clang compiler.   [#654](https://github.com/greenbone/openvas/pull/654)
 - Fix gcc-9 adn gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)
+- Fix double free in nasl_cert_query. [#658](https://github.com/greenbone/openvas/pull/658)
 
 ### Removed
 

--- a/nasl/nasl_cert.c
+++ b/nasl/nasl_cert.c
@@ -954,7 +954,6 @@ nasl_cert_query (lex_ctxt *lexic)
           != GNUTLS_E_SUCCESS)
         return NULL;
       gnutls_x509_crt_get_pk_algorithm (cert, &bits);
-      gnutls_free (datum.data);
       gnutls_x509_crt_deinit (cert);
 
       retc = alloc_typed_cell (CONST_INT);


### PR DESCRIPTION
**What**:

Double free in `cert_query`.
`ksba_cert_get_image` does not return a copy but only a pointer to the image. Do not free it with `gnutls_free`. It will get freed with `ksba_cert_release` when `nasl_cert_close` is called.

**Why**:

<!-- Why are these changes necessary? -->
Fix https://github.com/greenbone/openvas-scanner/issues/480.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Test with some VT

```C
if(description) {
  script_oid("1.2.3");
  exit(0);
}

cert = "<Some BER encoded certificate>";
if( ! cert = cert_open( cert) )
  display( "Error opening cert!" );

size = cert_query( cert, "key-size" ); 
display(size);

cert_close( cert );
exit(0);
```

Error `double free or corruption (!prev)` will be gone after applied PR. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
