### PR TITLE
Fix interrupted scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+Fix interrupted scan, when the process table is full. [#832](https://github.com/greenbone/openvas-scanner/pull/832)
 
 [21.4.3]: https://github.com/greenbone/openvas-scanner/compare/v21.4.2...gvmd-21.04
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -56,7 +56,6 @@
 #include <unistd.h>   /* for close() */
 
 #define ERR_HOST_DEAD -1
-#define ERR_CANT_FORK -2
 
 #define MAX_FORK_RETRIES 10
 /**
@@ -346,13 +345,14 @@ check_new_vhosts (void)
  * Does not launch a plugin twice if !save_kb_replay.
  *
  * @return ERR_HOST_DEAD if host died, ERR_CANT_FORK if forking failed,
- *         0 otherwise.
+ *         ERR_NO_FREE_SLOT if the process table is full, 0 otherwise.
  */
 static int
 launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
                struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb)
 {
-  int optimize = prefs_get_bool ("optimize_test"), pid, ret = 0;
+  int optimize = prefs_get_bool ("optimize_test");
+  int launch_error, pid, ret = 0;
   char *oid, *name, *error = NULL, ip_str[INET6_ADDRSTRLEN];
   nvti_t *nvti;
 
@@ -428,14 +428,13 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
 
   /* Update vhosts list and start the plugin */
   check_new_vhosts ();
-  pid = plugin_launch (globals, plugin, ip, vhosts, kb, main_kb, nvti);
-  if (pid < 0)
+  launch_error = 0;
+  pid = plugin_launch (globals, plugin, ip, vhosts, kb, main_kb, nvti,
+                       &launch_error);
+  if (launch_error == ERR_NO_FREE_SLOT || launch_error == ERR_CANT_FORK)
     {
       plugin->running_state = PLUGIN_STATUS_UNRUN;
-      if (pid == ERR_NO_FREE_SLOT)
-        ret = ERR_NO_FREE_SLOT;
-      else
-        ret = ERR_CANT_FORK;
+      ret = launch_error;
       goto finish_launch_plugin;
     }
 
@@ -524,17 +523,23 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                 }
               else if (e == ERR_NO_FREE_SLOT)
                 {
-                  g_debug (
-                    "fork() failed for %s. No free slot to run a plugin.",
-                    plugin->oid);
-                  goto again;
+                  if (forks_retry < MAX_FORK_RETRIES)
+                    {
+                      forks_retry++;
+                      g_warning ("Launch failed for %s. No free slot available "
+                                 "in the internal process table for starting a "
+                                 "plugin.",
+                                 plugin->oid);
+                      fork_sleep (forks_retry);
+                      goto again;
+                    }
                 }
               else if (e == ERR_CANT_FORK)
                 {
                   if (forks_retry < MAX_FORK_RETRIES)
                     {
                       forks_retry++;
-                      g_debug (
+                      g_warning (
                         "fork() failed for %s - sleeping %d seconds (%s)",
                         plugin->oid, forks_retry, strerror (errno));
                       fork_sleep (forks_retry);
@@ -542,7 +547,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                     }
                   else
                     {
-                      g_debug ("fork() failed too many times - aborting");
+                      g_warning ("fork() failed too many times - aborting");
                       goto host_died;
                     }
                 }

--- a/src/attack.c
+++ b/src/attack.c
@@ -432,7 +432,7 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
   if (pid < 0)
     {
       plugin->running_state = PLUGIN_STATUS_UNRUN;
-      if (pid == ERR_NO_FREE_SLOT )
+      if (pid == ERR_NO_FREE_SLOT)
         ret = ERR_NO_FREE_SLOT;
       else
         ret = ERR_CANT_FORK;
@@ -524,8 +524,9 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                 }
               else if (e == ERR_NO_FREE_SLOT)
                 {
-                  g_debug ("fork() failed for %s. Not free slot to run a plugin.",
-                           plugin->oid);
+                  g_debug (
+                    "fork() failed for %s. Not free slot to run a plugin.",
+                    plugin->oid);
                   goto again;
                 }
               else if (e == ERR_CANT_FORK)
@@ -533,8 +534,9 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
                   if (forks_retry < MAX_FORK_RETRIES)
                     {
                       forks_retry++;
-                      g_debug ("fork() failed for %s - sleeping %d seconds (%s)",
-                               plugin->oid, forks_retry, strerror (errno));
+                      g_debug (
+                        "fork() failed for %s - sleeping %d seconds (%s)",
+                        plugin->oid, forks_retry, strerror (errno));
                       fork_sleep (forks_retry);
                       goto again;
                     }

--- a/src/attack.c
+++ b/src/attack.c
@@ -525,7 +525,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
               else if (e == ERR_NO_FREE_SLOT)
                 {
                   g_debug (
-                    "fork() failed for %s. Not free slot to run a plugin.",
+                    "fork() failed for %s. No free slot to run a plugin.",
                     plugin->oid);
                   goto again;
                 }

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -239,8 +239,8 @@ simult_ports (const char *oid, const char *next_oid)
 /**
  * If another NVT with same port requirements is running, wait.
  *
- * @return ERR_NO_FREE_SLOT if MAX_PROCESSES are running, the index of the first free "slot"
- *          in the processes array otherwise.
+ * @return ERR_NO_FREE_SLOT if MAX_PROCESSES are running, the index of the first
+ * free "slot" in the processes array otherwise.
  */
 static int
 next_free_process (kb_t kb, struct scheduler_plugin *upcoming)
@@ -407,7 +407,7 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
                "probably because the parallel check is temporally disabled. "
                "Current parallel checks: %d. Old parallel checks: %d",
                max_running_processes, old_max_running_processes);
