### PR TITLE
Add deprecation warning for source_iface settings which will be removed with 21.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Improve nasl linter to catch more cases of undeclared variables. [#728][(https://github.com/greenbone/openvas-scanner/pull/728)
+- Add deprecation warning for source_iface related settings which will be removed with the 21.10 release. [#732][(https://github.com/greenbone/openvas-scanner/pull/732)
 
 ### Changed
 - Update default log config [#711](https://github.com/greenbone/openvas-scanner/pull/711)

--- a/src/attack.c
+++ b/src/attack.c
@@ -627,6 +627,47 @@ vhosts_to_str (GSList *list)
   return g_string_free (string, FALSE);
 }
 
+/**
+ * @brief Check if any deprecated prefs are in pref table and print warning.
+ *
+ * @return True if deprecated prefs are in preference table. Else False.
+ */
+gboolean
+check_deprecated_prefs ()
+{
+  gboolean ret = FALSE;
+
+  const gchar *source_iface = prefs_get ("source_iface");
+  const gchar *ifaces_allow = prefs_get ("ifaces_allow");
+  const gchar *ifaces_deny = prefs_get ("ifaces_deny");
+  const gchar *sys_ifaces_allow = prefs_get ("sys_ifaces_allow");
+  const gchar *sys_ifaces_deny = prefs_get ("sys_ifaces_deny");
+
+  if (source_iface || ifaces_allow || ifaces_deny || sys_ifaces_allow
+      || sys_ifaces_deny)
+    {
+      ret = TRUE;
+      kb_t main_kb = NULL;
+      gchar *msg = NULL;
+
+      msg = g_strdup_printf (
+        "The following provided settings are deprecated since the 21.10 "
+        "release and will be ignored: %s%s%s%s%s",
+        source_iface ? "source_iface (task setting) " : "",
+        ifaces_allow ? "ifaces_allow (user setting) " : "",
+        ifaces_deny ? "ifaces_deny (user setting) " : "",
+        sys_ifaces_allow ? "sys_ifaces_allow (scanner only setting) " : "",
+        sys_ifaces_deny ? "sys_ifaces_deny (scanner only setting)" : "");
+      g_warning ("%s: %s", __func__, msg);
+
+      connect_main_kb (&main_kb);
+      message_to_client (main_kb, msg, NULL, NULL, "ERRMSG");
+      kb_lnk_reset (main_kb);
+      g_free (msg);
+    }
+  return ret;
+}
+
 /*
  * Check if a scan is authorized on a host.
  *
@@ -1048,6 +1089,8 @@ attack_network (struct scan_globals *globals)
   kb_t host_kb, main_kb;
   GSList *unresolved;
   char buf[96];
+
+  check_deprecated_prefs ();
 
   gboolean test_alive_hosts_only = prefs_get_bool ("test_alive_hosts_only");
   gvm_hosts_t *alive_hosts_list = NULL;

--- a/src/attack.c
+++ b/src/attack.c
@@ -651,8 +651,8 @@ check_deprecated_prefs ()
       gchar *msg = NULL;
 
       msg = g_strdup_printf (
-        "The following provided settings are deprecated since the 21.10 "
-        "release and will be ignored: %s%s%s%s%s",
+        "The following provided settings are deprecated and will be ignored "
+        "starting with the upcoming release 21.10: %s%s%s%s%s",
         source_iface ? "source_iface (task setting) " : "",
         ifaces_allow ? "ifaces_allow (user setting) " : "",
         ifaces_deny ? "ifaces_deny (user setting) " : "",

--- a/src/attack.c
+++ b/src/attack.c
@@ -629,14 +629,10 @@ vhosts_to_str (GSList *list)
 
 /**
  * @brief Check if any deprecated prefs are in pref table and print warning.
- *
- * @return True if deprecated prefs are in preference table. Else False.
  */
-gboolean
+static void
 check_deprecated_prefs ()
 {
-  gboolean ret = FALSE;
-
   const gchar *source_iface = prefs_get ("source_iface");
   const gchar *ifaces_allow = prefs_get ("ifaces_allow");
   const gchar *ifaces_deny = prefs_get ("ifaces_deny");
@@ -646,7 +642,6 @@ check_deprecated_prefs ()
   if (source_iface || ifaces_allow || ifaces_deny || sys_ifaces_allow
       || sys_ifaces_deny)
     {
-      ret = TRUE;
       kb_t main_kb = NULL;
       gchar *msg = NULL;
 
@@ -665,7 +660,6 @@ check_deprecated_prefs ()
       kb_lnk_reset (main_kb);
       g_free (msg);
     }
-  return ret;
 }
 
 /*


### PR DESCRIPTION
**What**:

Add deprecation warning for source_iface settings which will be removed with 21.10 release.

related: greenbone/openvas-scanner#730

**Why**:

<!-- Why are these changes necessary? -->

To warn users about upcoming changes.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Add options sys_ifaces_allow and sys_ifaces_deny to the openvas conf file and start a small scan via gvm-cli with options:

        <scanner_params>\
            <source_iface>enp0s8</source_iface>\
            <ifaces_deny>enp0s8</ifaces_deny>\
            <ifaces_allow>foo</ifaces_allow>\
        </scanner_params>\

In the results the following error result will appear: The following provided settings are deprecated and will be ignored starting with the upcoming release 21.10: source_iface (task setting) ifaces_ allow (user setting) ifaces_deny (user setting) sys_ifaces_allow (scanner only setting)sys_ifaces_deny (scanner only setting)

The scan will stop in the interruped status with the above test.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
