### PR TITLE
Fix: starting notus-scanner after stop-scan

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -748,7 +748,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
       pluginlaunch_wait_for_free_process (main_kb, kb);
     }
 
-  if (prefs_get_bool ("table_driven_lsc"))
+  if (!scan_is_stopped () && prefs_get_bool ("table_driven_lsc"))
     {
       g_message ("Running LSC via Notus for %s", ip_str);
       if (run_table_driven_lsc (globals->scan_id, kb, ip_str, NULL))


### PR DESCRIPTION
**What**:
Do not start notus-scanner after a scan is stopped.
SC-501

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The behavior of getting results from notus after a scan is successfully stopped is misleading to the operation.

<!-- Why are these changes necessary? -->

**How**:
Start a full and fast scan and stop it at 80% This will ensure that `gather-package-list.nasl` definitely ran.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
