### PR TITLE
add destination to message init

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -369,7 +369,7 @@ make_result_json_str (const gchar *scan_id, const gchar *type,
   gchar *json_str;
 
   if ((msg = eulabeia_initialize_message (EULABEIA_INFO_SCAN_RESULT,
-                                          EULABEIA_SCAN, NULL))
+                                          EULABEIA_SCAN, NULL, NULL))
       == NULL)
     {
       g_warning ("%s: unable to initialize start.scan message", __func__);

--- a/src/attack.c
+++ b/src/attack.c
@@ -151,7 +151,8 @@ send_failure (char *error)
     {
       goto exit;
     }
-  msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL);
+  msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL,
+                                     NULL);
   failure.id = scan_id;
   failure.error = error;
 
@@ -200,7 +201,8 @@ set_scan_status (char *status)
     {
       goto exit;
     }
-  msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL);
+  msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL,
+                                     NULL);
   estatus.id = scan_id;
   estatus.status = status;
 


### PR DESCRIPTION
There was a API change within eulabeia to add a destination when
initializing a message; this commit is using the new method signature.