### PR TITLE
[middleware] Add `find_all` to eregmatch() nasl function. Backport #875

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Notus integration mqtt. 
   [#806](https://github.com/greenbone/openvas/pull/806)
   [#843](https://github.com/greenbone/openvas/pull/843)
+- Add `find_all` to eregmatch() nasl function. Backport PR #875. [#877](https://github.com/greenbone/openvas/pull/877)
 
 ### Changed
 - Revert [#809](https://github.com/greenbone/openvas/pull/809) and adjust json result format and json lsc info format. [#837](https://github.com/greenbone/openvas/pull/837)

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -801,7 +801,8 @@ nasl_eregmatch (lex_ctxt *lexic)
   char *pattern = get_str_var_by_name (lexic, "pattern");
   char *string = get_str_var_by_name (lexic, "string");
   int icase = get_int_var_by_name (lexic, "icase", 0);
-  int copt = 0, i;
+  int find_all = get_int_var_by_name (lexic, "find_all", 0);
+  int copt = 0;
   tree_cell *retc;
   regex_t re;
   regmatch_t subs[NS];
@@ -820,24 +821,63 @@ nasl_eregmatch (lex_ctxt *lexic)
                    pattern);
       return NULL;
     }
-
-  if (regexec (&re, string, (size_t) NS, subs, 0) != 0)
-    {
-      regfree (&re);
-      return NULL;
-    }
-
   retc = alloc_typed_cell (DYN_ARRAY);
   retc->x.ref_val = a = g_malloc0 (sizeof (nasl_array));
 
-  for (i = 0; i < NS; i++)
-    if (subs[i].rm_so != -1)
-      {
-        v.var_type = VAR2_DATA;
-        v.v.v_str.s_siz = subs[i].rm_eo - subs[i].rm_so;
-        v.v.v_str.s_val = (unsigned char *) string + subs[i].rm_so;
-        (void) add_var_to_list (a, i, &v);
-      }
+  if (find_all == 0)
+    {
+      if (regexec (&re, string, (size_t) NS, subs, 0) != 0)
+        {
+          regfree (&re);
+          return NULL;
+        }
+
+      int i;
+      for (i = 0; i < NS; i++)
+        if (subs[i].rm_so != -1)
+          {
+            v.var_type = VAR2_DATA;
+            v.v.v_str.s_siz = subs[i].rm_eo - subs[i].rm_so;
+            v.v.v_str.s_val = (unsigned char *) string + subs[i].rm_so;
+            (void) add_var_to_list (a, i, &v);
+          }
+    }
+  else
+    {
+      int index = 0;
+      char *current_pos;
+      current_pos = string;
+      while (1)
+        {
+          if (regexec (&re, current_pos, (size_t) NS, subs, 0) != 0)
+            {
+              regfree (&re);
+              break;
+            }
+
+          unsigned int offset = 0, i = 0;
+          for (i = 0; i < NS; i++)
+            {
+              char current_pos_cp[strlen (current_pos) + 1];
+
+              if (subs[i].rm_so == -1)
+                break;
+
+              if (i == 0)
+                offset = subs[i].rm_eo;
+
+              strcpy (current_pos_cp, current_pos);
+              current_pos_cp[subs[i].rm_eo] = 0;
+              v.var_type = VAR2_DATA;
+              v.v.v_str.s_siz = subs[i].rm_eo - subs[i].rm_so;
+              v.v.v_str.s_val =
+                (unsigned char *) current_pos_cp + subs[i].rm_so;
+              (void) add_var_to_list (a, index, &v);
+              index++;
+            }
+          current_pos += offset;
+        }
+    }
 
   regfree (&re);
   return retc;

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -792,8 +792,21 @@ nasl_egrep (lex_ctxt *lexic)
 
 /**
  * @brief Does extended regular expression pattern matching.
+ * @naslfn{eregmatch}
  *
- * In NASL, this function returns an array.
+ * @nasluparam
+ *
+ * - @a pattern An regex pattern
+ * - @a string A string
+ * - @a icase Boolean, for case sensitve
+ * - @a find_all Boolean, to find all matches
+ *
+ * @naslret An array with the first match (find_all: False)
+ *          or an array with all matches (find_all: TRUE).
+ *          NULL or empty if no match was found.
+ *
+ * @param[in] lexic Lexical context of NASL interpreter.
+ *
  */
 tree_cell *
 nasl_eregmatch (lex_ctxt *lexic)


### PR DESCRIPTION

**What**:
Add `find_all` to eregmatch() nasl function. Backport #875
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The current implementation only returns the first match in the string.
Now it will return all matches if the option `find_all: TRUE` is passed to the function.
For backward compatibility, if FALSE is passed or no option, it will return the first match as before.

<!-- Why are these changes necessary? -->

**How**:
See PR #875 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
