### PR TITLE
Fix stop scan.

### DIFF
--- a/src/openvas.c
+++ b/src/openvas.c
@@ -569,6 +569,17 @@ openvas (int argc, char *argv[])
   /* openvas --scan-stop */
   if (stop_scan_id)
     {
+      set_default_openvas_prefs ();
+      prefs_config (config_file);
+      if (plugins_cache_init ())
+        {
+          g_message ("Failed to initialize nvti cache. Not possible to "
+                     "stop the scan");
+          nvticache_reset ();
+          exit (1);
+        }
+      nvticache_reset ();
+
       global_scan_id = g_strdup (stop_scan_id);
       stop_single_task_scan ();
       gvm_close_sentry ();

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -576,6 +576,7 @@ openvas (int argc, char *argv[])
           g_message ("Failed to initialize nvti cache. Not possible to "
                      "stop the scan");
           nvticache_reset ();
+          gvm_close_sentry ();
           exit (1);
         }
       nvticache_reset ();


### PR DESCRIPTION
Set preferences and initialize the cache when stopping a scan.
Otherwise, it doesn't find the cache and it segfaults.

Jira: SC-498

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To a void segmentation fault when stopping a scan

<!-- Why are these changes necessary? -->

**How**:
Run a scan and stop it once it has started.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] PR merge commit message adjusted
