### PR TITLE
Fix various typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update default log config [#711](https://github.com/greenbone/openvas-scanner/pull/711)
 
 ### Fixed
-- Use host from the orignal hosts list when boreas is enabled. [#725](https://github.com/greenbone/openvas/pull/725)
+- Use host from the original hosts list when boreas is enabled. [#725](https://github.com/greenbone/openvas/pull/725)
 - Initialize the the kb to store results for openvas-nasl [#735](https://github.com/greenbone/openvas/pull/735)
 
 ### Removed

--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1619,7 +1619,7 @@ nasl_lint (lex_ctxt *, tree_cell *);
  *
  * @return 0 if the script was executed successfully, negative values if an
  * error occurred. Return number of errors if mode is NASL_LINT and no none
- * linting errors occured.
+ * linting errors occurred.
  */
 int
 exec_nasl_script (struct script_infos *script_infos, int mode)
@@ -1700,7 +1700,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   if (mode & NASL_LINT)
     {
       /* ret is set to the number of errors the linter finds.
-      ret will be overwritten with -1 if any erros occur in the steps
+      ret will be overwritten with -1 if any errors occur in the steps
       after linting so we do not break other behaviour dependent on a
       negative return value when doing more than just linting. */
       tree_cell *ret = nasl_lint (lexic, ctx.tree);


### PR DESCRIPTION
Found via codespell:

```
./CHANGELOG.md:17: orignal ==> original
./nasl/exec.c:1622: occured ==> occurred
./nasl/exec.c:1703: erros ==> errors
```