### PR TITLE
ignore script_bugtraq_id() and warn in linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Extend nasl lint to check Syntax for Arguments for script_xref() function. [#714](https://github.com/greenbone/openvas/pull/714)
 
 ### Changed
+- function script_bugtraq_id getting skipped, linter warns. [#724](https://github.com/greenbone/openvas/pull/724)
 ### Fixed
 ### Removed
 

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -366,7 +366,7 @@ validate_script_xref (lex_ctxt *lexic, tree_cell *st)
 }
 
 /**
- * @brief Check if a function has valid parameters
+ * @brief Validate functions
  *
  * @param lexic
  * @param st
@@ -380,6 +380,14 @@ validate_function (lex_ctxt *lexic, tree_cell *st)
     {
       if (!g_strcmp0 (st->x.str_val, "script_xref"))
         return validate_script_xref (lexic, st->link[0]);
+      if (!g_strcmp0 (st->x.str_val, "script_bugtraq_id"))
+        {
+          nasl_perror (lexic,
+                       "WARNING: use of unsupported function"
+                       " script_bugtraq_id() - please use"
+                       " script_xref(name:\"URL\", value:\"\") instead.\n");
+          return FAKE_CELL;
+        }
     }
   else
     return NULL;

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -83,7 +83,9 @@ static init_func libfuncs[] = {
   {"script_get_preference_file_location", script_get_preference_file_location},
   {"script_oid", script_oid},
   {"script_cve_id", script_cve_id},
-  {"script_bugtraq_id", script_bugtraq_id},
+  {"script_bugtraq_id",
+   script_bugtraq_id_dummy}, // Replace orginal script_bugtraq_id_dummy to
+                             // ignore it
   {"script_xref", script_xref},
   {"script_tag", script_tag},
   {"vendor_version", nasl_vendor_version},

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -84,7 +84,7 @@ static init_func libfuncs[] = {
   {"script_oid", script_oid},
   {"script_cve_id", script_cve_id},
   {"script_bugtraq_id",
-   script_bugtraq_id_dummy}, // Replace orginal script_bugtraq_id_dummy to
+   script_bugtraq_id_dummy}, // Replace orginal script_bugtraq_id to
                              // ignore it
   {"script_xref", script_xref},
   {"script_tag", script_tag},

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -134,6 +134,12 @@ script_bugtraq_id (lex_ctxt *lexic)
   return FAKE_CELL;
 }
 
+tree_cell *
+script_bugtraq_id_dummy ()
+{
+  return FAKE_CELL;
+}
+
 /**
  * @brief Add a cross reference to the meta data.
  *

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -34,6 +34,9 @@ tree_cell *
 script_bugtraq_id (lex_ctxt *);
 
 tree_cell *
+script_bugtraq_id_dummy ();
+
+tree_cell *
 script_xref (lex_ctxt *);
 
 tree_cell *


### PR DESCRIPTION
**What**:
The nasl-function script_bugtraq_id() is now getting ignored. The linter warns if it is used.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
As securityfocus.com has lost it's value / importance these days it doesn't make much sense to have a dedicated script tag just for this page which isn't a clickable link anyway. In addition users probably don't know what the "BID" in the reference is as well.

<!-- Why are these changes necessary? -->

**How**:
Changed the pointer to the script_bugtraq_id() function to a dummy function which does nothing, so it skips it. Added a warning for the linter in case the function appears. Tested it with a custom script which contains the function. For openvas-nasl nothing happened and for openvas-nasl-linter a warning was shown on the command line.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
