### PR TITLE
Xref check arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add support for volatile keys. [#682](https://github.com/greenbone/openvas/pull/682)
+- Extend nasl lint to check Syntax for Arguments for script_xref() function. [#714](https://github.com/greenbone/openvas/pull/714)
 
 ### Changed
 ### Fixed

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -373,6 +373,7 @@ validate_script_xref(lex_ctxt *lexic, tree_cell *st)
 tree_cell *
 validate_function(lex_ctxt *lexic, tree_cell *st)
 {
+  lexic->line_nb = st->line_nb;
   if(st != NULL)
     {
       if(!g_strcmp0(st->x.str_val, "script_xref"))

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -297,6 +297,95 @@ nasl_lint_def (lex_ctxt *lexic, tree_cell *st, int lint_mode,
 }
 
 /**
+ * @brief Checks if a given Arguments is within a given Argument List
+ * 
+ * @param st Argument List, should be of Type NODE_ARG
+ * @param name Name of the Argument to search for
+ * @return char* Value of the given Argument name
+ */
+char *
+get_argument_by_name(tree_cell *st, char *name)
+{
+  if(st == NULL)
+    return NULL;
+  
+  if(st->type != NODE_ARG)
+    return NULL;
+
+  tree_cell *cp;
+  for(cp = st; cp != NULL; cp = cp->link[1])
+  {
+    if(!g_strcmp0(cp->x.str_val, name))
+      return cp->link[0]->x.str_val;
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief Validates parameters of a script_xref function call
+ * 
+ * @param st Function Parameters should be of type NODE_ARG
+ * @return tree_cell* 
+ */
+tree_cell *
+validate_script_xref(lex_ctxt *lexic, tree_cell *st)
+{
+  char *name = get_argument_by_name(st, "name");
+  char *value = get_argument_by_name(st, "value");
+  char *csv = get_argument_by_name(st, "csv");
+
+  if (((value == NULL) && (csv == NULL)) || name == NULL)
+    {
+      nasl_perror (lexic,
+                   "script_xref() syntax error - should be"
+                   " script_xref(name:<name>, value:<value>) or"
+                   " script_xref(name:<name>, value:<value>, csv:<CSVs>) or"
+                   " script_xref(name:<name>, csv:<CSVs>)\n");
+      if (name == NULL)
+        {
+          nasl_perror (lexic, "  <name> is empty\n");
+        }
+      else
+        {
+          nasl_perror (lexic, "  <name> is %s\n", name);
+        }
+      if ((value == NULL) && (csv == NULL))
+        {
+          nasl_perror (lexic, "  <value> and <csv> is empty)\n");
+        }
+      else
+        {
+          nasl_perror (lexic, "  <value> is %s\n)", value);
+          nasl_perror (lexic, "  <csv> is %s\n)", csv);
+        }
+      return NULL;
+    }
+  return FAKE_CELL;
+}
+
+/**
+ * @brief Check if a function has valid parameters
+ * 
+ * @param st 
+ * @return tree_cell* NULL if it is invalid, FAKE_CELL if it is valid
+ */
+tree_cell *
+validate_function(lex_ctxt *lexic, tree_cell *st)
+{
+  if(st != NULL)
+    {
+      if(!g_strcmp0(st->x.str_val, "script_xref"))
+        return validate_script_xref(lexic, st->link[0]);
+    }
+  else
+    return NULL;
+
+
+  return FAKE_CELL;
+}
+
+/**
  * @brief Check if a called function was defined.
  */
 tree_cell *
@@ -350,6 +439,12 @@ nasl_lint_call (lex_ctxt *lexic, tree_cell *st, GHashTable **include_files,
                 nasl_perror (lexic, "Undefined function '%s'\n", st->x.str_val);
                 return NULL;
               }
+        }
+      else
+        {
+          // Check if function parameters are right
+          if(validate_function(lexic, st) == NULL)
+            return NULL;
         }
       if (*include_files && st->x.str_val)
         {

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -369,7 +369,7 @@ validate_script_xref (lex_ctxt *lexic, tree_cell *st)
  * @brief Check if a function has valid parameters
  *
  * @param lexic
- * @param st 
+ * @param st
  * @return tree_cell * NULL if it is invalid, FAKE_CELL if it is valid
  */
 tree_cell *

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -298,42 +298,43 @@ nasl_lint_def (lex_ctxt *lexic, tree_cell *st, int lint_mode,
 
 /**
  * @brief Checks if a given Arguments is within a given Argument List
- * 
+ *
  * @param st Argument List, should be of Type NODE_ARG
  * @param name Name of the Argument to search for
  * @return char* Value of the given Argument name
  */
 char *
-get_argument_by_name(tree_cell *st, char *name)
+get_argument_by_name (tree_cell *st, char *name)
 {
-  if(st == NULL)
+  if (st == NULL)
     return NULL;
-  
-  if(st->type != NODE_ARG)
+
+  if (st->type != NODE_ARG)
     return NULL;
 
   tree_cell *cp;
-  for(cp = st; cp != NULL; cp = cp->link[1])
-  {
-    if(!g_strcmp0(cp->x.str_val, name))
-      return cp->link[0]->x.str_val;
-  }
+  for (cp = st; cp != NULL; cp = cp->link[1])
+    {
+      if (!g_strcmp0 (cp->x.str_val, name))
+        return cp->link[0]->x.str_val;
+    }
 
   return NULL;
 }
 
 /**
  * @brief Validates parameters of a script_xref function call
- * 
+ *
+ * @param lexic
  * @param st Function Parameters should be of type NODE_ARG
- * @return tree_cell* 
+ * @return tree_cell*
  */
 tree_cell *
-validate_script_xref(lex_ctxt *lexic, tree_cell *st)
+validate_script_xref (lex_ctxt *lexic, tree_cell *st)
 {
-  char *name = get_argument_by_name(st, "name");
-  char *value = get_argument_by_name(st, "value");
-  char *csv = get_argument_by_name(st, "csv");
+  char *name = get_argument_by_name (st, "name");
+  char *value = get_argument_by_name (st, "value");
+  char *csv = get_argument_by_name (st, "csv");
 
   if (((value == NULL) && (csv == NULL)) || name == NULL)
     {
@@ -366,22 +367,22 @@ validate_script_xref(lex_ctxt *lexic, tree_cell *st)
 
 /**
  * @brief Check if a function has valid parameters
- * 
+ *
+ * @param lexic
  * @param st 
- * @return tree_cell* NULL if it is invalid, FAKE_CELL if it is valid
+ * @return tree_cell * NULL if it is invalid, FAKE_CELL if it is valid
  */
 tree_cell *
-validate_function(lex_ctxt *lexic, tree_cell *st)
+validate_function (lex_ctxt *lexic, tree_cell *st)
 {
   lexic->line_nb = st->line_nb;
-  if(st != NULL)
+  if (st != NULL)
     {
-      if(!g_strcmp0(st->x.str_val, "script_xref"))
-        return validate_script_xref(lexic, st->link[0]);
+      if (!g_strcmp0 (st->x.str_val, "script_xref"))
+        return validate_script_xref (lexic, st->link[0]);
     }
   else
     return NULL;
-
 
   return FAKE_CELL;
 }
@@ -444,7 +445,7 @@ nasl_lint_call (lex_ctxt *lexic, tree_cell *st, GHashTable **include_files,
       else
         {
           // Check if function parameters are right
-          if(validate_function(lexic, st) == NULL)
+          if (validate_function (lexic, st) == NULL)
             return NULL;
         }
       if (*include_files && st->x.str_val)


### PR DESCRIPTION
**What**:
Fixed NASL-linter to catch Syntax error when wrong Arguments were used with script_xref
example:
script_xref(name: "URL", valie: "[https://www.wordfence.com/blog/2017/10/zero-day-vulnerability-ultimate-form-builder-lite/"
gave no error message for wrong spelling of value

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: 
Linter was not able to catch a Syntax Error, but the scanner itself does

<!-- Why are these changes necessary? -->

**How**:
I tested the case described in the Issue so that a error message is now shown if one of the parameters is missing or misspelled. No error message is shown if everything is correct.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
