### PR TITLE
Fix: stable.Dockerfile use gvm-libs as root

### DIFF
--- a/.docker/stable.Dockerfile
+++ b/.docker/stable.Dockerfile
@@ -8,6 +8,7 @@ RUN DESTDIR=/install cmake --build /build -- install
 
 FROM greenbone/community-feed-vts AS feed
 
+FROM greenbone/gvm-libs:$VERSION
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     bison \
     libjson-glib-1.0-0 \


### PR DESCRIPTION
The stable.Dockerfile was using the feed image as a root image which is
incorrect; this changes that to use gvm-libs instead.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