-      usleep(250000);
+      usleep (250000);
       return ERR_NO_FREE_SLOT;
     }
 
@@ -471,9 +471,10 @@ pluginlaunch_wait_for_free_process (kb_t kb)
    * to timeout. */
 
   if (num_running_processes >= max_running_processes)
-    g_debug ("%s. Number of running processes >= maximum running processes (%d >= %d). "
+    g_debug ("%s. Number of running processes >= maximum running processes (%d "
+             ">= %d). "
              "Waitting for free slot for processes.",
-        __func__, num_running_processes, max_running_processes);
+             __func__, num_running_processes, max_running_processes);
 
   while (
     (num_running_processes >= max_running_processes)

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -461,6 +461,12 @@ pluginlaunch_wait_for_free_process (kb_t kb)
   update_running_processes (kb);
   /* Max number of processes are still running, wait for a child to exit or
    * to timeout. */
+
+  if (num_running_processes >= max_running_processes)
+    g_debug ("%s. Number of running processes >= maximum running processes (%d >= %d). "
+             "Waitting for free slot for processes.",
+        __func__, num_running_processes, max_running_processes);
+
   while (
     (num_running_processes >= max_running_processes)
     || (num_running_processes > 0 && (check_memory () || check_sysload ())))

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -403,9 +403,9 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   p = next_free_process (main_kb, plugin);
   if (p < 0)
     {
-      g_debug ("There are currently no free slot for running a new plugins, "
-               "probably because the parallel check is temporally disabled. "
-               "Current parallel checks: %d. Old parallel checks: %d",
+      g_debug ("There is currently no free slot available for starting a new "
+               "plugin, probably because the parallel check is temporarily "
+               "disabled. Current parallel checks: %d. Old parallel checks: %d",
                max_running_processes, old_max_running_processes);
       usleep (250000);
       return ERR_NO_FREE_SLOT;
@@ -473,7 +473,7 @@ pluginlaunch_wait_for_free_process (kb_t kb)
   if (num_running_processes >= max_running_processes)
     g_debug ("%s. Number of running processes >= maximum running processes (%d "
              ">= %d). "
-             "Waitting for free slot for processes.",
+             "Waiting for free slot for processes.",
              __func__, num_running_processes, max_running_processes);
 
   while (

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -462,7 +462,7 @@ pluginlaunch_wait_for_free_process (kb_t kb)
   /* Max number of processes are still running, wait for a child to exit or
    * to timeout. */
   while (
-    (num_running_processes == max_running_processes)
+    (num_running_processes >= max_running_processes)
     || (num_running_processes > 0 && (check_memory () || check_sysload ())))
     {
       sigset_t mask;

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -388,13 +388,20 @@ check_sysload ()
 }
 
 /**
+ * @brief Start a plugin.
+ *
+ * Check for free slots available in the process table. Set error with
+ * ERR_NO_FREE_SLOT if the process table is full. Set error with ERR_CANT_FORK
+ * if was not possible to fork() a new child.
+ *
  * @return PID of process that is connected to the plugin as returned by plugin
- *         classes pl_launch function (<=0 means there was a problem).
+ *         classes pl_launch function. Less than 0 means there was a problem,
+ *         but error param should be checked.
  */
 int
 plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
                struct in6_addr *ip, GSList *vhosts, kb_t kb, kb_t main_kb,
-               nvti_t *nvti)
+               nvti_t *nvti, int *error)
 {
   int p;
 
@@ -403,12 +410,11 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   p = next_free_process (main_kb, plugin);
   if (p < 0)
     {
-      g_debug ("There is currently no free slot available for starting a new "
-               "plugin, probably because the parallel check is temporarily "
-               "disabled. Current parallel checks: %d. Old parallel checks: %d",
-               max_running_processes, old_max_running_processes);
-      usleep (250000);
-      return ERR_NO_FREE_SLOT;
+      g_warning ("%s. There is currently no free slot available for starting a "
+                 "new plugin.",
+                 __func__);
+      *error = ERR_NO_FREE_SLOT;
+      return -1;
     }
 
   processes[p].plugin = plugin;
@@ -420,8 +426,10 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   if (processes[p].pid > 0)
     num_running_processes++;
   else
-    processes[p].plugin->running_state = PLUGIN_STATUS_UNRUN;
-
+    {
+      processes[p].plugin->running_state = PLUGIN_STATUS_UNRUN;
+      *error = ERR_CANT_FORK;
+    }
   return processes[p].pid;
 }
 

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -29,6 +29,11 @@
 #include "pluginload.h"      /* for struct pl_class_t */
 #include "pluginscheduler.h" /* for struct plugins_scheduler_t */
 
+/**
+ * @brief Error for max. number of concurrent plugins per host reached.
+ */
+#define ERR_NO_FREE_SLOT -99
+
 void
 pluginlaunch_init (const char *);
 void pluginlaunch_wait (kb_t);

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -30,7 +30,11 @@
 #include "pluginscheduler.h" /* for struct plugins_scheduler_t */
 
 /**
- * @brief Error for max. number of concurrent plugins per host reached.
+ * @brief Error for when it is not possible to fork a new plugin process.
+ */
+#define ERR_CANT_FORK -2
+/**
+ * @brief Error for when the process table is full
  */
 #define ERR_NO_FREE_SLOT -99
 
@@ -44,7 +48,7 @@ pluginlaunch_stop (void);
 
 int
 plugin_launch (struct scan_globals *, struct scheduler_plugin *,
-               struct in6_addr *, GSList *, kb_t, kb_t, nvti_t *);
+               struct in6_addr *, GSList *, kb_t, kb_t, nvti_t *, int *);
 
 void
 pluginlaunch_disable_parallel_checks (void);


### PR DESCRIPTION
SC-177

**What**:
Check if the max running process was reached or even exceed, when waiting for running a new plugin. 
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Fix an issue which produced interrupted scan, because a host not being scan 100%
<!-- Why are these changes necessary? -->

**How**:
Not easy to reproduce. It depends on the system, scan config and mainly on the target system (some plugins must be trigger in a especial order). Good luck.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
