### PR TITLE
Fix: two times enable_testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,13 +201,6 @@ configure_file (VERSION.in VERSION @ONLY)
 configure_file (tools/greenbone-nvt-sync.in tools/greenbone-nvt-sync @ONLY)
 configure_file (src/openvas_log_conf.cmake_in src/openvas_log.conf)
 
-## Testing
-
-enable_testing ()
-
-add_custom_target (tests
-                   DEPENDS pcap-test)
-
 ## Program
 
 if (ENABLE_COVERAGE)
@@ -233,9 +226,11 @@ endif (NOT SKIP_SRC)
 
 add_subdirectory (doc)
 
-
-## Tests
+## Testing
 
 enable_testing ()
+
+add_custom_target (tests
+                   DEPENDS pcap-test)
 
 ## End


### PR DESCRIPTION
Instead of having two times enable_testing it is sufficient to enable it
onces.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
