### PR TITLE
Change: key for notus package list

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -418,7 +418,7 @@ run_table_driven_lsc (const char *scan_id, kb_t kb, const char *ip_str,
   /* Get the OS release. TODO: have a list with supported OS. */
   os_release = kb_item_get_str (kb, "ssh/login/release_notus");
   /* Get the package list. Currently only rpm support */
-  package_list = kb_item_get_str (kb, "ssh/login/rpms_notus");
+  package_list = kb_item_get_str (kb, "ssh/login/package_list_notus");
   if (!os_release || !package_list)
     return 0;
 


### PR DESCRIPTION
**What**:
Adjust key for notus package list acording to FE-1130
SC-480

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Be able to start the notus-scanner for Debian.

<!-- Why are these changes necessary? -->

**How**:
- Start `ospd-openvas` and `notus-scanner`
- Start a scan on a Debian system (I used my own system) with the following script:
```xml
<start_scan scan_id='97079ee9-8917-49da-aa4f-4ef95f757ac1'>
    <vt_selection>
        <vt_single id='1.3.6.1.4.1.25623.1.0.50282'>
        </vt_single>
    </vt_selection>
    <targets>
        <target>
            <hosts>127.0.0.1</hosts>
            <ports>80,8080,443,22</ports>
            <credentials>
                <credential service="ssh" type="up" port="22">
                    <username>username</username>
                    <password>password</password>
                </credential>
            </credentials>
        </target>
    </targets>
    <scanner_params>
    </scanner_params>
</start_scan>
```
- remember to adjust username an password

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
