### PR TITLE
Refactor: add hostname to unable to SSL authenticate message

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -813,7 +813,6 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
   fp->priority = NULL;
   if (open_SSL_connection (fp, cert, key, passwd, cafile, hostname) <= 0)
     {
-      g_free (hostname);
       g_free (cert);
       g_free (key);
       g_free (passwd);
@@ -821,10 +820,12 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
       if (!connection_failed_msg_sent)
         {
           g_message ("Function socket_negotiate_ssl called from %s: "
-                     "SSL/TLS connection failed.",
-                     nasl_get_plugin_filename ());
+                     "SSL/TLS connection (host: %s) failed.",
+                     nasl_get_plugin_filename (),
+                     hostname ? hostname : "unknown");
           connection_failed_msg_sent = TRUE;
         }
+      g_free (hostname);
       release_connection_fd (fd, 0);
       return -1;
     }


### PR DESCRIPTION
To test it create a nasl plugin with:

```
soc = open_sock_tcp(22t, transport:ENCAPS_IP );
if( ! soc )
  exit ( 0 );

log_message(data:"opened socket");
if( ! socket_negotiate_ssl( socket:soc ) )
  exit( 0 );
close( soc );
```

Then execute it and verify the that the failed log within openvas is printing the host; e.g.:
```
lib  misc:MESSAGE:2022-01-26 09h53.40 utc:46636: Function socket_negotiate_ssl called from test_socket_negotiate_ssl.nasl: SSL/TLS connection (host: localhost) failed.
```