### PR TITLE
Add JSON support for result strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for volatile keys. [#682](https://github.com/greenbone/openvas/pull/682)
 - Extend nasl lint to check Syntax for Arguments for script_xref() function. [#714](https://github.com/greenbone/openvas/pull/714)
 - Recheck alive status of host with specified amount of NVT timeouts. [#729](https://github.com/greenbone/openvas/pull/729)
+- Add json-glib support for creating JSON result strings. [#739](https://github.com/greenbone/openvas/pull/739)
 
 ### Changed
 - function script_bugtraq_id getting skipped, linter warns. [#724](https://github.com/greenbone/openvas/pull/724)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,7 @@ Prerequisites:
 * libgvm_base, libgvm_util >= 21.10
 * glib-2.0 >= 2.42
 * gio-2.0
+* json-glib-1.0 >= 1.4.4
 * bison
 * flex
 * libgcrypt >= 1.6
@@ -44,8 +45,8 @@ Recommended to have improved SNMP support:
 Install prerequisites on Debian GNU/Linux 'Buster' 10:
 
     apt-get install gcc pkg-config libssh-gcrypt-dev libgnutls28-dev \
-    libglib2.0-dev libpcap-dev libgpgme-dev bison libksba-dev libsnmp-dev \
-    libgcrypt20-dev redis-server
+    libglib2.0-dev libjson-glib-dev libpcap-dev libgpgme-dev bison libksba-dev \
+    libsnmp-dev libgcrypt20-dev redis-server
 
 
 Compiling openvas

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -26,6 +26,7 @@ if (NOT PKG_CONFIG_FOUND)
 endif (NOT PKG_CONFIG_FOUND)
 
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
+pkg_check_modules (GLIB_JSON REQUIRED json-glib-1.0>=1.4.4)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.6.4)
 
 pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=21.10)
@@ -77,7 +78,7 @@ set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 ## Pass-throughs
 
-include_directories (${GLIB_INCLUDE_DIRS}
+include_directories (${GLIB_INCLUDE_DIRS} ${GLIB_JSON_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS}
                      ${GNUTLS_INCLUDE_DIRS})
 
@@ -123,7 +124,7 @@ set_target_properties (openvas_misc_shared PROPERTIES SOVERSION "${PROJECT_VERSI
 set_target_properties (openvas_misc_shared PROPERTIES VERSION "${PROJECT_VERSION_STRING}")
 
 target_link_libraries (openvas_misc_shared LINK_PRIVATE ${GNUTLS_LDFLAGS} ${UUID_LDFLAGS}
-                       ${GLIB_LDFLAGS} ${PCAP_LDFLAGS}
+                       ${GLIB_LDFLAGS} ${GLIB_JSON_LDFLAGS} ${PCAP_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS})
 
 if (OPENVAS_STATE_DIR)


### PR DESCRIPTION
**What**:

Add JSON support for result strings

Related: https://github.com/greenbone/gvm-libs/pull/505 greenbone/openvas-scanner#743

**Why**:

<!-- Why are these changes necessary? -->
Improvement.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

JSON result string will be send via mqtt on `scanner/results` on the provided broker (`mqtt_server_uri`).

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
