### PR TITLE
Fix possible g_memdup() silent memory truncation.

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -871,10 +871,7 @@ socket_get_cert (int fd, void **cert, int *certlen)
   if (cert_list_len == 0)
     return;
   *certlen = cert_list[0].size;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  *cert = g_memdup (cert_list[0].data, *certlen);
-#pragma GCC diagnostic pop
+  *cert = g_memdup2 (cert_list[0].data, *certlen);
 }
 
 /*

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -26,6 +26,7 @@
 #include "plugutils.h"
 
 #include "network.h" // for OPENVAS_ENCAPS_IP
+#include "support.h" // for g_memdup2 workaround
 
 #include <errno.h>               // for errno
 #include <gvm/base/hosts.h>      // for g_vhost_t
@@ -932,10 +933,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
         {
           if (type != NULL)
             *type = KB_TYPE_INT;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          ret = g_memdup (&res->v_int, sizeof (res->v_int));
-#pragma GCC diagnostic pop
+          ret = g_memdup2 (&res->v_int, sizeof (res->v_int));
         }
       else
         {
@@ -943,10 +941,9 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
             *type = KB_TYPE_STR;
           if (len)
             *len = res->len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-          ret = g_memdup (res->v_str, res->len + 1);
-#pragma GCC diagnostic pop
+
+          ret = g_malloc0 (res->len + 1);
+          memcpy (ret, res->v_str, res->len + 1);
         }
       kb_item_free (res);
       return ret;
@@ -968,10 +965,7 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
             {
               if (type != NULL)
                 *type = KB_TYPE_INT;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              ret = g_memdup (&res->v_int, sizeof (res->v_int));
-#pragma GCC diagnostic pop
+              ret = g_memdup2 (&res->v_int, sizeof (res->v_int));
             }
           else
             {
@@ -979,10 +973,9 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
                 *type = KB_TYPE_STR;
               if (len)
                 *len = res->len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              ret = g_memdup (res->v_str, res->len + 1);
-#pragma GCC diagnostic pop
+
+              ret = g_malloc0 (res->len + 1);
+              memcpy (ret, res->v_str, res->len + 1);
             }
           kb_item_free (res_list);
           return ret;

--- a/misc/support.h
+++ b/misc/support.h
@@ -32,4 +32,13 @@
 #endif // __APPLE__ || __FreeBSD__
 #endif // !s6_addr32
 
+// Add backward compatibility for systems with older glib version
+// which still support g_memdup
+// TODO: Remove once our reference system supports g_memdup2
+
+#include <glib.h>
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION < 68
+#define g_memdup2 g_memdup
+#endif
+
 #endif /* not _OPENVAS_MISC_SUPPORT_H */

--- a/nasl/nasl_cert.c
+++ b/nasl/nasl_cert.c
@@ -985,10 +985,9 @@ nasl_cert_query (lex_ctxt *lexic)
 
       retc = alloc_typed_cell (CONST_DATA);
       retc->size = m.size;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      retc->x.str_val = g_memdup (m.data, m.size);
-#pragma GCC diagnostic pop
+      retc->x.str_val = g_malloc0 (m.size);
+      memcpy (retc->x.str_val, m.data, m.size);
+
       gnutls_free (m.data);
       gnutls_free (e.data);
       gnutls_x509_crt_deinit (cert);
@@ -1012,10 +1011,9 @@ nasl_cert_query (lex_ctxt *lexic)
 
       retc = alloc_typed_cell (CONST_DATA);
       retc->size = e.size;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      retc->x.str_val = g_memdup (e.data, e.size);
-#pragma GCC diagnostic pop
+      retc->x.str_val = g_malloc0 (e.size);
+      memcpy (retc->x.str_val, e.data, e.size);
+
       gnutls_free (m.data);
       gnutls_free (e.data);
       gnutls_x509_crt_deinit (cert);

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -25,6 +25,7 @@
 
 #include "nasl_crypto.h"
 
+#include "../misc/support.h"
 #include "exec.h"
 #include "hmacmd5.h"
 #include "nasl_debug.h"
@@ -71,7 +72,7 @@ nasl_gcrypt_hash (lex_ctxt *lexic, int algorithm, void *data, size_t datalen,
   gcry_md_hd_t hd;
   gcry_error_t err;
   tree_cell *retc;
-  int dlen = gcry_md_get_algo_dlen (algorithm);
+  unsigned int dlen = gcry_md_get_algo_dlen (algorithm);
 
   if (data == NULL)
     return NULL;
@@ -100,10 +101,8 @@ nasl_gcrypt_hash (lex_ctxt *lexic, int algorithm, void *data, size_t datalen,
   gcry_md_write (hd, data, datalen);
 
   retc = alloc_typed_cell (CONST_DATA);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (gcry_md_read (hd, algorithm), dlen + 1);
-#pragma GCC diagnostic pop
+  retc->x.str_val = g_malloc0 (dlen + 1);
+  memcpy (retc->x.str_val, gcry_md_read (hd, algorithm), dlen + 1);
   retc->size = dlen;
 
   gcry_md_close (hd);
@@ -343,10 +342,7 @@ hmac_sha384 (const void *key, int keylen, const void *buf, int buflen)
     }
 
   gcry_md_write (hd, buf, buflen);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  ret = g_memdup (gcry_md_read (hd, 0), 48);
-#pragma GCC diagnostic pop
+  ret = g_memdup2 (gcry_md_read (hd, 0), 48);
   gcry_md_close (hd);
   return ret;
 }
