### PR TITLE
Change: handle Fatal alert during handshake.

### DIFF
--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -1619,6 +1619,14 @@ plugin_do_run (struct script_infos *desc, GSList *h, int test_ssl)
                 }
               else if (cnx < 0 && test_ssl)
                 {
+                  if (cnx == -3)
+                    {
+                      host_fqdn = plug_get_host_fqdn (desc);
+                      g_message ("%s: A TLS fatal alert has been received "
+                                 "during the handshake with %s:%d",
+                                 __func__, host_fqdn, port);
+                      g_free (host_fqdn);
+                    }
                   trp = OPENVAS_ENCAPS_IP;
                   gettimeofday (&tv1, NULL);
                   cnx = open_stream_connection (desc, port, trp, cnx_timeout);


### PR DESCRIPTION
**What**:
Change: handle Fatal alert during handshake.

**Why**:
This would make users aware that there is some kind of connectivity issue to the server, be it some strange SSL/TLS configuration or a required client certificate.

**How**:
```
$ mkdir -p /tmp/ssl
$ cd /tmp/ssl
$ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes
$ openssl s_server -tls1_2 -key key.pem -cert cert.pem -CAfile cert.pem -accept 8443 -www -Verify 1

openvas-nasl -X -B -d -t 127.0.0.1 -i $VTDIR find_service.nasl --kb="Ports/tcp/8443=1"
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
