### PR TITLE
Fix mqtt_publish call for json result string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for volatile keys. [#682](https://github.com/greenbone/openvas/pull/682)
 - Extend nasl lint to check Syntax for Arguments for script_xref() function. [#714](https://github.com/greenbone/openvas/pull/714)
 - Recheck alive status of host with specified amount of NVT timeouts. [#729](https://github.com/greenbone/openvas/pull/729)
-- Add json-glib support for creating JSON result strings. [#739](https://github.com/greenbone/openvas/pull/739)
+- Add json-glib support for creating JSON result strings.
+  [#739](https://github.com/greenbone/openvas/pull/739)
+  [#754](https://github.com/greenbone/openvas/pull/754)
 - Integrate sentry for debugging purposes [#742](https://github.com/greenbone/openvas/pull/742)
 - Add support for non-interactive shell to nasl_ssh_shell_open(). [#744](https://github.com/greenbone/openvas/pull/744)
 

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -479,7 +479,7 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
           if (json == NULL)
             g_warning ("%s: Error while creating JSON.", __func__);
           else
-            mqtt_publish (mqtt, "scanner/results", data);
+            mqtt_publish (mqtt, "scanner/results", json);
           g_free (json);
         }
     }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Send json string instead of old redis format string if mqtt is enabled.

**Why**:

<!-- Why are these changes necessary? -->

Bugfix.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Add e.g. `mqtt_server_uri = "tcp://127.0.0.1:1883"` to the openvas.conf. gvm-libs with MQTTv5 support need to be installed as well as some broker supporting MQTTv5.
Results are then send to the broker via json.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
