### PR TITLE
Fix a typo. Strip spaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 ### Fixed
-- Fix issues discovered with clang compiler.   [#654](https://github.com/greenbone/openvas/pull/654)
-- Fix gcc-9 adn gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)
+- Fix issues discovered with clang compiler. [#654](https://github.com/greenbone/openvas/pull/654)
+- Fix gcc-9 and gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)
 - Fix double free in nasl_cert_query. [#658](https://github.com/greenbone/openvas/pull/658)
 
 ### Removed


### PR DESCRIPTION
From codespell:

```
./CHANGELOG.md:17: adn ==> and
```