### PR TITLE
Update default log config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 ### Changed
+- Update default log config [#711][(https://github.com/greenbone/openvas-scanner/pull/711)
+
 ### Fixed
 ### Removed
 

--- a/src/openvas_log_conf.cmake_in
+++ b/src/openvas_log_conf.cmake_in
@@ -10,7 +10,35 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/openvas.log
 level=127
 
-[alive scan]
+[lib  misc]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/openvas.log
+level=127
+
+[lib  nasl]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/openvas.log
+level=127
+
+[libgvm base]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/openvas.log
+level=127
+
+[libgvm boreas]
+prepend=%t %s %p
+separator=:
+prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
+file=${GVM_LOG_DIR}/openvas.log
+level=127
+
+[libgvm util]
 prepend=%t %s %p
 separator=:
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z


### PR DESCRIPTION
**What**:
The config now contains all the used log domains including "lib  misc",
"lib  nasl" and the new "libgvm" ones. This includes changing
"alive scan" to "libgvm boreas".

**Why**:
To make the config match the gvm-libs changes from greenbone/gvm-libs#479 and to make it obvious which log domains are actually used.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
