### PR TITLE
Add mqtt support for sending results

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -389,17 +389,19 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
   mqtt = plug_get_mqtt (desc);
   if (mqtt_server_uri)
     {
-      if (NULL == mqtt)
+      if (!gvm_has_mqtt_support ())
+        g_warning (
+          "%s: Gvm-libs not build with MQTT support. MQTT not available.",
+          __func__);
+      else if (NULL == mqtt)
         g_warning ("%s: MQTT not initialized! Can not send results via MQTT.",
                    __func__);
       else
         mqtt_publish (mqtt, "scanner/results", data);
     }
-  else
-    {
-      kb = plug_get_results_kb (desc);
-      kb_item_push_str (kb, "internal/results", data);
-    }
+
+  kb = plug_get_results_kb (desc);
+  kb_item_push_str (kb, "internal/results", data);
 
   g_free (data);
   g_free (buffer);

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -160,6 +160,9 @@ plug_get_kb (struct script_infos *);
 kb_t
 plug_get_results_kb (struct script_infos *);
 
+mqtt_t *
+plug_get_mqtt (struct script_infos *);
+
 void *
 plug_get_key (struct script_infos *, char *, int *, size_t *, int);
 

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -28,6 +28,7 @@
 #include <glib.h>
 #include <gvm/base/nvti.h>
 #include <gvm/util/kb.h>
+#include <gvm/util/mqtt.h>
 
 struct scan_globals
 {
@@ -43,6 +44,7 @@ struct script_infos
   struct scan_globals *globals;
   kb_t key;
   kb_t results;
+  mqtt_t *mqtt;
   nvti_t *nvti;
   char *oid;
   char *name;

--- a/src/attack.c
+++ b/src/attack.c
@@ -48,7 +48,8 @@
 #include <gvm/base/proctitle.h>
 #include <gvm/boreas/alivedetection.h> /* for start_alive_detection() */
 #include <gvm/boreas/boreas_io.h>      /* for get_host_from_queue() */
-#include <gvm/util/nvticache.h>        /* for nvticache_t */
+#include <gvm/util/mqtt.h>
+#include <gvm/util/nvticache.h> /* for nvticache_t */
 #include <pthread.h>
 #include <stdlib.h>   /* for exit() */
 #include <string.h>   /* for strlen() */
@@ -92,6 +93,7 @@ struct attack_start_args
   plugins_scheduler_t sched;
   kb_t host_kb;
   kb_t main_kb;
+  mqtt_t *mqtt;
   gvm_host_t *host;
 };
 
@@ -350,7 +352,8 @@ check_new_vhosts (void)
  */
 static int
 launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
