### PR TITLE
Fix grammar in socket_cert_verify() function description

### DIFF
--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -1451,8 +1451,8 @@ nasl_get_sock_info (lex_ctxt *lexic)
  *
  * - @a socket A NASL socket.
  *
- * @naslret 0 in case of successfully verification. A positive integer in
- * case of verification error or NULL on other errors.
+ * @naslret 0 in case of successful verification. A positive integer in
+ * case of a verification error or NULL on other errors.
  *
  * @param[in] lexic  Lexical context of the NASL interpreter.
  *


### PR DESCRIPTION
Just some additional grammar corrections as a follow-up to #928 

I leave it up to the development team if / how to do the backports.