### PR TITLE
Remove libnet.h include no longer required.

### DIFF
--- a/nasl/nasl_frame_forgery.c
+++ b/nasl/nasl_frame_forgery.c
@@ -33,15 +33,17 @@
 
 #include <errno.h>
 #include <gvm/base/networking.h>
-#include <libnet.h>
 #include <linux/if_packet.h>
 #include <net/ethernet.h>
+#include <net/if.h>
 #include <net/if_arp.h>
 #include <netinet/ether.h>
 #include <netinet/if_ether.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
 
 #undef G_LOG_DOMAIN
 /**


### PR DESCRIPTION
**What**:
Remove libnet.h include no longer required.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It is no longer required. Also, prevent to break the CI checks, as it is not present in the build environment.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
