### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - SYSCONFDIR is /etc by default now
   - LOCALSTATEDIR is /var by default now
   - OPENVAS_RUN_DIR is /run/ospd by default now
-  - OPENVAS_FEED_LOOK_PATH is /var/lib/openvas/feed-update.lock by default now
+  - OPENVAS_FEED_LOCK_PATH is /var/lib/openvas/feed-update.lock by default now
 
 ### Deprecated
 ### Removed


### PR DESCRIPTION
Fix a typo introduced in #826

:warning:
- Some one with edit permissions please also fix the typo in the comment / description of #826
- It seems the changes of the backport #828 are not listed in the changelog of the 21.04 branch at all / is currently completely missing there. This probably should be fixed as well.
- Not sure what do do about the other branches like master (which received a backport in #827 or the middleware one which still has a MR open with #829

:warning: