### PR TITLE
Fix: Check 'reader' for NULL before trying to unreference it during cleanup

### DIFF
--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -161,7 +161,7 @@ get_status_of_table_driven_lsc_from_json (const char *scan_id,
                                           int len)
 {
   JsonParser *parser;
-  JsonReader *reader;
+  JsonReader *reader = NULL;
 
   GError *err = NULL;
   gchar *ret = NULL;
@@ -206,7 +206,8 @@ get_status_of_table_driven_lsc_from_json (const char *scan_id,
   json_reader_end_member (reader);
 
 cleanup:
-  g_object_unref (reader);
+  if (reader)
+    g_object_unref (reader);
   g_object_unref (parser);
   if (err != NULL)
     {


### PR DESCRIPTION
**What**:
Check 'reader' for NULL before trying to unreference it during cleanup
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To fix the `warning: ‘reader’ may be used uninitialized in this function [-Wmaybe-uninitialized]`

<!-- Why are these changes necessary? -->

**How**:
Build with release flag
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
