### PR TITLE
Nasl stat open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle script timeout as script preference with ID 0 [#841](https://github.com/greenbone/gvm-libs/pull/841)
 - Integrate eulabeia [842](https://github.com/greenbone/openvas-scanner/pull/842)
 - Set deprecated g_memdup as WARNING instead of ERROR for glib versions above 2.68 [852](https://github.com/greenbone/openvas-scanner/pull/852)
+### Fixed
+- Use fchmod to change file permission instead of on open to prevent race conditions [860](https://github.com/greenbone/openvas-scanner/pull/860)
 
 ## [21.10] (unreleased)
 


### PR DESCRIPTION
**What**:

Fix https://github.com/greenbone/openvas-scanner/security/code-scanning/15 and https://github.com/greenbone/openvas-scanner/security/code-scanning/16

Instead of using lstat before opening the file to later on check if it
was changed manually the file descriptor can also be open before and
just check if fstat is returning an error after opening it.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
