### PR TITLE
Fix function description of nasl_socket_cert_verify()

### DIFF
--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -1447,9 +1447,9 @@ nasl_get_sock_info (lex_ctxt *lexic)
  * This function is used to retrieve and verify a certificate from an
  * active socket. It requires the NASL socket number.
  *
- * @nasluparam
+ * @naslnparam
  *
- * - A NASL socket.
+ * - @a socket A NASL socket.
  *
  * @naslret 0 in case of successfully verification. A positive integer in
  * case of verification error or NULL on other errors.

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -1451,7 +1451,7 @@ nasl_get_sock_info (lex_ctxt *lexic)
  *
  * - @a socket A NASL socket.
  *
- * @naslret 0 in case of successfully verification. A negative integer in
+ * @naslret 0 in case of successfully verification. A positive integer in
  * case of verification error or NULL on other errors.
  *
  * @param[in] lexic  Lexical context of the NASL interpreter.

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -1451,7 +1451,7 @@ nasl_get_sock_info (lex_ctxt *lexic)
  *
  * - @a socket A NASL socket.
  *
- * @naslret 0 in case of successfully verification. A positive integer in
+ * @naslret 0 in case of successfully verification. A negative integer in
  * case of verification error or NULL on other errors.
  *
  * @param[in] lexic  Lexical context of the NASL interpreter.


### PR DESCRIPTION
`socket` is a named parameter of nasl_socket_cert_verify():

https://github.com/greenbone/openvas-scanner/blob/641ab331b7e22b11e24c9fef0d2c3311af87b1af/nasl/nasl_socket.c#L1477

so this should be reflected accordingly in the function description.

Notes:
- As this is no functional change i have removed the PR template on purpose.
- Please make sure to add the backport labels for at least the stable branch.