### PR TITLE
PoC alternative way to scan vhosts

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -214,6 +214,17 @@ check_duplicated_vhost (struct script_infos *args, const char *hostname)
   return 0;
 }
 
+/**
+ * @brief Set the the value of the current vhost being scanned.
+ *
+ * @param vhost gvm_vhost structure with value and source.
+ */
+void
+plug_set_current_vhost(gvm_vhost_t *vhost)
+{
+  current_vhost = vhost;
+}
+
 int
 plug_add_host_fqdn (struct script_infos *args, const char *hostname,
                     const char *source)

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -267,7 +267,6 @@ plug_add_host_fqdn (struct script_infos *args, const char *hostname,
 char *
 plug_get_host_fqdn (struct script_infos *args)
 {
-
   static char oid[64] = "";
 
   if (oid[0] == 0)
@@ -278,7 +277,8 @@ plug_get_host_fqdn (struct script_infos *args)
       g_snprintf (oid, sizeof (oid), "%s", args->oid);
       /* stores the plugin oid, to be launch again for all vhosts associated
        * to this host */
-      buffer = g_strdup_printf("internal/vhostplugins/%s", addr6_as_str (args->ip));
+      buffer =
+        g_strdup_printf ("internal/vhostplugins/%s", addr6_as_str (args->ip));
       kb_item_add_str_unique (args->results, buffer, args->oid, len, pos);
       g_free (buffer);
     }

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -28,7 +28,8 @@
 
 #include "scanneraux.h" /* for struct script_infos */
 
-#include <gvm/base/nvti.h> /* for nvti_t */
+#include <gvm/base/nvti.h>  /* for nvti_t */
+#include <gvm/base/hosts.h> /* for g_vhost_t */
 
 #define ARG_STRING 1
 #define ARG_INT 2
@@ -180,5 +181,8 @@ get_plugin_preference_file_content (struct script_infos *, const char *);
 
 long
 get_plugin_preference_file_size (struct script_infos *, const char *);
+
+void
+plug_set_current_vhost(gvm_vhost_t *);
 
 #endif

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -28,8 +28,8 @@
 
 #include "scanneraux.h" /* for struct script_infos */
 
-#include <gvm/base/nvti.h>  /* for nvti_t */
 #include <gvm/base/hosts.h> /* for g_vhost_t */
+#include <gvm/base/nvti.h>  /* for nvti_t */
 
 #define ARG_STRING 1
 #define ARG_INT 2
@@ -183,6 +183,6 @@ long
 get_plugin_preference_file_size (struct script_infos *, const char *);
 
 void
-plug_set_current_vhost(gvm_vhost_t *);
+plug_set_current_vhost (gvm_vhost_t *);
 
 #endif

--- a/src/attack.c
+++ b/src/attack.c
@@ -483,6 +483,23 @@ prepare_vhosts_plugin_list (char *ip_str, kb_t main_kb)
   return plugin_set;
 }
 
+static int
+kb_duplicate(kb_t dst, kb_t src, const gchar *filter)
+{
+  struct kb_item *items, *p_itm;
+
+  items = kb_item_get_pattern(src, filter ? filter : "*");
+  for (p_itm = items; p_itm != NULL; p_itm = p_itm->next)
+    {
+      gchar *newname;
+
+      newname = p_itm->name;
+      kb_item_add_str(dst, newname, p_itm->v_str, 0);
+    }
+  return 0;
+}
+
+
 /**
  * @brief Attack one host.
  */

