### PR TITLE
Fix typos in docs, source code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker build -t <image-name> .docker/prod.Dockerfile .
 For more information about building docker images, see 
 [official man](https://docs.docker.com/engine/reference/commandline/build/).
 
->Please beware: The Greenbone docker environment is currently under developement.
+>Please beware: The Greenbone docker environment is currently under development.
 
 ## Support
 

--- a/config/redis-openvas.conf
+++ b/config/redis-openvas.conf
@@ -1131,7 +1131,7 @@ hll-sparse-max-bytes 3000
 # maximum number of items it may contain before switching to a new node when
 # appending new stream entries. If any of the following settings are set to
 # zero, the limit is ignored, so for instance it is possible to set just a
-# max entires limit by setting max-bytes to 0 and max-entries to the desired
+# max entries limit by setting max-bytes to 0 and max-entries to the desired
 # value.
 stream-node-max-bytes 4096
 stream-node-max-entries 100

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1099,7 +1099,7 @@ HTML_STYLESHEET        =
 # cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra stylesheet files is of importance (e.g. the last
 # stylesheet in the list overrules the setting of the previous ones in the

--- a/doc/Doxyfile_full.in
+++ b/doc/Doxyfile_full.in
@@ -1099,7 +1099,7 @@ HTML_STYLESHEET        =
 # cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra stylesheet files is of importance (e.g. the last
 # stylesheet in the list overrules the setting of the previous ones in the

--- a/doc/Doxyfile_xml.in
+++ b/doc/Doxyfile_xml.in
@@ -1099,7 +1099,7 @@ HTML_STYLESHEET        =
 # cascading style sheets that are included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra stylesheet files is of importance (e.g. the last
 # stylesheet in the list overrules the setting of the previous ones in the

--- a/nasl/byteorder.h
+++ b/nasl/byteorder.h
@@ -67,8 +67,8 @@ then to extract a uint16 value at offset 25 in a buffer you do this:
 char *buffer = foo_bar();
 uint16 xx = SVAL(buffer,25);
 
-We are using the byteoder independence of the ANSI C bitshifts to do
-the work. A good optimising compiler should turn this into efficient
+We are using the byteorder independence of the ANSI C bitshifts to do
+the work. A good optimizing compiler should turn this into efficient
 code, especially if it happens to have the right byteorder :-)
 
 I know these macros can be made a bit tidier by removing some of the

--- a/nasl/nasl_frame_forgery.c
+++ b/nasl/nasl_frame_forgery.c
@@ -177,7 +177,7 @@ send_frame (const u_char *frame, int frame_sz, int use_pcap, int timeout,
       return -1;
     }
 
-  // Preapre sockaddr_ll. This is necessary for further captures
+  // Prepare sockaddr_ll. This is necessary for further captures
   u_char dst_haddr[ETHER_ADDR_LEN];
   memcpy (&dst_haddr, (struct pseudo_frame *) frame, ETHER_ADDR_LEN);
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -156,7 +156,7 @@ set_scan_status (char *status)
  * which is vulnerability tested. Launched is the number of plguins(VTs) which
  * got already started. Total is the total number of plugins which will be
  * started for the current host. But here we use the format "current_host/0/-1"
- * for implicit singalling that the host ist dead.
+ * for implicit singalling that the host is dead.
  *
  * @param main_kb Kb to use
  * @param ip_str str representation of host ip
@@ -469,7 +469,7 @@ run_table_driven_lsc (const char *scan_id, kb_t kb, const char *ip_str,
   // If started wait for it to finish or interrupt
   if (!g_strcmp0 (status, "running"))
     {
-      g_debug ("%s: table driven LSC with scan id %s succesfully started "
+      g_debug ("%s: table driven LSC with scan id %s successfully started "
                "for host %s",
                __func__, scan_id, ip_str);
       g_free (status);
@@ -513,7 +513,7 @@ run_table_driven_lsc (const char *scan_id, kb_t kb, const char *ip_str,
       err = -1;
     }
   else
-    g_debug ("%s: table driven lsc with scan id %s succesfully finished "
+    g_debug ("%s: table driven lsc with scan id %s successfully finished "
              "for host %s",
              __func__, scan_id, ip_str);
   g_free (status);


### PR DESCRIPTION
Fixes typographical errors across the project

**What**:

```
developement -> development
entires -> entries
therefor -> therefore
byteoder -> byteorder
optimising -> optimizing
Preapre -> Prepare
ist -> is
succesfully -> successfully
```

**Why**:

Improve clarity of documentation and code comments, especially for non-native English speakers. 
Make the project more "professional". ;)

**How**:

Used codespell to surface possible typos, manual review results to weed out false positives.

When in doubt, use a dictionary or Google to check that the word doesn't have multiple "correct" spellings.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
