### PR TITLE
Updated function description of nasl_ssh_shell_read()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix SIGSEGV when no best route is found. [#702](https://github.com/greenbone/openvas/pull/702)
 - Fix host count when reverse_lookup_only is enabled. [#715](https://github.com/greenbone/openvas/pull/715)
 - Use host from the orignal hosts list when boreas is enabled. Backport of [PR #727](https://github.com/greenbone/openvas/pull/727). [#725](https://github.com/greenbone/openvas/pull/725)
+- The function description of nasl_ssh_shell_read() has been fixed. [#755](https://github.com/greenbone/openvas/pull/755)
 
 ### Removed
 - Remove code from the openvas daemon era. Do not flushall redis. [#689](https://github.com/greenbone/openvas/pull/689)

--- a/nasl/nasl_ssh.c
+++ b/nasl/nasl_ssh.c
@@ -1788,7 +1788,10 @@ nasl_ssh_shell_read (lex_ctxt *lexic)
  * @nasluparam
  *
  * - An ssh session id.
- * - A string to write to shell.
+ *
+ * @naslnparam
+ *
+ * - @a cmd A string to write to shell.
  *
  * @naslret An integer: 0 on success, -1 on failure.
  *


### PR DESCRIPTION
**What**:

As seen on https://github.com/greenbone/openvas-scanner/blob/8d1c76acaf755da13c872e07172eef9f934740f5/nasl/nasl_ssh.c#L1841 the `cmd` parameter is a named one so it should be described accordingly.

Please add the backport labels to the following branches:
- opevas-21.04
- master

**Why**:

Improve source code documentation.

**How**:

Just text changes, no testing done.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
