### PR TITLE
fix error msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix interrupted scan, when the process table is full. [#832](https://github.com/greenbone/openvas-scanner/pull/832)
 - Use fchmod to change file permission instead of on open to prevent race conditions [854](https://github.com/greenbone/openvas-scanner/pull/854)
 - Fix plugins upload [#878](https://github.com/greenbone/openvas/pull/878)
+- Fix Error Message when NVTI chache init failed [#885](https://github.com/greenbone/openvas/pull/885)
 
 [21.4.3]: https://github.com/greenbone/openvas-scanner/compare/v21.4.2...gvmd-21.04
 

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -411,7 +411,7 @@ start_single_task_scan (void)
     {
       g_message ("Failed to initialize nvti cache.");
       send_message_to_client_and_finish_scan (
-        "ERRMSG||||||||||||NVTI cache initialization failed");
+        "ERRMSG||| ||| ||| ||| |||NVTI cache initialization failed");
       exit (1);
     }
   init_signal_handlers ();


### PR DESCRIPTION
**What**:
Fixing a bug where ospd-openvas gets an IndexError. This was caused by openvas because of a small error when sending a error message when the NVTI cache init failed.  The error message should be fixed now.
SC-17
PR-88

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This error caused an exception within ospd-openvas

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/openvas/blob/master/CHANGELOG.md) Entry
