### PR TITLE
[master] Fix loadup master. Backport #878

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Use fchmod to change file permission instead of on open to prevent race conditions [854](https://github.com/greenbone/openvas-scanner/pull/854)
 - Several minor potential security risks in different files, spotted by Code QL [854](https://github.com/greenbone/openvas-scanner/pull/854)
+- Fix plugins upload. Backport #878 [#880](https://github.com/greenbone/openvas/pull/880)
 
 ### Removed
 - Remove handling of source_iface related preferences. [#730](https://github.com/greenbone/openvas/pull/730)

--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1657,6 +1657,8 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   bzero (&ctx, sizeof (ctx));
   if (mode & NASL_ALWAYS_SIGNED)
     ctx.always_signed = 1;
+  if ((mode & NASL_EXEC_DESCR) != 0)
+    ctx.exec_descr = 1;
   if (nvticache_initialized ())
     ctx.kb = nvticache_get_kb ();
   else

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -26,7 +26,10 @@
 typedef struct
 {
   int line_nb;
-  int always_signed;
+  int always_signed; /**< If set disable signature check during scans and feed
+                        upload. */
+  int exec_descr; /**< Tell grammar that is a feed upload process or a running a
+                     scan process. */
   int index;
   tree_cell *tree;
   char *buffer;

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -382,6 +382,25 @@ stop_single_task_scan (void)
 }
 
 /**
+ * @brief Send a failure message and set the scan as finished.
+ *
+ * @param msg Message to send to the client.
+ */
+void
+send_message_to_client_and_finish_scan (const char *msg)
+{
+  char key[1024];
+  kb_t kb;
+
+  snprintf (key, sizeof (key), "internal/%s/scanprefs", global_scan_id);
+  kb = kb_find (prefs_get ("db_address"), key);
+  kb_item_push_str (kb, "internal/results", msg);
+  snprintf (key, sizeof (key), "internal/%s", global_scan_id);
+  kb_item_set_str (kb, key, "finished", 0);
+  kb_lnk_reset (kb);
+}
+
+/**
  * @brief Set up data needed for attack_network().
  *
  * @param globals scan_globals needed for client preference handling.
@@ -401,6 +420,8 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
   if (plugins_cache_init ())
     {
       g_message ("Failed to initialize nvti cache.");
+      send_message_to_client_and_finish_scan (
+          "ERRMSG||||||||||||NVTI cache initialization failed");
       nvticache_reset ();
       exit (1);
     }

--- a/src/pluginload.c
+++ b/src/pluginload.c
@@ -360,6 +360,7 @@ include_dirs (void)
 int
 plugins_cache_init (void)
 {
+  int ret;
   const char *plugins_folder = prefs_get ("plugins_folder");
 
   if (nvticache_init (plugins_folder, prefs_get ("db_address")))
@@ -368,6 +369,10 @@ plugins_cache_init (void)
       return -1;
     }
   include_dirs ();
+  ret = nasl_file_check (plugins_folder, "plugin_feed_info.inc");
+  if (ret)
+    return -1;
+
   return 0;
 }
 

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -52,6 +52,8 @@ total_loading_plugins (void);
 /* From nasl_plugins.c */
 int
 nasl_plugin_add (char *, char *);
+int
+nasl_file_check (const char *, const char *);
 
 int
 nasl_plugin_launch (struct scan_globals *, struct in6_addr *, GSList *, kb_t,


### PR DESCRIPTION
**What**:
Fix loadup master. Backport #878
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When a plugin modification was done quite earlier than the time in which it is put in the feed,
the mtime is older than the feed version and the plugin is no uploaded/updated in the redis cache.
This produced that some metadata or preferences is outdated for vts in this situation.
This patch fix this, and now the upload is always done for all vts to ensure that the cache is up-to-date.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