--- a/src/attack.c
+++ b/src/attack.c
@@ -522,8 +522,8 @@ attack_vhosts (struct scan_globals *globals, struct in6_addr *ip,
       int rc;
       kb_t vhost_kb;
       plugins_scheduler_t sched = NULL;
-      int num_plugs;
       int scheduler_phase_reset = 1;
+
       if (plug_list)
         {
           sched = plugins_scheduler_init (plug_list, no_plug_dependencies,
@@ -560,7 +560,6 @@ attack_vhosts (struct scan_globals *globals, struct in6_addr *ip,
       g_message ("%s: Scanning vhosts %s found in %s", globals->scan_id,
                  current_vhost->value, current_vhost->source);
 
-      num_plugs = plugins_scheduler_count_active (sched);
       plugins_scheduler_next (sched, scheduler_phase_reset);
       for (;;)
         {

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -442,17 +442,24 @@ current_category (int category, int set_category)
 }
 
 struct scheduler_plugin *
-plugins_scheduler_next (plugins_scheduler_t h)
+plugins_scheduler_next (plugins_scheduler_t h, int phase_reset)
 {
   struct scheduler_plugin *ret;
   static int scheduler_phase = 0;
-
+  int set_cat = 1;
+      
+  if (phase_reset)
+    {
+      scheduler_phase = 0;
+      return NULL;
+    }
+  
   if (h == NULL)
-    return NULL;
+      return NULL;
 
   if (scheduler_phase == 0)
     {
-      ret = get_next_in_range (h, ACT_INIT, ACT_INIT);
+      ret = get_next_in_range (h, ACT_INIT, ACT_INIT); //0
       if (ret)
         return ret;
       scheduler_phase = 1;
@@ -460,7 +467,7 @@ plugins_scheduler_next (plugins_scheduler_t h)
     }
   if (scheduler_phase <= 1)
     {
-      ret = get_next_in_range (h, ACT_SCANNER, ACT_SCANNER);
+      ret = get_next_in_range (h, ACT_SCANNER, ACT_SCANNER);//1
       if (ret)
         return ret;
       scheduler_phase = 2;
@@ -468,7 +475,7 @@ plugins_scheduler_next (plugins_scheduler_t h)
     }
   if (scheduler_phase <= 2)
     {
-      ret = get_next_in_range (h, ACT_SETTINGS, ACT_GATHER_INFO);
+      ret = get_next_in_range (h, ACT_SETTINGS, ACT_GATHER_INFO); //2-3
       if (ret)
         return ret;
       scheduler_phase = 3;
@@ -476,7 +483,7 @@ plugins_scheduler_next (plugins_scheduler_t h)
     }
   if (scheduler_phase <= 3)
     {
-      ret = get_next_in_range (h, ACT_ATTACK, ACT_FLOOD);
+      ret = get_next_in_range (h, ACT_ATTACK, ACT_FLOOD); //4-9
       if (ret)
         return ret;
       scheduler_phase = 4;
@@ -484,7 +491,8 @@ plugins_scheduler_next (plugins_scheduler_t h)
     }
   if (scheduler_phase <= 4)
     {
-      ret = get_next_in_range (h, ACT_END, ACT_END);
+      current_category (ACT_END, set_cat);
+      ret = get_next_in_range (h, ACT_END, ACT_END); // 10
       if (ret)
         return ret;
       scheduler_phase = 5;

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -315,7 +315,7 @@ plugins_scheduler_t
 plugins_scheduler_init (const char *plugins_list, int autoload, int *error)
 {
   plugins_scheduler_t ret;
-
+  
   /* Fill our lists */
   ret = g_malloc0 (sizeof (*ret));
   *error = plugins_scheduler_enable (ret, plugins_list, autoload);
@@ -339,6 +339,8 @@ plugins_scheduler_count_active (plugins_scheduler_t sched)
     ret += g_slist_length (sched->list[i]);
   return ret;
 }
+
+
 
 static struct scheduler_plugin *
 plugins_next_unrun (GSList *plugins)

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -315,7 +315,7 @@ plugins_scheduler_t
 plugins_scheduler_init (const char *plugins_list, int autoload, int *error)
 {
   plugins_scheduler_t ret;
-  
+
   /* Fill our lists */
   ret = g_malloc0 (sizeof (*ret));
   *error = plugins_scheduler_enable (ret, plugins_list, autoload);
@@ -339,8 +339,6 @@ plugins_scheduler_count_active (plugins_scheduler_t sched)
     ret += g_slist_length (sched->list[i]);
   return ret;
 }
-
-
 
 static struct scheduler_plugin *
 plugins_next_unrun (GSList *plugins)
@@ -436,7 +434,7 @@ int
 current_category (int category, int set_category)
 {
   static int cur_cat = 0;
-  
+
   if (set_category)
     cur_cat = category;
 
@@ -449,19 +447,19 @@ plugins_scheduler_next (plugins_scheduler_t h, int phase_reset)
   struct scheduler_plugin *ret;
   static int scheduler_phase = 0;
   int set_cat = 1;
-      
+
   if (phase_reset)
     {
       scheduler_phase = 0;
       return NULL;
     }
-  
+
   if (h == NULL)
-      return NULL;
+    return NULL;
 
   if (scheduler_phase == 0)
     {
-      ret = get_next_in_range (h, ACT_INIT, ACT_INIT); //0
+      ret = get_next_in_range (h, ACT_INIT, ACT_INIT); // 0
       if (ret)
         return ret;
       scheduler_phase = 1;
@@ -469,7 +467,7 @@ plugins_scheduler_next (plugins_scheduler_t h, int phase_reset)
     }
   if (scheduler_phase <= 1)
     {
-      ret = get_next_in_range (h, ACT_SCANNER, ACT_SCANNER);//1
+      ret = get_next_in_range (h, ACT_SCANNER, ACT_SCANNER); // 1
       if (ret)
         return ret;
       scheduler_phase = 2;
@@ -477,7 +475,7 @@ plugins_scheduler_next (plugins_scheduler_t h, int phase_reset)
     }
   if (scheduler_phase <= 2)
     {
-      ret = get_next_in_range (h, ACT_SETTINGS, ACT_GATHER_INFO); //2-3
+      ret = get_next_in_range (h, ACT_SETTINGS, ACT_GATHER_INFO); // 2-3
       if (ret)
         return ret;
       scheduler_phase = 3;
@@ -485,7 +483,7 @@ plugins_scheduler_next (plugins_scheduler_t h, int phase_reset)
     }
   if (scheduler_phase <= 3)
     {
-      ret = get_next_in_range (h, ACT_ATTACK, ACT_FLOOD); //4-9
+      ret = get_next_in_range (h, ACT_ATTACK, ACT_FLOOD); // 4-9
       if (ret)
         return ret;
       scheduler_phase = 4;

--- a/src/pluginscheduler.c
+++ b/src/pluginscheduler.c
@@ -430,6 +430,17 @@ scheduler_phase_cleanup (plugins_scheduler_t sched, int start, int end)
   malloc_trim (0);
 }
 
+int
+current_category (int category, int set_category)
+{
+  static int cur_cat = 0;
+  
+  if (set_category)
+    cur_cat = category;
+
+  return cur_cat;
+}
+
 struct scheduler_plugin *
 plugins_scheduler_next (plugins_scheduler_t h)
 {

--- a/src/pluginscheduler.h
+++ b/src/pluginscheduler.h
@@ -51,7 +51,10 @@ typedef struct plugins_scheduler *plugins_scheduler_t;
 plugins_scheduler_t
 plugins_scheduler_init (const char *, int, int *);
 
-struct scheduler_plugin *plugins_scheduler_next (plugins_scheduler_t);
+int
+current_category (int, int);
+
+struct scheduler_plugin *plugins_scheduler_next (plugins_scheduler_t, int);
 
 int plugins_scheduler_count_active (plugins_scheduler_t);
 

--- a/src/pluginscheduler.h
+++ b/src/pluginscheduler.h
@@ -54,7 +54,8 @@ plugins_scheduler_init (const char *, int, int *);
 int
 current_category (int, int);
 
-struct scheduler_plugin *plugins_scheduler_next (plugins_scheduler_t, int);
+struct scheduler_plugin *
+plugins_scheduler_next (plugins_scheduler_t, int);
 
 int plugins_scheduler_count_active (plugins_scheduler_t);
 


### PR DESCRIPTION
**What**:
This a PoC to implement an alternative way to scan vhosts. The main idea is to detect vhosts first, identify which plugins must be run against vhosts and create a shorter plugin list. 
Currently, plugins are forked for each vhosts. This means that vhosts are scanned at plugin level, and the results are stored in the host kb.
This PoC present an scan alternative for vhosts, in which the vhosts are scanned at host process level. Once the plugins list for vhosts is done and the vhosts were detected, the host kb is duplicated for the vhosts, the shorter list of plugins is launched against the vhosts. Results are stored/sent to ospd, kb items are stored only in vhost kb, and once the vhost scan finished the vhost kb is delete and redis memory is release
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Some host have many vhosts. With current scanner, all data generated for vhosts is stored in the same host kb, and memory is released once the host and its vhosts have been scanned.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
