### PR TITLE
Fix: eulabeia scan exit with interrupted

### DIFF
--- a/misc/reporting.c
+++ b/misc/reporting.c
@@ -184,6 +184,7 @@ set_scan_status (const char *global_scan_id, const char *status)
   msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL,
                                      NULL);
 
+  estatus = g_malloc0 (sizeof (*estatus));
   estatus->id = g_strdup (global_scan_id);
   estatus->status = g_strdup (status);
 
@@ -221,6 +222,7 @@ send_failure (const char *global_scan_id, const char *error)
   char *topic_send = NULL, *msg_send = NULL;
   int rc;
 
+  failure = g_malloc0 (sizeof (*failure));
   context = prefs_get ("mqtt_context");
   msg = eulabeia_initialize_message (EULABEIA_INFO_STATUS, EULABEIA_SCAN, NULL,
                                      NULL);

--- a/src/attack.c
+++ b/src/attack.c
@@ -1058,10 +1058,10 @@ attack_network (struct scan_globals *globals)
     goto stop;
   hosts_init (max_hosts);
 
-  g_message ("Vulnerability scan %s started: Target has %d hosts: "
-             "%s, with max_hosts = %d and max_checks = %d",
-             globals->scan_id, gvm_hosts_count (hosts), hostlist, max_hosts,
-             max_checks);
+  g_debug ("Vulnerability scan %s started: Target has %d hosts: "
+           "%s, with max_hosts = %d and max_checks = %d.",
+           globals->scan_id, gvm_hosts_count (hosts), hostlist, max_hosts,
+           max_checks);
 
   set_scan_status (globals->scan_id, "running");
 
@@ -1082,7 +1082,6 @@ attack_network (struct scan_globals *globals)
           "to create thread.",
           __func__);
       set_alive_detection_tid (tid);
-      g_debug ("%s: started alive detection.", __func__);
 
       for (host = get_host_from_queue (alive_hosts_kb, &ad_finished);
            !host && !ad_finished && !scan_is_stopped ();


### PR DESCRIPTION
While calling set_scan_status the estatus was not initialized, this
commit initializes EulabeiaStatus before using it.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
