### PR TITLE
Use host from the orignal hosts list when boreas is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update default log config [#711](https://github.com/greenbone/openvas-scanner/pull/711)
 
 ### Fixed
+- Use host from the orignal hosts list when boreas is enabled. [#725](https://github.com/greenbone/openvas/pull/725)
+
 ### Removed
 
 [21.04.1]: https://github.com/greenbone/openvas/compare/v21.4.0...openvas-21.04

--- a/src/attack.c
+++ b/src/attack.c
@@ -1169,6 +1169,7 @@ attack_network (struct scan_globals *globals)
       gboolean ad_finished = FALSE;
       int err;
       pthread_t tid;
+      struct in6_addr tmpaddr;
 
       /* Reset the iterator. */
       hosts->current = 0;
@@ -1187,11 +1188,16 @@ attack_network (struct scan_globals *globals)
         {
           fork_sleep (1);
         }
-      if (host)
-        g_debug ("%s: Get first host to test from Queue. This host is used for "
-                 "initialising the alive_hosts_list.",
-                 __func__);
 
+      if (gvm_host_get_addr6 (host, &tmpaddr) == 0)
+        host = gvm_host_find_in_hosts (host, &tmpaddr, hosts);
+      if (host)
+        {
+          g_debug (
+            "%s: Get first host to test from Queue. This host is used for "
+            "initialising the alive_hosts_list.",
+            __func__);
+        }
       alive_hosts_list = gvm_hosts_new (gvm_host_value_str (host));
     }
 
@@ -1280,6 +1286,8 @@ attack_network (struct scan_globals *globals)
 
       if (test_alive_hosts_only)
         {
+          struct in6_addr tmpaddr;
+
           while (1)
             {
               /* Boolean signalling if alive detection finished. */
@@ -1321,8 +1329,14 @@ attack_network (struct scan_globals *globals)
               else
                 break;
             }
+
+          if (gvm_host_get_addr6 (host, &tmpaddr) == 0)
+            host = gvm_host_find_in_hosts (host, &tmpaddr, hosts);
+
           if (host)
-            gvm_hosts_add (alive_hosts_list, host);
+            {
+              gvm_hosts_add (alive_hosts_list, host);
+            }
           else
             g_debug ("%s: got NULL host, stop/finish scan", __func__);
         }


### PR DESCRIPTION
Depends on greenbone/gvm-libs#490

**What**:
Use host from the orignal hosts list when boreas is enabled
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When boreas is enabled, a new host element is created with only the IP address,
while the hostname was lost during the alive detection.

<!-- Why are these changes necessary? -->

**How**:
Find a host which has an alias, which resolves to an IP. The ip reverse-lookup to another hostname/vhost. eg www.google.com
it resolves to 142.250.184.196, and the IP reverse-lookup to fra24s11-in-f4.1e100.net

Then start a scan against it
``` xml
start_scan scan_id="829097a9-85d5-4bb8-bac0-e64c362b2836">
  <targets>
    <target>
      <hosts>www.google.com</hosts>
      <exclude_hosts/>
      <finished_hosts/>
      <ports>22</ports>
      </credentials>
    </target>
  </targets>
  <scanner_params>
    <test_alive_hosts_only>1</test_alive_hosts_only>
    <expand_vhosts>1</expand_vhosts>
  </scanner_params>
  <vt_selection>
    <vt_single id="1.3.6.1.4.1.25623.1.0.90022"/>
  </vt_selection>
</start_scan>
```

without the patch you see:
```
sd   main:MESSAGE:2021-05-03 14h05.27 utc:25679: Vulnerability scan 829097a9-85d5-4bb8-bac0-e64c362b2836 started for host: 172.217.22.196 (Vhosts: 172.217.22.196, muc11s01-in-f4.1e100.net)
```
with the patch you see, and the original hostname (the one in the target) is used as vhosts as well:

```
sd   main:MESSAGE:2021-05-03 14h10.58 utc:25911: Vulnerability scan 829097a9-85d5-4bb8-bac0-e64c362b2836 started for host: 172.217.22.196 (Vhosts: 172.217.22.196, muc11s01-in-f4.1e100.net, www.google.com)
```


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ X] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
