### PR TITLE
Change: Only log SSL/TLS failure once per script

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -792,6 +792,7 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
   openvas_connection *fp;
   kb_t kb;
   char buf[1024];
+  static gboolean connection_failed_msg_sent = FALSE; // send msg only once
 
   if (!fd_is_stream (fd))
     {
@@ -817,9 +818,13 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
       g_free (key);
       g_free (passwd);
       g_free (cafile);
-      g_message ("Function socket_negotiate_ssl called from %s: "
-                 "SSL/TLS connection failed.",
-                 nasl_get_plugin_filename ());
+      if (!connection_failed_msg_sent)
+        {
+          g_message ("Function socket_negotiate_ssl called from %s: "
+                     "SSL/TLS connection failed.",
+                     nasl_get_plugin_filename ());
+          connection_failed_msg_sent = TRUE;
+        }
       release_connection_fd (fd, 0);
       return -1;
     }


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Only log SSL/TLS failure once per script

jira: SC-454

**Why**:

<!-- Why are these changes necessary? -->

To many logs.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Start ssl server

```
mkdir /tmp/ssl
cd /tmp/ssl
openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes
# nb: To serve TLSv1.2 with disabled renegotiation
openssl s_server -tls1_2 -key key.pem -cert cert.pem -accept 8443 -www -no_renegotiation
```
Run script

`sudo openvas-nasl -X -B -d -t 127.0.0.1 gb_ssl_tls_secure_renegotiation_supported.nasl --kb="ssl_tls/port=8443" --kb="tls/supported/8443=1"`

Only 1 log entry should be visible about SSL/TLS connection failure.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
