### PR TITLE
Fix a typo.

### DIFF
--- a/src/hosts.c
+++ b/src/hosts.c
@@ -271,7 +271,7 @@ hosts_read (void)
 }
 
 /**
- * @brief Returns 1 if the host is being scanned. 0 otherwhise.
+ * @brief Returns 1 if the host is being scanned. 0 otherwise.
  *
  * It checks not only the main IP of the host, but also the ips
  * that a dns-lookup returns.


### PR DESCRIPTION
From codespell:

```
./src/hosts.c:274: otherwhise ==> otherwise
```

Seems that typo doesn't exist in the openvas-scanner-20.08 branch so i have created the PR against master.