### PR TITLE
Refactor: add repository dispatch to container.yml

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, stable, oldstable, middleware ]
     tags: ["v*"]
   workflow_dispatch:
+  repository_dispatch:
 
 jobs:
   main:


### PR DESCRIPTION
To allow gvm-libs to trigger building new docker images the container
workflow should also be triggered on repository_dispatch.
