### PR TITLE
Do not abort when log file not accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix size calculation which lead to alloc error in get_tcp_element() of openvas-nasl. [#546](https://github.com/greenbone/openvas/pull/546)
 - Fix filter out of default 'radio' type preferences [#560](https://github.com/greenbone/openvas/pull/560)
 - Allow group access to lockfile and fix empty timestamp [#562](https://github.com/greenbone/openvas/pull/562)
+- Do not simply abort when log file is not writable but print err msg and shutdown gracefully instead. [#661](https://github.com/greenbone/openvas/pull/661)
 
 ### Removed
 - Removed "network scan" mode. This includes removal of NASL API methods "scan_phase()" and "network_targets()". Sending a "network_mode=yes" in a scanner configuration will have no effect anymore. [#493](https://github.com/greenbone/openvas/pull/493)

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -314,6 +314,7 @@ init_openvas (const char *config_file)
 {
   static gchar *rc_name = NULL;
   int i;
+  int err;
 
   for (i = 0; openvas_defaults[i].option != NULL; i++)
     prefs_set (openvas_defaults[i].option, openvas_defaults[i].value);
@@ -323,8 +324,16 @@ init_openvas (const char *config_file)
   rc_name = g_build_filename (OPENVAS_SYSCONF_DIR, "openvas_log.conf", NULL);
   if (g_file_test (rc_name, G_FILE_TEST_EXISTS))
     log_config = load_log_configuration (rc_name);
+  err = setup_log_handlers (log_config);
+  if (err)
+    {
+      g_warning ("%s: Can not open or create log file or directory. "
+                 "Please check permissions of log files listed in %s.",
+                 __func__, rc_name);
+      g_free (rc_name);
+      return -1;
+    }
   g_free (rc_name);
-  setup_log_handlers (log_config);
   set_globals_from_preferences ();
 
   return 0;


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Do not abort when log file not accessible. Instead let `init_openvas` print an error message and return gracefully if `setup_log_handlers` returns an error. 
Return value of `setup_log_handlers` is not evaluated by `reload_openvas` as Its probably better to have a successful reload and print the logs to stderr instead of having no reload at all.

`openvas -V` works even when we have wrong permission. `openvas -s` does not.

Depends on: https://github.com/greenbone/gvm-libs/pull/447

**Why**:

<!-- Why are these changes necessary? -->
fix https://github.com/greenbone/openvas-scanner/issues/415.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Change permissions of some log file to root and do `openvas -s' as non root. Program will be aborted abruptly without applied PR. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
