### PR TITLE
Don't use g_error. Use g_warning instead and let the scanner to continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Replace bogus data with a better message and the vendor. [#665](https://github.com/greenbone/openvas/pull/665)
 - Improve log message for WMI connect failed or missing WMI support. [#670](https://github.com/greenbone/openvas/pull/670)
+- Don't use g_error. Use g_warning instead and let the scanner to continue. [#710](https://github.com/greenbone/openvas/pull/710)
 
 ### Fixed
 - Fix issues discovered with clang compiler. [#654](https://github.com/greenbone/openvas/pull/654)

--- a/src/attack.c
+++ b/src/attack.c
@@ -1232,8 +1232,8 @@ attack_network (struct scan_globals *globals)
           if (fork_retries > MAX_FORK_RETRIES)
             {
               /* Forking failed - we go to the wait queue. */
-              g_debug ("fork() failed - %s. %s won't be tested",
-                       strerror (errno), host_str);
+              g_warning ("fork() failed - %s. %s won't be tested",
+                         strerror (errno), host_str);
               g_free (host_str);
               goto stop;
             }

--- a/src/processes.c
+++ b/src/processes.c
@@ -111,6 +111,6 @@ create_process (process_func_t function, void *argument)
       exit (0);
     }
   if (pid < 0)
-    g_error ("Error : could not fork ! Error : %s", strerror (errno));
+    g_warning ("Error : could not fork ! Error : %s", strerror (errno));
   return pid;
 }


### PR DESCRIPTION
**What**:
Don't use g_error. Use g_warning instead and let the scanner to continue
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Error messages are always fatal, resulting in a call to G_BREAKPOINT() to terminate the application. This function will result in a core dump; don't use it for errors you expect.

For more information see:
https://developer.gnome.org/glib/stable/glib-Message-Logging.html#g-error

<!-- Why are these changes necessary? -->

**How**:
During a running scan, run a program which consume the whole free memory. The scanner will not fork() because no memory available.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
