### PR TITLE
g_memdup2

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -870,10 +870,7 @@ socket_get_cert (int fd, void **cert, int *certlen)
   if (cert_list_len == 0)
     return;
   *certlen = cert_list[0].size;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  *cert = g_memdup (cert_list[0].data, *certlen);
-#pragma GCC diagnostic pop
+  *cert = g_memdup2 (cert_list[0].data, *certlen);
 }
 
 /*

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -932,10 +932,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
         {
           if (type != NULL)
             *type = KB_TYPE_INT;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          ret = g_memdup (&res->v_int, sizeof (res->v_int));
-#pragma GCC diagnostic pop
+          ret = g_memdup2 (&res->v_int, sizeof (res->v_int));
         }
       else
         {
@@ -943,10 +940,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
             *type = KB_TYPE_STR;
           if (len)
             *len = res->len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          ret = g_memdup (res->v_str, res->len + 1);
-#pragma GCC diagnostic pop
+          ret = g_memdup2 (res->v_str, res->len + 1);
         }
       kb_item_free (res);
       return ret;
@@ -968,10 +962,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
             {
               if (type != NULL)
                 *type = KB_TYPE_INT;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              ret = g_memdup (&res->v_int, sizeof (res->v_int));
-#pragma GCC diagnostic pop
+              ret = g_memdup2 (&res->v_int, sizeof (res->v_int));
             }
           else
             {
@@ -979,10 +970,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
                 *type = KB_TYPE_STR;
               if (len)
                 *len = res->len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              ret = g_memdup (res->v_str, res->len + 1);
-#pragma GCC diagnostic pop
+              ret = g_memdup2 (res->v_str, res->len + 1);
             }
           kb_item_free (res_list);
           return ret;

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -195,10 +195,7 @@ nasl_telnet_init (lex_ctxt *lexic)
     n += n2;
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = n;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (buffer, n + 1);
-#pragma GCC diagnostic pop
+  retc->x.str_val = g_memdup2 (buffer, n + 1);
 #undef iac
 #undef data
 #undef option

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -405,10 +405,7 @@ nasl_tolower (lex_ctxt *lexic)
   if (str == NULL)
     return NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  str = g_memdup (str, str_len + 1);
-#pragma GCC diagnostic pop
+  str = g_memdup2 (str, str_len + 1);
   for (i = 0; i < str_len; i++)
     str[i] = tolower (str[i]);
 
@@ -430,10 +427,7 @@ nasl_toupper (lex_ctxt *lexic)
   if (str == NULL)
     return NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  str = g_memdup (str, str_len + 1);
-#pragma GCC diagnostic pop
+  str = g_memdup2 (str, str_len + 1);
   for (i = 0; i < str_len; i++)
     str[i] = toupper (str[i]);
 
@@ -557,7 +551,7 @@ _regreplace (const char *pattern, const char *replace, const char *string,
              1) find out how long the string will be, and allocate buf
              2) copy the part before match, replacement and backrefs to buf
 
-             Jaakko Hyvätti <Jaakko.Hyvatti@iki.fi>
+             Jaakko Hyv?tti <Jaakko.Hyvatti@iki.fi>
            */
 
           new_l = strlen (buf) + subs[0].rm_so; /* part before the match */
@@ -1254,10 +1248,7 @@ nasl_strstr (lex_ctxt *lexic)
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = sz_a - (c - a);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (c, retc->size + 1);
-#pragma GCC diagnostic pop
+  retc->x.str_val = g_memdup2 (c, retc->size + 1);
   return retc;
 }
 


### PR DESCRIPTION
- Fix: use g_memdup2 inseatd of g_memdup
- Fix: use g_memdup2 instead of g_memdup
- Fix: use g_memdup2 instead of g_memdup
- Fix: use g_memdup2 instead of g_memdup
