### PR TITLE
Add support for volatile keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.10] (unreleased)
 
 ### Added
+
+- Add support for volatile keys. [#682](https://github.com/greenbone/openvas/pull/682)
+
 ### Changed
 ### Removed
 ### Fixed

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -684,6 +684,57 @@ plug_set_key (struct script_infos *args, char *name, int type,
   plug_set_key_len (args, name, type, value, 0);
 }
 
+/**
+ * @brief Set volatile key with expire.
+ *
+ * @param args    Script infos.
+ * @param name    Key name.
+ * @param type    Key type.
+ * @param value   Key value.
+ * @param expire  Key expire in seconds.
+ * @param len     Len of value.
+ */
+void
+plug_set_key_len_volatile (struct script_infos *args, char *name, int type,
+                           const void *value, int expire, size_t len)
+{
+  kb_t kb = plug_get_kb (args);
+  int pos = 0; // Append the item on the right position of the list
+
+  if (name == NULL || value == NULL || expire == -1)
+    return;
+
+  if (type == ARG_STRING)
+    kb_add_str_unique_volatile (kb, name, value, expire, len, pos);
+  else if (type == ARG_INT)
+    kb_add_int_unique_volatile (kb, name, GPOINTER_TO_SIZE (value),
+                                GPOINTER_TO_SIZE (expire));
+  if (global_nasl_debug == 1)
+    {
+      if (type == ARG_STRING)
+        g_message ("set volatile key %s -> %s", name, (char *) value);
+      else if (type == ARG_INT)
+        g_message ("set volatile key %s -> %d", name,
+                   (int) GPOINTER_TO_SIZE (value));
+    }
+}
+
+/**
+ * @brief Set volatile key with expire.
+ *
+ * @param args  Script infos.
+ * @param name  Key name.
+ * @param type  Key type.
+ * @param value Key value.
+ * @param expire Key expire in seconds.
+ */
+void
+plug_set_key_volatile (struct script_infos *args, char *name, int type,
+                       const void *value, int expire)
+{
+  plug_set_key_len_volatile (args, name, type, value, expire, 0);
+}
+
 void
 plug_replace_key_len (struct script_infos *args, char *name, int type,
                       void *value, size_t len)

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -142,6 +142,13 @@ void
 plug_set_key_len (struct script_infos *, char *, int, const void *, size_t);
 
 void
+plug_set_key_volatile (struct script_infos *, char *, int, const void *, int);
+
+void
+plug_set_key_len_volatile (struct script_infos *, char *, int, const void *,
+                           int, size_t);
+
+void
 plug_replace_key (struct script_infos *, char *, int, void *);
 
 void


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Add support for volatile keys. Add timeout in seconds for keys to expire.
Depends on https://github.com/greenbone/gvm-libs/pull/460.

**Why**:

<!-- Why are these changes necessary? -->

Can be used in combination with redis settings such as `maxmemory` and `maxmemory-policy` to have a more options in handling memory issues in regards to redis.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Stop ospd-openvas if running. 
Do a flushall in redis. `sudo redis-cli -s /run/redis-openvas/redis.sock  FLUSHALL`)
Start nasl script which places keys with expire in redis. `sudo openvas-nasl -X -i <installpath>/var/lib/openvas/plugins/ -t 127.0.0.1 add_volatile_keys.nasl`

```
include("misc_func.inc"); # for rand_str()

i = 0;
key  = "VOLATILE";
value = rand_str(length: 100000);
for (; i<100; i++) {
    set_kb_item(name: key+i, value:value+i, expire:1000000);
}

sleep(10000);
exit(0);
```

Check number of keys in db. `sudo redis-cli -s /run/redis-openvas/redis.sock -n 1 DBSIZE`. Should be 100.
Set maxmemory `config set maxmemory 15728640` in redis.
Set maxmemory-policy `Config set maxmemory-policy volatile-lru` in redis.
Start VT2 which places keys without expire set in other terminal. `sudo openvas-nasl -X -i <installpath>/var/lib/openvas/plugins/ -t 127.0.0.1 persistent_keys.nasl`.

```
include("misc_func.inc"); # for rand_str()

i = 0;
key  = "PERSISTENT";
value = rand_str(length: 100000);
for (; i<100; i++ ) {
    set_kb_item(name: key+i, value:value);
}

sleep(10000);
```

When maxmemory is hit the keys with expire set will get removed by redis to make space for new keys. Check number of keys in db 1 and 2. db 2 should have 100 keys while db 1 should have less.
This way we can make sure which keys can be removed when memory limits are reached.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
