### PR TITLE
Store the timeout as preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Revert [#809](https://github.com/greenbone/openvas/pull/809) and adjust json result format and json lsc info format. [#837](https://github.com/greenbone/openvas/pull/837)
+- Handle script timeout as script preference with ID 0 [#841](https://github.com/greenbone/gvm-libs/pull/841)
 
 ## [21.10] (unreleased)
 

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -669,12 +669,12 @@ get_plugin_preference (const char *oid, const char *name, int pref_id)
   char prefix[1024], suffix[1024];
 
   prefs = preferences_get ();
-  if (!prefs || !nvticache_initialized () || !oid || (!name && pref_id < 1))
+  if (!prefs || !nvticache_initialized () || !oid || (!name && pref_id < 0))
     return NULL;
 
   g_hash_table_iter_init (&iter, prefs);
 
-  if (pref_id > 0)
+  if (pref_id >= 0)
     {
       snprintf (prefix, sizeof (prefix), "%s:%d:", oid, pref_id);
       while (g_hash_table_iter_next (&iter, &itername, &itervalue))

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -82,6 +82,18 @@ isalldigit (char *str, int len)
  * scanner.
  */
 
+/**
+ * @brief Add timeout preference to VT preferences
+ *
+ * VT timeout is handled as normal VT preference.
+ * Because of backward compatibility issues the timeout preference is always
+ * located at the VT pref location with id NVTPREF_TIMEOUT_ID.
+ *
+ * @param[in] lexic   lexic
+ * @param[in] to      script timeout
+ *
+ * @return FAKE_CELL
+ */
 tree_cell *
 script_timeout (lex_ctxt *lexic)
 {
@@ -95,7 +107,7 @@ script_timeout (lex_ctxt *lexic)
 
   timeout = g_strdup_printf ("%d", to);
 
-  np = nvtpref_new (0, "timeout", "entry", timeout);
+  np = nvtpref_new (NVTPREF_TIMEOUT_ID, "timeout", "entry", timeout);
   nvti_add_pref (nvti, np);
   return FAKE_CELL;
 }

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -87,11 +87,16 @@ script_timeout (lex_ctxt *lexic)
 {
   nvti_t *nvti = lexic->script_infos->nvti;
   int to = get_int_var_by_num (lexic, 0, -65535);
+  nvtpref_t *np;
+  gchar *timeout;
 
   if (to == -65535)
     return FAKE_CELL;
 
-  nvti_set_timeout (nvti, to ? to : -1);
+  timeout = g_strdup_printf ("%d", to);
+
+  np = nvtpref_new (0, "timeout", "entry", timeout);
+  nvti_add_pref (nvti, np);
   return FAKE_CELL;
 }
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -376,8 +376,9 @@ plugin_timeout (nvti_t *nvti)
   gchar *timeout_str;
 
   timeout = 0;
-  if ((timeout_str = get_plugin_preference (nvti_oid (nvti), "timeout", 0)) != NULL)
-        timeout = atoi (timeout_str);
+  if ((timeout_str = get_plugin_preference (nvti_oid (nvti), "timeout", 0))
+      != NULL)
+    timeout = atoi (timeout_str);
 
   if (timeout == 0)
     {

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -376,7 +376,15 @@ plugin_timeout (nvti_t *nvti)
   assert (nvti);
   timeout = prefs_nvt_timeout (nvti_oid (nvti));
   if (timeout == 0)
-    timeout = nvti_timeout (nvti);
+    {
+      const nvtpref_t *timeout_pref;
+      gchar *timeout_str;
+
+      timeout_pref = nvti_pref (nvti, NVTPREF_TIMEOUT_ID);
+      timeout = 0;
+      if ((timeout_str = nvtpref_default (timeout_pref)) != NULL)
+        timeout = atoi (timeout_str);
+    }
   if (timeout == 0)
     {
       if (nvti_category (nvti) == ACT_SCANNER)

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -27,6 +27,7 @@
 
 #include "../misc/network.h"
 #include "../misc/nvt_categories.h" /* for ACT_SCANNER */
+#include "../misc/plugutils.h"      /* for get_plugin_preference */
 #include "pluginload.h"
 #include "pluginscheduler.h"
 #include "plugs_req.h"
@@ -372,19 +373,12 @@ static int
 plugin_timeout (nvti_t *nvti)
 {
   int timeout;
+  gchar *timeout_str;
 
-  assert (nvti);
-  timeout = prefs_nvt_timeout (nvti_oid (nvti));
-  if (timeout == 0)
-    {
-      const nvtpref_t *timeout_pref;
-      gchar *timeout_str;
-
-      timeout_pref = nvti_pref (nvti, NVTPREF_TIMEOUT_ID);
-      timeout = 0;
-      if ((timeout_str = nvtpref_default (timeout_pref)) != NULL)
+  timeout = 0;
+  if ((timeout_str = get_plugin_preference (nvti_oid (nvti), "timeout", 0)) != NULL)
         timeout = atoi (timeout_str);
-    }
+
   if (timeout == 0)
     {
       if (nvti_category (nvti) == ACT_SCANNER)


### PR DESCRIPTION
Closes SC-354.

Depends on greenbone/gvm-libs#578

**What**:
Store and get the script timeout as preference
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The script timeout is now handle as preference and it is stored as another preference, but always with the ID 0.
<!-- Why are these changes necessary? -->

**How**:
Use an up to date build of middleware from gvmd (send the script preference) and gvm-libs (handle timeout as preference)
Set a timeout to 1second for a script in gsa, one which runs for a long time (find_service.nasl). Run the scanner. Check that the script timeouts. You can check this with "log_whole_attack = yes" 

A redis flushall() is required, since it is a change in the redis nvticache and all plugins must be loaded up again.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
