### PR TITLE
Fix various typos.

### DIFF
--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -84,7 +84,7 @@ static init_func libfuncs[] = {
   {"script_oid", script_oid},
   {"script_cve_id", script_cve_id},
   {"script_bugtraq_id",
-   script_bugtraq_id_dummy}, // Replace orginal script_bugtraq_id to
+   script_bugtraq_id_dummy}, // Replace original script_bugtraq_id to
                              // ignore it
   {"script_xref", script_xref},
   {"script_tag", script_tag},

--- a/src/utils.c
+++ b/src/utils.c
@@ -242,7 +242,7 @@ check_host_still_alive (kb_t kb, const char *hostname)
     {
       const gchar *alive_test_str = prefs_get ("ALIVE_TEST");
 
-      /* Don't perfom a hearbeat check if the host is always considered
+      /* Don't perform a hearbeat check if the host is always considered
          alive or the alive test is not valid. */
       if (!(alive_test_str
             && atoi (alive_test_str) >= ALIVE_TEST_TCP_ACK_SERVICE
@@ -253,7 +253,7 @@ check_host_still_alive (kb_t kb, const char *hostname)
   else
     {
       g_warning ("%s: Max VTs timeout has been reached, but Boreas is not "
-                 "enabled. Heartbeat check for %s will not be perfomed",
+                 "enabled. Heartbeat check for %s will not be performed",
                  __func__, hostname);
       return -1;
     }


### PR DESCRIPTION
Found via codespell:

```
./src/utils.c:245: perfom ==> perform
./src/utils.c:256: perfomed ==> performed
./nasl/nasl_init.c:87: orginal ==> original
```

Those only exists in the master branch so targeting that branch directly.