### PR TITLE
Fix SIGSEGV when no best route is found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix gcc-9 and gcc-10 warnings. [#655](https://github.com/greenbone/openvas/pull/655)
 - Fix double free in nasl_cert_query. [#658](https://github.com/greenbone/openvas/pull/658)
 - Fix message to the client if there is a iface problem. [#695](https://github.com/greenbone/openvas/pull/695)
+- Fix SIGSEGV when no best route is found. [#702](https://github.com/greenbone/openvas/pull/702)
 
 ### Removed
 - Remove code from the openvas daemon era. Do not flushall redis. [#689](https://github.com/greenbone/openvas/pull/689)

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -1245,13 +1245,26 @@ routethrough (struct in_addr *dest, struct in_addr *source)
             }
         }
     }
+
   /* Set source */
   if (source)
     {
+      /* Source address is given */
       if (src.s_addr != INADDR_ANY)
         source->s_addr = src.s_addr;
-      else
+      /* Source address is INADDR_ANY and there is a good route */
+      else if (best_match != -1)
         source->s_addr = myroutes[best_match].dev->addr.s_addr;
+      /* No best route found and no default */
+      else
+        {
+          /* Assigned first route in the table */
+          if (myroutes[0].dev)
+            source->s_addr = myroutes[0].dev->addr.s_addr;
+          /* or any */
+          else
+            source->s_addr = INADDR_ANY;
+        }
     }
 
   if (best_match != -1)

--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -1260,7 +1260,10 @@ routethrough (struct in_addr *dest, struct in_addr *source)
         {
           /* Assigned first route in the table */
           if (myroutes[0].dev)
-            source->s_addr = myroutes[0].dev->addr.s_addr;
+            {
+              source->s_addr = myroutes[0].dev->addr.s_addr;
+              best_match = 0;
+            }
           /* or any */
           else
             source->s_addr = INADDR_ANY;


### PR DESCRIPTION
**What**:
Fix SIGSEGV when no best route is found.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some case there is no a best route, and no source route can be assigned.
This fix set source with the address in the first route found in the route table
or 0.0.0.0 in case an empty route table.

There is no issue with IPv6, since there is no IPv6 broadcast address.
<!-- Why are these changes necessary? -->

**How**:
Set veth in a new namespace and run the following script (which sends to broadcast address).

```
sudo ip netns exec scan1 openvas-nasl -X -d -i /home/jnicola/install/var/lib/openvas/plugins/ -t 10.1.1.3 /home/jnicola/install/var/lib/openvas/plugins/gb_netgear_nsdp_detect.nasl --kb="keys/islocalnet=1"
```
Without the patch, the command above SIGSEGVs 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