@@ -836,10 +832,7 @@ nasl_lm_owf_gen (lex_ctxt *lexic)
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = 16;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (p16, 16);
-#pragma GCC diagnostic pop
+  retc->x.str_val = g_memdup2 (p16, 16);
   return retc;
 }
 

--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -1639,10 +1639,8 @@ encrypt_stream_data (lex_ctxt *lexic, int cipher, const char *caller_func)
   if (cipher == GCRY_CIPHER_ARCFOUR)
     {
       resultlen = datalen;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      tmp = g_memdup (data, datalen);
-#pragma GCC diagnostic pop
+      tmp = g_malloc0 (datalen);
+      memcpy (tmp, data, datalen);
       tmplen = datalen;
     }
   else
@@ -1735,10 +1733,8 @@ encrypt_data (lex_ctxt *lexic, int cipher, int mode)
   if (cipher == GCRY_CIPHER_ARCFOUR)
     {
       resultlen = datalen;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      tmp = g_memdup (data, datalen);
-#pragma GCC diagnostic pop
+      tmp = g_malloc0 (datalen);
+      memcpy (tmp, data, datalen);
       tmplen = datalen;
     }
   else if (cipher == GCRY_CIPHER_3DES)

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -195,10 +195,8 @@ nasl_telnet_init (lex_ctxt *lexic)
     n += n2;
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = n;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (buffer, n + 1);
-#pragma GCC diagnostic pop
+  retc->x.str_val = g_malloc0 (n + 1);
+  memcpy (retc->x.str_val, buffer, n + 1);
 #undef iac
 #undef data
 #undef option

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -1898,11 +1898,8 @@ get_icmp_element (lex_ctxt *lexic)
             get_var_size_by_name (lexic, "icmp") - (ip->ip_hl * 4) - 8;
           if (retc->size > 0)
             {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              retc->x.str_val =
-                g_memdup (&(p[ip->ip_hl * 4 + 8]), retc->size + 1);
-#pragma GCC diagnostic pop
+              retc->x.str_val = g_malloc0 (retc->size + 1);
+              memcpy (retc->x.str_val, &(p[ip->ip_hl * 4 + 8]), retc->size + 1);
             }
           else
             {

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -2026,10 +2026,8 @@ get_icmp_v6_element (lex_ctxt *lexic)
           retc->size = get_var_size_by_name (lexic, "icmp") - 40 - 8;
           if (retc->size > 0)
             {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-              retc->x.str_val = g_memdup (&(p[40 + 8]), retc->size + 1);
-#pragma GCC diagnostic pop
+              retc->x.str_val = g_malloc0 (retc->size + 1);
+              memcpy (retc->x.str_val, &(p[40 + 8]), retc->size + 1);
             }
           else
             {

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -29,6 +29,7 @@
 
 #include "../misc/network.h"       /* for getpts */
 #include "../misc/plugutils.h"     /* for plug_set_id */
+#include "../misc/support.h"       /* for the g_memdup2 workaround */
 #include "../misc/vendorversion.h" /* for vendor_version_get */
 #include "nasl_debug.h"
 #include "nasl_func.h"
@@ -1000,10 +1001,8 @@ security_something (lex_ctxt *lexic, proto_post_something_t proto_post_func,
       int len = get_var_size_by_name (lexic, "data");
       int i;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      dup = g_memdup (data, len + 1);
-#pragma GCC diagnostic pop
+      dup = g_memdup2 (data, len + 1);
+
       for (i = 0; i < len; i++)
         if (dup[i] == 0)
           dup[i] = ' ';

--- a/nasl/nasl_socket.c
+++ b/nasl/nasl_socket.c
@@ -30,6 +30,7 @@
 /*--------------------------------------------------------------------------*/
 #include "../misc/network.h"
 #include "../misc/plugutils.h" /* for plug_get_host_ip */
+#include "../misc/support.h"   /* for the g_memdup2 workaround */
 #include "exec.h"
 #include "nasl.h"
 #include "nasl_debug.h"
@@ -165,16 +166,10 @@ add_udp_data (struct script_infos *script_infos, int soc, char *data, int len)
 {
   GHashTable *udp_data = script_infos->udp_data;
   struct udp_record *data_record = g_malloc0 (sizeof (struct udp_record));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  int *key = g_memdup (&soc, sizeof (int));
-#pragma GCC diagnostic pop
+  int *key = g_memdup2 (&soc, sizeof (int));
 
   data_record->len = len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  data_record->data = g_memdup ((gconstpointer) data, (guint) len);
-#pragma GCC diagnostic pop
+  data_record->data = g_memdup2 ((gconstpointer) data, (guint) len);
 
   if (udp_data == NULL)
     {
@@ -846,10 +841,7 @@ nasl_recv (lex_ctxt *lexic)
   if (new_len > 0)
     {
       tree_cell *retc = alloc_typed_cell (CONST_DATA);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-      retc->x.str_val = g_memdup (data, new_len);
-#pragma GCC diagnostic pop
+      retc->x.str_val = g_memdup2 (data, new_len);
       retc->size = new_len;
       g_free (data);
       return retc;
@@ -918,11 +910,7 @@ nasl_recv_line (lex_ctxt *lexic)
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = new_len;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (data, new_len + 1);
-#pragma GCC diagnostic pop
-
+  retc->x.str_val = g_memdup2 (data, new_len + 1);
   g_free (data);
 
   return retc;

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -398,23 +398,22 @@ tree_cell *
 nasl_tolower (lex_ctxt *lexic)
 {
   tree_cell *retc;
-  char *str = get_str_var_by_num (lexic, 0);
+  char *str = get_str_var_by_num (lexic, 0), *ret;
   int str_len = get_var_size_by_num (lexic, 0);
   int i;
 
   if (str == NULL)
     return NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  str = g_memdup (str, str_len + 1);
-#pragma GCC diagnostic pop
+  ret = g_malloc0 (str_len + 1);
+  memcpy (ret, str, str_len + 1);
+
   for (i = 0; i < str_len; i++)
-    str[i] = tolower (str[i]);
+    ret[i] = tolower (ret[i]);
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = str_len;
-  retc->x.str_val = str;
+  retc->x.str_val = ret;
   return retc;
 }
 
@@ -423,23 +422,22 @@ tree_cell *
 nasl_toupper (lex_ctxt *lexic)
 {
   tree_cell *retc;
-  char *str = get_str_var_by_num (lexic, 0);
+  char *str = get_str_var_by_num (lexic, 0), *ret;
   int str_len = get_var_size_by_num (lexic, 0);
   int i;
 
   if (str == NULL)
     return NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  str = g_memdup (str, str_len + 1);
-#pragma GCC diagnostic pop
+  ret = g_malloc0 (str_len + 1);
+  memcpy (ret, str, str_len + 1);
+
   for (i = 0; i < str_len; i++)
-    str[i] = toupper (str[i]);
+    ret[i] = toupper (ret[i]);
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = str_len;
-  retc->x.str_val = str;
+  retc->x.str_val = ret;
   return retc;
 }
 
@@ -1254,10 +1252,10 @@ nasl_strstr (lex_ctxt *lexic)
 
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = sz_a - (c - a);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-  retc->x.str_val = g_memdup (c, retc->size + 1);
-#pragma GCC diagnostic pop
+
+  retc->x.str_val = g_malloc0 (retc->size + 1);
+  memcpy (retc->x.str_val, c, retc->size + 1);
+
   return retc;
 }
 

--- a/nasl/nasl_var.c
+++ b/nasl/nasl_var.c
@@ -1088,11 +1088,9 @@ get_variable_by_name (lex_ctxt *ctxt, const char *name)
        break;
      case VAR2_STRING:
      case VAR2_DATA:
-#pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wdeprecated-declarations"
-       v->string_form =
-         g_memdup ((char *) v->v.v_str.s_val ?: "", v->v.v_str.s_siz + 1);
-#pragma GCC diagnostic pop
+       v->string_form = g_malloc0 (v->v.v_str.s_siz + 1);
+       memcpy (v->string_form, (char *) v->v.v_str.s_val ?: "",
+               v->v.v_str.s_siz + 1);
        break;
      case VAR2_UNDEF:
        break;


### PR DESCRIPTION
**What**:
Fix possible g_memdup() silent memory truncation.
Also, prepare openvas for supporting g_memdup2(), since g_memdup() is deprecated since GLib version 2.68.

Jira: SC-502

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Replace g_memdup() with memcpy() in some places, since g_memdup expects an guint (unsigned int)
and some functions were passing bigger memory sizes (like size_t). This avoid truncation.

Replace g_memdup() with g_memdup2() where possible.
For backward compatibility with system with GLib < v2.68, preprocessor directives were added to continue using g_memdup()
This is only for those cases in which the caller function pass valid size.

<!-- Why are these changes necessary? -->

**How**:
Run the following script with `openvas-nasl -X ../my_nasl/memcpy.nasl `
```
$ cat ../my_nasl/memcpy.nasl

a = "AAAAAAAAAAAAAAA";
display (tolower(a));
display(a);

b= "bbbbbbbbbbbbbbbb";
display (toupper(b));
display(b);

c = "hola mundo";
display (strstr(c, "la"));
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
