### PR TITLE
Improve log message for WMI connect failed or missing WMI support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Replace bogus data with a better message and the vendor. [#665](https://github.com/greenbone/openvas/pull/665)
+- Improve log message for WMI connect failed or missing WMI support. [#670](https://github.com/greenbone/openvas/pull/670)
+
 ### Fixed
 - Fix issues discovered with clang compiler. [#654](https://github.com/greenbone/openvas/pull/654)
 - Fix gcc-9 and gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)

--- a/nasl/nasl_wmi.c
+++ b/nasl/nasl_wmi.c
@@ -180,7 +180,8 @@ nasl_wmi_connect (lex_ctxt *lexic)
   handle = wmi_connect (argc, argv);
   if (!handle)
     {
-      g_message ("nasl_wmi_connect: WMI Connect failed");
+      g_message ("nasl_wmi_connect: WMI Connect failed or missing WMI support "
+                 "for the scanner");
       return NULL;
     }
 
@@ -320,7 +321,8 @@ nasl_wmi_connect_rsop (lex_ctxt *lexic)
   handle = wmi_connect_rsop (argc, argv);
   if (!handle)
     {
-      g_message ("nasl_wmi_connect_rsop: WMI Connect failed");
+      g_message ("nasl_wmi_connect_rsop: WMI Connect failed or missing WMI "
+                 "support for the scanner");
       return NULL;
     }
 
@@ -430,7 +432,8 @@ nasl_wmi_connect_reg (lex_ctxt *lexic)
   handle = wmi_connect_reg (argc, argv);
   if (!handle)
     {
-      g_message ("nasl_wmi_connect_reg: WMI Connect failed");
+      g_message ("nasl_wmi_connect_reg: WMI Connect failed or missing WMI "
+                 "support for the scanner");
       return NULL;
     }
 


### PR DESCRIPTION
**What**:
Both, a WMI connect failed or the WMI stub function return NULL.
The message suggest that the connect failed can be produce because
missing WMI support.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To let now the user that the libopenvas_wmiclient is missing. See [openvas-smb](https://github.com/greenbone/openvas-smb)
<!-- Why are these changes necessary? -->

**How**:
Build the scanner from scratch, but remove/rename the openvas-smb libs, so you don't have WMI support. Run a scan and check the log.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
