### PR TITLE
Initialize the the kb to store results for openvas-nasl.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Use host from the orignal hosts list when boreas is enabled. [#725](https://github.com/greenbone/openvas/pull/725)
+- Initialize the the kb to store results for openvas-nasl [#735](https://github.com/greenbone/openvas/pull/735)
 
 ### Removed
 

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -81,6 +81,7 @@ init (struct in6_addr *ip, GSList *vhosts, kb_t kb)
 
   infos->standalone = 1;
   infos->key = kb;
+  infos->results = kb;
   infos->ip = ip;
   infos->vhosts = vhosts;
   if (prefs_get_bool ("test_empty_vhost"))


### PR DESCRIPTION
**What**:
Initialize the the kb to store results for openvas-nasl.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If not initialized, openvas-nasl can not store results
<!-- Why are these changes necessary? -->

**How**:
run a script with openvas-nasl

`openvas-nasl -X -B -d -i /home/juan/install/var/lib/openvas/plugins -t www.google.com find_service.nasl --kb="Ports/tcp/443=1"`

without the patch you should see an assertion error:
```
$ openvas-nasl -X -B -d -i /home/juan/install/var/lib/openvas/plugins -t www.google.com find_service.nasl --kb="Ports/tcp/443=1"
lib  misc-Message: 02:41:50.701: replace key FindService/CnxTime1000/443 -> 95
lib  misc-Message: 02:41:50.701: set key Transports/TCP/443 -> 9
openvas-nasl: /home/juan/install/include/gvm/util/kb.h:395: kb_item_push_str: Assertion `kb' failed.
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
