### PR TITLE
Wait for notus to finish

### DIFF
--- a/misc/table_driven_lsc.h
+++ b/misc/table_driven_lsc.h
@@ -31,4 +31,8 @@ gchar *
 make_table_driven_lsc_info_json_str (const char *, const char *, const char *,
                                      const char *, const char *);
 
+gchar *
+get_status_of_table_driven_lsc_from_json (const char *, const char *,
+                                          const char *, int);
+
 #endif // TABLE_DRIVEN_LSC_H

--- a/src/attack.c
+++ b/src/attack.c
@@ -401,31 +401,122 @@ run_table_driven_lsc (const char *scan_id, kb_t kb, const char *ip_str,
   gchar *json_str;
   gchar *package_list;
   gchar *os_release;
+  gchar *topic;
+  gchar *payload;
+  gchar *status = NULL;
+  int topic_len;
+  int payload_len;
   int err = 0;
 
+  // Subscribe to status topic
+  err = mqtt_subscribe ("scanner/status");
+  if (err)
+    {
+      g_warning ("%s: Error starting lsc. Unable to subscribe", __func__);
+      return -1;
+    }
   /* Get the OS release. TODO: have a list with supported OS. */
   os_release = kb_item_get_str (kb, "ssh/login/release_notus");
-  if (NULL == os_release)
-    return err;
-
-  /* Get the package list. Currently only rpm support*/
+  /* Get the package list. Currently only rpm support */
   package_list = kb_item_get_str (kb, "ssh/login/rpms_notus");
-  if (NULL == package_list)
-    return err;
+  if (!os_release || !package_list)
+    return 0;
 
   json_str = make_table_driven_lsc_info_json_str (scan_id, ip_str, hostname,
                                                   os_release, package_list);
   g_free (package_list);
   g_free (os_release);
 
+  // Run table driven lsc
   if (json_str == NULL)
     return -1;
-
   err = mqtt_publish ("scanner/package/cmd/notus", json_str);
-  if (err != 0)
-    g_warning ("%s: Error publishing message for Notus.", __func__);
+  if (err)
+    {
+      g_warning ("%s: Error publishing message for Notus.", __func__);
+      g_free (json_str);
+      return -1;
+    }
 
   g_free (json_str);
+
+  // Wait for Notus scanner to start or interrupt
+  while (!status)
+    {
+      err = mqtt_retrieve_message (&topic, &topic_len, &payload, &payload_len,
+                                   60000);
+      if (err == -1)
+        {
+          g_warning ("%s: Unable to retrieve status message from notus.",
+                     __func__);
+          return -1;
+        }
+      if (err == 1)
+        {
+          g_warning ("%s: Unablet to retrieve message. Timeout after 60s.",
+                     __func__);
+          return -1;
+        }
+
+      // Get status if it belongs to corresponding scan and host
+      // Else wait for next status message
+      status = get_status_of_table_driven_lsc_from_json (scan_id, ip_str,
+                                                         payload, payload_len);
+
+      g_free (topic);
+      g_free (payload);
+    }
+  // If started wait for it to finish or interrupt
+  if (!g_strcmp0 (status, "running"))
+    {
+      g_debug ("%s: table driven LSC with scan id %s succesfully started "
+               "for host %s",
+               __func__, scan_id, ip_str);
+      g_free (status);
+      status = NULL;
+      while (!status)
+        {
+          err = mqtt_retrieve_message (&topic, &topic_len, &payload,
+                                       &payload_len, 60000);
+          if (err == -1)
+            {
+              g_warning ("%s: Unable to retrieve status message from notus.",
+                         __func__);
+              return -1;
+            }
+          if (err == 1)
+            {
+              g_warning ("%s: Unablet to retrieve message. Timeout after 60s.",
+                         __func__);
+              return -1;
+            }
+
+          status = get_status_of_table_driven_lsc_from_json (
+            scan_id, ip_str, payload, payload_len);
+          g_free (topic);
+          g_free (payload);
+        }
+    }
+  else
+    {
+      g_warning ("%s: Unable to start lsc. Got status: %s", __func__, status);
+      g_free (status);
+      return -1;
+    }
+
+  if (g_strcmp0 (status, "finished"))
+    {
+      g_warning (
+        "%s: table driven lsc with scan id %s did not finish successfully "
+        "for host %s. Last status was %s",
+        __func__, scan_id, ip_str, status);
+      err = -1;
+    }
+  else
+    g_debug ("%s: table driven lsc with scan id %s succesfully finished "
+             "for host %s",
+             __func__, scan_id, ip_str);
+  g_free (status);
   return err;
 }
 
@@ -660,7 +751,16 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   if (prefs_get_bool ("table_driven_lsc"))
     {
       g_message ("Running LSC via Notus for %s", ip_str);
-      run_table_driven_lsc (globals->scan_id, kb, ip_str, NULL);
+      if (run_table_driven_lsc (globals->scan_id, kb, ip_str, NULL))
+        {
+          char buffer[2048];
+          snprintf (
+            buffer, sizeof (buffer),
+            "ERRMSG|||%s||| ||| ||| ||| Unable to launch table driven lsc",
+            ip_str);
+          kb_item_push_str (main_kb, "internal/results", buffer);
+          g_warning ("%s: Unable to launch table driven LSC", __func__);
+        }
     }
 
   pluginlaunch_wait (main_kb, kb);


### PR DESCRIPTION
**What**:
Openvas waits for notus to finish before finishing scan.
Depends on https://github.com/greenbone/gvm-libs/pull/612
SC-450

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In order to guarantee a scan is completely done when openvas sets the finished flag, it waits until notus is finished as well.

<!-- Why are these changes necessary? -->

**How**:
Use the complete stack to start a full and fast scan. When enabling debug messages in openvas (for main), the status of the notus scan gets logged. (Alternatively a script that just do the package gathering should be enough too). Also in the `openvas.conf` the option `table_driven_lsc = yes` must be set.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
