### PR TITLE
[master] Add `find_all` to eregmatch() nasl function. Backport #875

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add nasl function sftp_enabled_check() to check if sftp subsystem is enabled in the target.
   - [#853](https://github.com/greenbone/openvas/pull/853)
   - [#862](https://github.com/greenbone/openvas/pull/862)
+- Add `find_all` to eregmatch() nasl function. Backport PR #875. [#876](https://github.com/greenbone/openvas/pull/876)
 
 ### Changed
 - function script_bugtraq_id getting skipped, linter warns. [#724](https://github.com/greenbone/openvas/pull/724)

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -786,8 +786,21 @@ nasl_egrep (lex_ctxt *lexic)
 
 /**
  * @brief Does extended regular expression pattern matching.
+ * @naslfn{eregmatch}
  *
- * In NASL, this function returns an array.
+ * @nasluparam
+ *
+ * - @a pattern An regex pattern
+ * - @a string A string
+ * - @a icase Boolean, for case sensitve
+ * - @a find_all Boolean, to find all matches
+ *
+ * @naslret An array with the first match (find_all: False)
+ *          or an array with all matches (find_all: TRUE).
+ *          NULL or empty if no match was found.
+ *
+ * @param[in] lexic Lexical context of NASL interpreter.
+ *
  */
 tree_cell *
 nasl_eregmatch (lex_ctxt *lexic)


### PR DESCRIPTION
Backport #875

**What**:
Add `find_all` to eregmatch() nasl function
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The current implementation only returns the first match in the string.
Now it will return all matches if the option `find_all: TRUE` is passed to the function.
For backward compatibility, if FALSE is passed or no option, it will return the first match as before.

<!-- Why are these changes necessary? -->

**How**:
See PR #875
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
