### PR TITLE
Set file permissions when syncing community feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve log message for WMI connect failed or missing WMI support. [#670](https://github.com/greenbone/openvas/pull/670)
 - Don't use g_error. Use g_warning instead and let the scanner to continue. [#710](https://github.com/greenbone/openvas/pull/710)
 - Update COPYING file. [#750](https://github.com/greenbone/openvas/pull/750)
+- Set file permissions when syncing community feed [#769](https://github.com/greenbone/openvas-scanner/pull/769)
 
 ### Fixed
 - Fix issues discovered with clang compiler. [#654](https://github.com/greenbone/openvas/pull/654)

--- a/tools/greenbone-nvt-sync.in
+++ b/tools/greenbone-nvt-sync.in
@@ -325,7 +325,7 @@ is_feed_current () {
     # IP blocking due to network equipment in between keeping the previous connection too long open.
     sleep 5
     log_notice "No Greenbone Security Feed access key found, falling back to Greenbone Community Feed"
-    eval "$RSYNC -ltvrP \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$FEED_INFO_TEMP_DIR\""
+    eval "$RSYNC -ltvrP $RSYNC_CHMOD \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$FEED_INFO_TEMP_DIR\""
     if [ $? -ne 0 ]
     then
       log_err "rsync failed, aborting synchronization."
@@ -362,7 +362,7 @@ do_rsync_community_feed () {
   sleep 5
   log_notice "Configured NVT rsync feed: $COMMUNITY_NVT_RSYNC_FEED"
   mkdir -p "$NVT_DIR"
-  eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED\" \"$NVT_DIR\" --exclude=plugin_feed_info.inc"
+  eval "$RSYNC -ltvrP $RSYNC_DELETE $RSYNC_CHMOD \"$COMMUNITY_NVT_RSYNC_FEED\" \"$NVT_DIR\" --exclude=plugin_feed_info.inc"
   if [ $? -ne 0 ] ; then
     log_err "rsync failed."
     exit 1
@@ -370,7 +370,7 @@ do_rsync_community_feed () {
   # Sleep for five seconds (after the above rsync call) to prevent IP blocking due
   # to network equipment in between keeping the previous connection too long open.
   sleep 5
-  eval "$RSYNC -ltvrP $RSYNC_DELETE \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$NVT_DIR\""
+  eval "$RSYNC -ltvrP $RSYNC_DELETE $RSYNC_CHMOD \"$COMMUNITY_NVT_RSYNC_FEED/plugin_feed_info.inc\" \"$NVT_DIR\""
   if [ $? -ne 0 ] ; then
     log_err "rsync failed."
     exit 1


### PR DESCRIPTION
**What**:
When using the community feed, greenbone-nvt-sync will now also apply
the chmod options to make the feed directory and its contents group
readable.

**Why**:
This will help using the community feed with multi-user setups.

**How**:
Tested by removing the feed directory and running `greenbone-nvt-sync`,
then checking the file permissions.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