-               struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb)
+               struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb,
+               mqtt_t *mqtt)
 {
   int optimize = prefs_get_bool ("optimize_test"), pid, ret = 0;
   char *oid, *name, *error = NULL, ip_str[INET6_ADDRSTRLEN];
@@ -428,7 +431,7 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
 
   /* Update vhosts list and start the plugin */
   check_new_vhosts ();
-  pid = plugin_launch (globals, plugin, ip, vhosts, kb, main_kb, nvti);
+  pid = plugin_launch (globals, plugin, ip, vhosts, kb, main_kb, mqtt, nvti);
   if (pid < 0)
     {
       plugin->running_state = PLUGIN_STATUS_UNRUN;
@@ -453,7 +456,7 @@ finish_launch_plugin:
  */
 static void
 attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
-             plugins_scheduler_t sched, kb_t kb, kb_t main_kb)
+             plugins_scheduler_t sched, kb_t kb, kb_t main_kb, mqtt_t *mqtt)
 {
   /* Used for the status */
   int num_plugs, forks_retry = 0, all_plugs_launched = 0;
@@ -468,6 +471,8 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   kb_lnk_reset (main_kb);
   proctitle_set ("openvas: testing %s", ip_str);
   kb_lnk_reset (kb);
+
+  mqtt = mqtt_connect (prefs_get ("mqtt_server_uri"));
 
   /* launch the plugins */
   pluginlaunch_init (ip_str);
@@ -494,7 +499,8 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
           static int last_status = 0, cur_plug = 0;
 
         again:
-          e = launch_plugin (globals, plugin, ip, host_vhosts, kb, main_kb);
+          e =
+            launch_plugin (globals, plugin, ip, host_vhosts, kb, main_kb, mqtt);
           if (e < 0)
             {
               /*
@@ -708,6 +714,7 @@ attack_start (struct attack_start_args *args)
   kb_t kb = args->host_kb;
   kb_t main_kb = args->main_kb;
   int ret, ret_host_auth;
+  mqtt_t *mqtt = args->mqtt;
 
   nvticache_reset ();
   kb_lnk_reset (kb);
@@ -754,7 +761,8 @@ attack_start (struct attack_start_args *args)
     g_message ("Vulnerability scan %s started for host: %s", globals->scan_id,
                ip_str);
   g_free (hostnames);
-  attack_host (globals, &hostip, args->host->vhosts, args->sched, kb, main_kb);
+  attack_host (globals, &hostip, args->host->vhosts, args->sched, kb, main_kb,
+               mqtt);
   kb_lnk_reset (main_kb);
 
   if (!scan_is_stopped ())
@@ -953,6 +961,7 @@ attack_network (struct scan_globals *globals)
   kb_t host_kb, main_kb;
   GSList *unresolved;
   char buf[96];
+  mqtt_t *mqtt = NULL;
 
   check_deprecated_prefs ();
 
@@ -1161,6 +1170,7 @@ attack_network (struct scan_globals *globals)
       args.sched = sched;
       args.host_kb = host_kb;
       args.main_kb = main_kb;
+      args.mqtt = mqtt;
 
     forkagain:
       pid = create_process ((process_func_t) attack_start, &args);

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -149,7 +149,8 @@ nasl_thread (struct script_infos *);
  */
 int
 nasl_plugin_launch (struct scan_globals *globals, struct in6_addr *ip,
-                    GSList *vhosts, kb_t kb, kb_t main_kb, const char *oid)
+                    GSList *vhosts, kb_t kb, kb_t main_kb, mqtt_t *mqtt,
+                    const char *oid)
 {
   int module;
   struct script_infos infos;
@@ -160,6 +161,7 @@ nasl_plugin_launch (struct scan_globals *globals, struct in6_addr *ip,
   infos.globals = globals;
   infos.key = kb;
   infos.results = main_kb;
+  infos.mqtt = mqtt;
   infos.oid = (char *) oid;
   infos.name = nvticache_get_src (oid);
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -443,7 +443,7 @@ check_sysload ()
 int
 plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
                struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb,
-               nvti_t *nvti)
+               mqtt_t *mqtt, nvti_t *nvti)
 {
   int p;
 
@@ -456,7 +456,7 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   processes[p].timeout = plugin_timeout (nvti);
   gettimeofday (&(processes[p].start), NULL);
   processes[p].pid =
-    nasl_plugin_launch (globals, ip, vhosts, kb, main_kb, plugin->oid);
+    nasl_plugin_launch (globals, ip, vhosts, kb, main_kb, mqtt, plugin->oid);
 
   if (processes[p].pid > 0)
     num_running_processes++;

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -39,7 +39,7 @@ pluginlaunch_stop (void);
 
 int
 plugin_launch (struct scan_globals *, struct scheduler_plugin *,
-               struct in6_addr *, GSList *, kb_t, kb_t, nvti_t *);
+               struct in6_addr *, GSList *, kb_t, kb_t, mqtt_t *, nvti_t *);
 
 void
 pluginlaunch_disable_parallel_checks (void);

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -55,6 +55,6 @@ nasl_plugin_add (char *, char *);
 
 int
 nasl_plugin_launch (struct scan_globals *, struct in6_addr *, GSList *, kb_t,
-                    kb_t, const char *);
+                    kb_t, mqtt_t *, const char *);
 
 #endif


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Add mqtt support for sending results. The server uri needs to be provided via openvas config setting `mqtt_server_uri` for now. E.g. `mqtt_server_uri = "tcp://127.0.0.1:1883"`. Results are put on the topic `scanner/results` for now.
This PR is only part of a series of PRs meant to enhance the scanner.

Related: https://github.com/greenbone/gvm-libs/pull/505

**Why**:

<!-- Why are these changes necessary? -->
Improvement.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Set the mqtt broker uri in the config. E.g.`mqtt_server_uri = "tcp://127.0.0.1:1883"`.
Do a scan. You should see results on the `scanner/results` topic.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
