### PR TITLE
Fix isotime_add and add zero padding for isotime

### DIFF
--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -279,11 +279,21 @@ string2isotime (my_isotime_t atime, const char *string)
   atime[9] = string[11];
   atime[10] = string[12];
   if (string[13] != ':')
+  {
+    atime[11] = '0';
+    atime[12] = '0';
+    atime[13] = '0';
+    atime[14] = '0';
     return 13;
+  }
   atime[11] = string[14];
   atime[12] = string[15];
   if (string[16] != ':')
+  {
+    atime[13] = '0';
+    atime[14] = '0';
     return 16;
+  }
   atime[13] = string[17];
   atime[14] = string[18];
   return 19;

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -76,7 +76,7 @@
 
 /* The type used to represent the time here is a string with a fixed
    length.  */
-#define ISOTIME_SIZE 19
+#define ISOTIME_SIZE 16
 typedef char my_isotime_t[ISOTIME_SIZE];
 
 /* Correction used to map to real Julian days. */

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -279,21 +279,21 @@ string2isotime (my_isotime_t atime, const char *string)
   atime[9] = string[11];
   atime[10] = string[12];
   if (string[13] != ':')
-  {
-    atime[11] = '0';
-    atime[12] = '0';
-    atime[13] = '0';
-    atime[14] = '0';
-    return 13;
-  }
+    {
+      atime[11] = '0';
+      atime[12] = '0';
+      atime[13] = '0';
+      atime[14] = '0';
+      return 13;
+    }
   atime[11] = string[14];
   atime[12] = string[15];
   if (string[16] != ':')
-  {
-    atime[13] = '0';
-    atime[14] = '0';
-    return 16;
-  }
+    {
+      atime[13] = '0';
+      atime[14] = '0';
+      return 16;
+    }
   atime[13] = string[17];
   atime[14] = string[18];
   return 19;

--- a/nasl/nasl_isotime.c
+++ b/nasl/nasl_isotime.c
@@ -63,6 +63,12 @@
 #include <time.h>
 #include <unistd.h>
 
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "lib  nasl"
+
 #ifndef DIM
 #define DIM(v) (sizeof (v) / sizeof ((v)[0]))
 #define DIMof(type, member) DIM (((type *) 0)->member)


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Size of 19 for ISOTIME_SIZE was introduced with f85dbd3. PR: #252
This broke the nasl_isotime_add function.

When time in the format like '869-10-02 12:34' or
'869-10-02 12' was given to string2isotime() the
function did not fill up the missing seconds and
minutes with zeroes.

Jira: SC-455

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Run `nasl/tests/test_isotime.nasl`. E.g. `openvas-nasl -X -t 127.0.0.1 test_isotime.nasl`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
