### PR TITLE
Add flag to set cipher suite preferences on a TLS session

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -575,6 +575,9 @@ is_ip_address (const char *str)
  * @param cafile The CA file
  * @param hostname Targets hostname
  * @param flags Extra options which can not be set via the priority string
+ *              Supported flags are:
+ *              - NO_PRIORITY_FLAGS
+ *              - INSECURE_DH_PRIME_BITS
  *
  * @return 1 on success. -1 on general error or timeout. -2 if DH prime bits on
  * server side are lower than minimum allowed.

--- a/misc/network.c
+++ b/misc/network.c
@@ -1000,12 +1000,14 @@ socket_get_ssl_ciphersuite (int fd)
 }
 
 /* Extended version of open_stream_connection to allow passing a
-   priority string.
+   priority string and a bit flag variable for setting extra options
+   which can't be set via the priority string.
 
    ABI_BREAK_NOTE: Merge this with open_stream_connection.  */
 int
 open_stream_connection_ext (struct script_infos *args, unsigned int port,
-                            int transport, int timeout, const char *priority)
+                            int transport, int timeout, const char *priority,
+                            int flags)
 {
   int fd;
   openvas_connection *fp;

--- a/misc/network.h
+++ b/misc/network.h
@@ -57,6 +57,11 @@ typedef enum openvas_encaps
 #define IS_ENCAPS_SSL(x) \
   ((x) >= OPENVAS_ENCAPS_SSLv23 && (x) <= OPENVAS_ENCAPS_TLScustom)
 
+/* Define FLAGS for setting other priorities in
+   open_stream_connection_ext */
+#define NO_PRIORITY_FLAGS 0
+#define INSECURE_DH_PRIME_BITS (1 << 0) // 1
+
 /* Plugin specific network functions */
 int
 open_sock_tcp (struct script_infos *, unsigned int, int);

--- a/misc/network.h
+++ b/misc/network.h
@@ -89,7 +89,7 @@ open_stream_connection (struct script_infos *, unsigned int, int, int);
 
 int
 open_stream_connection_ext (struct script_infos *, unsigned int, int, int,
-                            const char *);
+                            const char *, int);
 
 int
 open_stream_auto_encaps_ext (struct script_infos *, unsigned int port,

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -1607,7 +1607,16 @@ plugin_do_run (struct script_infos *desc, GSList *h, int test_ssl)
                 trp = OPENVAS_ENCAPS_IP;
               gettimeofday (&tv1, NULL);
               cnx = open_stream_connection (desc, port, trp, cnx_timeout);
-              if (cnx < 0 && test_ssl)
+              if (cnx == -2 && test_ssl)
+                {
+                  unsigned int flags = INSECURE_DH_PRIME_BITS;
+
+                  gettimeofday (&tv1, NULL);
+                  cnx = open_stream_connection_ext (
+                    desc, port, trp, cnx_timeout, "NORMAL:+ARCFOUR-128:%COMPAT",
+                    flags);
+                }
+              else if (cnx < 0 && test_ssl)
                 {
                   trp = OPENVAS_ENCAPS_IP;
                   gettimeofday (&tv1, NULL);

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -460,8 +460,8 @@ nasl_open_sock_tcp_bufsz (lex_ctxt *lexic, int bufsz)
   else if (transport == 0)
     soc = open_stream_auto_encaps_ext (script_infos, port, to, 1);
   else
-    soc =
-      open_stream_connection_ext (script_infos, port, transport, to, priority);
+    soc = open_stream_connection_ext (script_infos, port, transport, to,
+                                      priority, NO_PRIORITY_FLAGS);
   if (bufsz > 0 && soc >= 0)
     {
       if (stream_set_buffer (soc, bufsz) < 0)


### PR DESCRIPTION
**What**:
Currently, when the scanner opens a TLS session, cipher suite preferences can be set only via the priority string. Other preferences can be set via functions. This PR extends the open_stream_connection_ext() function to accept a flag which allows to set other preferences (e.g. the number of bits, for use in a Diffie-Hellman key exchange)

Jira: SC-441

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
nasl_builtin_find_service.c fails to detect SSL/TLS service because, in this particular case, the server sends a prime of 512 bits, and the client limit is 1008 (set with the NORMAL priority). This PR handles this error and set a new minimum (128) and retries to open the TLS connection.

<!-- Why are these changes necessary? -->

**How**:
sudo openvas-nasl -X -B -d -i $PLUGINSPATH -t `TARGET` find_service.nasl --kb="Ports/tcp/443=1" --debug-tls=9

```
[19893] (1) FFDHE groups advertised, but server didn't support it; falling back to server's choice
[19893] (2) Received a prime of 512 bits, limit is 1008
lib  misc-Message: 03:36:31.165: replace key FindService/CnxTime1000/443 -> 45
lib  misc-Message: 03:36:31.166: set key Transports/TCP/443 -> 1
lib  misc-Message: 03:36:51.279: set key Services/unknown -> 443
```

With the PR:
```
[19263] (1) FFDHE groups advertised, but server didn't support it; falling back to server's choice
[19263] (2) Received a prime of 512 bits, limit is 1008
lib  misc-Message: 03:19:20.218: [19263] gnutls_handshake: The Diffie-Hellman prime sent by the server is not acceptable (not long enough).
[19263] (1) Note that the security level of the Diffie-Hellman key exchange has been lowered to 128 bits and this may allow decryption of the session data
lib  misc-Message: 03:37:38.525: replace key FindService/RwTime1000/443 -> 101
lib  misc-Message: 03:37:38.525: replace key FindService/tcp/443/get_http -> HTTP/1.0 200 OK
Date: Sat, 01 Jan 2011 00:00:53 GMT
Server: Embedded HTTP Server.
Connection: close
Content-Length: 107
Last-Modified: Fri, 28 Feb 2014 14:53:02 GMT
Content-Type: text/html

<HTML><HEAD><meta http-equiv="refresh" content="0; URL=/scgi-bin/platform.cgi"></HEAD><BODY></BODY></HTML>

lib  misc-Message: 03:37:38.525: set key Services/www -> 443
lib  misc-Message: 03:37:38.525: replace key Known/tcp/443 -> www
lib  misc-Message: 03:37:38.525: replace key www/banner/443 -> HTTP/1.0 200 OK
Date: Sat, 01 Jan 2011 00:00:53 GMT
Server: Embedded HTTP Server.
Connection: close
Content-Length: 107
Last-Modified: Fri, 28 Feb 2014 14:53:02 GMT
Content-Type: text/html

<HTML><HEAD><meta http-equiv="refresh" content="0; URL=/scgi-bin/platform.cgi"></HEAD><BODY></BODY></HTML>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
