### PR TITLE
Change: Don't wrap-up the scan.

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -552,17 +552,8 @@ launch_plugin (struct scan_globals *globals, struct scheduler_plugin *plugin,
     }
   if (scan_is_stopped ())
     {
-      if (nvti_category (nvti) != ACT_END)
-        {
-          plugin->running_state = PLUGIN_STATUS_DONE;
-          goto finish_launch_plugin;
-        }
-      else
-        {
-          name = nvticache_get_filename (oid);
-          g_message ("Stopped scan wrap-up: Launching %s (%s)", name, oid);
-          g_free (name);
-        }
+      plugin->running_state = PLUGIN_STATUS_DONE;
+      goto finish_launch_plugin;
     }
 
   if (prefs_get_bool ("safe_checks")


### PR DESCRIPTION
**What**:
Change: Don't wrap-up the scan.
Jira: SC-378
Jira: SC-34

<!--
  Describe 
what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently a wrap-up is performed for stopped scan, which launch plugins in the ACT_END category, before finishing.
This has more disadvantage than advantages. If a scan is stopped, it is supposed that no more info is necessary.
Also, in case of resuming the scan, all results of non-finished hosts will be removed.

This is causing to leave some results or keys in the host's kb, after the kbs were released, which could produce to mix results for the next started scan.

<!-- Why are these changes necessary? -->

**How**:

Run a F&F scan, wait some minutes and stop it. Check in redis if there is some KB, with info, but it is not set as taken in the db namespace 0.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
