### PR TITLE
Don't log all target hosts in a normal message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Replace bogus data with a better message and the vendor. [#665](https://github.com/greenbone/openvas/pull/665)
 - Improve log message for WMI connect failed or missing WMI support. [#670](https://github.com/greenbone/openvas/pull/670)
+- Log target hosts only as debug message [#676](https://github.com/greenbone/openvas-scanner/pull/676)
 
 ### Fixed
 - Fix issues discovered with clang compiler. [#654](https://github.com/greenbone/openvas/pull/654)

--- a/src/attack.c
+++ b/src/attack.c
@@ -1124,10 +1124,11 @@ attack_network (struct scan_globals *globals)
     goto stop;
   hosts_init (max_hosts);
 
-  g_message ("Vulnerability scan %s started: Target has %d hosts: "
-             "%s, with max_hosts = %d and max_checks = %d",
-             globals->scan_id, gvm_hosts_count (hosts), hostlist, max_hosts,
-             max_checks);
+  g_message ("Vulnerability scan %s with max_hosts = %d and "
+             "max_checks = %d started. Target has %d hosts.",
+             globals->scan_id, max_hosts, max_checks, gvm_hosts_count (hosts));
+
+  g_debug ("Targets are %s", hostlist);
 
   if (test_alive_hosts_only)
     {


### PR DESCRIPTION
**What**:

Only log target hosts of a scan as debug message.


**Why**:

The list of target hosts can be rather big and is more a debug
information the a normal log message.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
