### PR TITLE
Fix hosts count when reverse_lookup_only preferences is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix double free in nasl_cert_query. [#658](https://github.com/greenbone/openvas/pull/658)
 - Fix message to the client if there is a iface problem. [#695](https://github.com/greenbone/openvas/pull/695)
 - Fix SIGSEGV when no best route is found. [#702](https://github.com/greenbone/openvas/pull/702)
+- Fix host count when reverse_lookup_only is enabled. [#715](https://github.com/greenbone/openvas/pull/715)
 
 ### Removed
 - Remove code from the openvas daemon era. Do not flushall redis. [#689](https://github.com/greenbone/openvas/pull/689)

--- a/src/attack.c
+++ b/src/attack.c
@@ -731,13 +731,30 @@ attack_start (struct attack_start_args *args)
 }
 
 static void
-apply_hosts_preferences (gvm_hosts_t *hosts)
+apply_hosts_excluded (gvm_hosts_t *hosts)
 {
-  const char *ordering = prefs_get ("hosts_ordering"),
-             *exclude_hosts = prefs_get ("exclude_hosts");
+  const char *exclude_hosts = prefs_get ("exclude_hosts");
+
+  /* Exclude hosts ? */
+  if (exclude_hosts)
+    {
+      /* Exclude hosts, resolving hostnames. */
+      int ret = gvm_hosts_exclude (hosts, exclude_hosts);
+
+      if (ret > 0)
+        g_message ("exclude_hosts: Skipped %d host(s).", ret);
+      if (ret < 0)
+        g_message ("exclude_hosts: Error.");
+    }
 
   if (hosts == NULL)
     return;
+}
+
+static void
+apply_hosts_preferences_ordering (gvm_hosts_t *hosts)
+{
+  const char *ordering = prefs_get ("hosts_ordering");
 
   /* Hosts ordering strategy: sequential, random, reversed... */
   if (ordering)
@@ -755,19 +772,11 @@ apply_hosts_preferences (gvm_hosts_t *hosts)
     }
   else
     g_debug ("hosts_ordering: Sequential.");
+}
 
-  /* Exclude hosts ? */
-  if (exclude_hosts)
-    {
-      /* Exclude hosts, resolving hostnames. */
-      int ret = gvm_hosts_exclude (hosts, exclude_hosts);
-
-      if (ret > 0)
-        g_message ("exclude_hosts: Skipped %d host(s).", ret);
-      if (ret < 0)
-        g_message ("exclude_hosts: Error.");
-    }
-
+static void
+apply_hosts_reverse_lookup_preferences (gvm_hosts_t *hosts)
+{
   /* Reverse-lookup unify ? */
   if (prefs_get_bool ("reverse_lookup_unify"))
     g_debug ("reverse_lookup_unify: Skipped %d host(s).",
@@ -1118,6 +1127,10 @@ attack_network (struct scan_globals *globals)
     }
   g_slist_free_full (unresolved, g_free);
 
+  /* Apply Hosts preferences. */
+  apply_hosts_preferences_ordering (hosts);
+  apply_hosts_reverse_lookup_preferences (hosts);
+
   /* Send the hosts count to the client, after removing duplicated and
    * unresolved hosts.*/
   sprintf (buf, "%d", gvm_hosts_count (hosts));
@@ -1125,8 +1138,7 @@ attack_network (struct scan_globals *globals)
   message_to_client (main_kb, buf, NULL, NULL, "HOSTS_COUNT");
   kb_lnk_reset (main_kb);
 
-  /* Apply Hosts preferences. */
-  apply_hosts_preferences (hosts);
+  apply_hosts_excluded (hosts);
 
   /* Don't start if the provided interface is unauthorized. */
   if (apply_source_iface_preference () != 0)

--- a/src/attack.c
+++ b/src/attack.c
@@ -746,9 +746,6 @@ apply_hosts_excluded (gvm_hosts_t *hosts)
       if (ret < 0)
         g_message ("exclude_hosts: Error.");
     }
-
-  if (hosts == NULL)
-    return;
 }
 
 static void


### PR DESCRIPTION
**What**:
Fix hosts count when reverse_lookup_only preferences is enabled.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When this option is enabled, hosts without a hostname are removed from the host list, which changes the host count.
As this differs from the host expected by ospd-openvas, finishes the scan as INTERRUPTED.

<!-- Why are these changes necessary? -->

**How**:
Run a scan (I tested via gvm-tools) with reverse_lookup_only enabled. Also, I added an excluded host, as this part of the code was modified as well. Ensure that some hosts in the target list can be reversed-lookup'ed.

gvm-cli --protocol OSP --timeout 120 socket --socketpath=/home/jnicola/install/var/run/ospd/openvas.sock --xml "<start_scan scan_id='829097a9-85d5-4bb8-bac0-e64c362b2836'><targets><target><hosts>192.168.0.0/24</hosts><exclude_hosts>192.168.0.10</exclude_hosts><finished_hosts/><ports>22</ports><credentials><credential port='22' service='ssh' type='up'><username>test</username><password>test</password></credential></credentials><reverse_lookup_only>1</reverse_lookup_only></target></targets><scanner_params></scanner_params><vt_selection><vt_single id='1.3.6.1.4.1.25623.1.0.14259'/></vt_selection></start_scan>" |xmlstarlet fo

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
