### PR TITLE
Fix greenbone-nvt-sync on (at least) FreeBSD

### DIFF
--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -202,7 +202,7 @@ if [ -z "$TMPDIR" ]; then
   SYNC_TMP_DIR=/tmp
   # If we have mktemp, create a temporary dir (safer)
   if [ -n "`which mktemp`" ]; then
-    SYNC_TMP_DIR=`mktemp -t -d greenbone-nvt-sync.XXXXXXXXXX` || { echo "ERROR: Cannot create temporary directory for file download" >&2; exit 1 ; }
+    SYNC_TMP_DIR=`mktemp -d -t greenbone-nvt-sync.XXXXXXXXXX` || { echo "ERROR: Cannot create temporary directory for file download" >&2; exit 1 ; }
     trap "rm -rf $SYNC_TMP_DIR" EXIT HUP INT TRAP TERM
   fi
 else
@@ -512,7 +512,7 @@ do_sync ()
     log_write "Feed is already current, skipping synchronization."
   else
     (
-      chmod +660 $OPENVAS_FEED_LOCK_PATH
+      chmod 660 $OPENVAS_FEED_LOCK_PATH
       flock -n 9
       if [ $? -eq 1 ] ; then
           log_warning "Another process related to the feed update is already running"


### PR DESCRIPTION
Two error messages when running greenbone-nvt-sync on FreeBSD.  (default shell, fresh install in an iocage)
- "chmod: invalid file mode: +660"
        chmod uses or numeric values or the +/- sign and symbolic notation.  
- "exit: greenbone-nvt-sync.vX4hC9RFi9: not found"
        mktemp [-d] [-t prefix] should be used

After these changes the script does not return errors and "md manage:WARNING:2021-04-11 17h41.07 UTC:85430: /usr/local/bin/greenbone-nvt-sync returned a non-zero exit code." is no longer present in the log files.