### PR TITLE
g memdup2

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -25,11 +25,11 @@
  */
 
 #include "../nasl/nasl_debug.h" /* for nasl_*_filename */
+#include "../src/macros.h"
 
 #include <arpa/inet.h> /* for inet_pton */
 #include <errno.h>
 #include <fcntl.h>
-#include <glib.h>
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
 #include <gvm/base/logging.h>

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -25,6 +25,7 @@
 
 #include "plugutils.h"
 
+#include "../src/macros.h"
 #include "network.h" // for OPENVAS_ENCAPS_IP
 
 #include <errno.h> // for errno

--- a/nasl/nasl_cert.c
+++ b/nasl/nasl_cert.c
@@ -29,6 +29,7 @@
 #ifdef HAVE_LIBKSBA
 #include "nasl_cert.h"
 
+#include "../src/macros.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"
 #include "nasl_global_ctxt.h"

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -25,6 +25,7 @@
 
 #include "nasl_crypto.h"
 
+#include "../src/macros.h"
 #include "exec.h"
 #include "hmacmd5.h"
 #include "nasl_debug.h"

--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -25,6 +25,7 @@
 #include "nasl_crypto2.h"
 
 #include "../misc/strutils.h"
+#include "../src/macros.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"
 #include "nasl_global_ctxt.h"

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -27,6 +27,7 @@
 #include "../misc/network.h"       /* read_stream_connection_min */
 #include "../misc/plugutils.h"     /* plug_get_host_open_port */
 #include "../misc/vendorversion.h" /* for vendor_version_get */
+#include "../src/macros.h"
 #include "byteorder.h"
 #include "exec.h"
 #include "nasl_debug.h"

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -21,6 +21,7 @@
 #include "../misc/bpf_share.h"    /* for bpf_open_live */
 #include "../misc/pcap_openvas.h" /* for routethrough */
 #include "../misc/plugutils.h"    /* plug_get_host_ip */
+#include "../src/macros.h"
 #include "capture_packet.h"
 #include "exec.h"
 #include "nasl_debug.h"

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -51,6 +51,7 @@
 #include "../misc/bpf_share.h"    /* for bpf_open_live */
 #include "../misc/pcap_openvas.h" /* for routethrough */
 #include "../misc/plugutils.h"    /* plug_get_host_ip */
+#include "../src/macros.h"
 #include "capture_packet.h"
 #include "exec.h"
 #include "nasl_debug.h"

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -30,6 +30,7 @@
 #include "../misc/network.h"       /* for getpts */
 #include "../misc/plugutils.h"     /* for plug_set_id */
 #include "../misc/vendorversion.h" /* for vendor_version_get */
+#include "../src/macros.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"
 #include "nasl_global_ctxt.h"

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -30,6 +30,7 @@
 /*--------------------------------------------------------------------------*/
 #include "../misc/network.h"
 #include "../misc/plugutils.h" /* for plug_get_host_ip */
+#include "../src/macros.h"
 #include "exec.h"
 #include "nasl.h"
 #include "nasl_debug.h"

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -27,6 +27,7 @@
 #include "nasl_text_utils.h"
 
 #include "../misc/strutils.h" /* for str_match */
+#include "../src/macros.h"
 #include "exec.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"
@@ -551,7 +552,7 @@ _regreplace (const char *pattern, const char *replace, const char *string,
              1) find out how long the string will be, and allocate buf
              2) copy the part before match, replacement and backrefs to buf
 
-             Jaakko Hyv‰tti <Jaakko.Hyvatti@iki.fi>
+             Jaakko Hyv√§tti <Jaakko.Hyvatti@iki.fi>
            */
 
           new_l = strlen (buf) + subs[0].rm_so; /* part before the match */

--- a/nasl/nasl_var.c
+++ b/nasl/nasl_var.c
@@ -18,6 +18,7 @@
 
 #include "nasl_var.h"
 
+#include "../src/macros.h"
 #include "exec.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,0 +1,10 @@
+#ifndef _GVM_LIBS_MACROS_H
+#define _GVM_LIBS_MACROS_H
+
+#include <glib.h>
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 68
+#undef g_memdup
+#define g_memdup g_memdup2
+#endif
+
+#endif


### PR DESCRIPTION
 Fix: g_memdup is depcreated; it is recommended to use g_memdup2 instead

Fix warning:
```
warning: 'g_memdup' is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
```

