### PR TITLE
Change: support error recovery during nasl parsing

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -50,7 +50,7 @@
 #define G_LOG_DOMAIN "lib  nasl"
 
 extern int
-naslparse (naslctxt *);
+naslparse (naslctxt *, int *);
 
 static int
 cell2bool (lex_ctxt *lexic, tree_cell *c)
@@ -1632,6 +1632,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   tree_cell tc;
   const char *str, *name = script_infos->name, *oid = script_infos->oid;
   gchar *short_name = g_path_get_basename (name);
+  int error_counter = 0;
 
   nasl_set_plugin_filename (short_name);
   g_free (short_name);
@@ -1664,9 +1665,10 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
 
   if (init_nasl_ctx (&ctx, name) == 0)
     {
-      if (naslparse (&ctx))
+      err = naslparse (&ctx, &error_counter);
+      if (err != 0 || error_counter > 0)
         {
-          g_message ("%s: Parse error at or near line %d", name, ctx.line_nb);
+          g_message ("%s. There were %d parse errors.\n", name, error_counter);
           nasl_clean_ctx (&ctx);
           g_chdir (old_dir);
           g_free (old_dir);

--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -1,6 +1,6 @@
 %define api.pure
-%parse-param {naslctxt * parm}
-%lex-param {naslctxt * parm}
+%parse-param {naslctxt * parm}{int * err_c}
+%lex-param {naslctxt * parm}{int * err_c}
 %expect 1
 %{
 /* Based on work Copyright (C) 2002 - 2004 Michel Arboi and Renaud Deraison
@@ -23,6 +23,8 @@
 
 #define YYPARSE_PARAM parm
 #define YYLEX_PARAM parm
+#define YYPARSE_ERRC err_c
+#define YYLEX_ERRC err_c
 
 #define LNB	(((naslctxt*)parm)->line_nb)
 
@@ -51,7 +53,7 @@ static char *parse_buffer = NULL;
 
 static int parse_len = 0;
 
-static void naslerror(naslctxt *, const char *);
+static void naslerror(naslctxt *, int *, const char *);
 
 GHashTable *includes_hash = NULL;
 
@@ -69,7 +71,7 @@ GHashTable *includes_hash = NULL;
 }
 
 %{
-static int nasllex(YYSTYPE * lvalp, void * parm);
+static int nasllex(YYSTYPE * lvalp, void * parm, int * err_c);
 %}
 
 %token IF
@@ -216,7 +218,9 @@ instr_list: instr
 	} ;
 
 /* Instructions */
-instr: simple_instr ';' { $$ = $1; } | block | if_block | loop ;
+instr: simple_instr ';' { $$ = $1; } | block | if_block | loop
+        | error ';' {yyerrok;}
+        ;
 
 /* "simple" instruction */
 simple_instr : aff | post_pre_incr | rep
@@ -313,6 +317,11 @@ inc: INCLUDE '(' string ')'
 	{
           char *tmp;
 	  naslctxt	subctx;
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+          int * error_counter;
+  #pragma GCC diagnostic pop
+          error_counter = (int*)err_c;
 
           bzero (&subctx, sizeof (subctx));
           subctx.always_signed = ((naslctxt*)parm)->always_signed;
@@ -335,7 +344,7 @@ inc: INCLUDE '(' string ')'
             }
           else if (init_nasl_ctx (&subctx, $3) >= 0)
             {
-              if (!naslparse (&subctx))
+              if (!naslparse (&subctx, err_c))
                 {
                   $$ = subctx.tree;
                   g_hash_table_insert (includes_hash, $3, $$);
@@ -535,10 +544,12 @@ glob: GLOBAL arg_decl
 #include <gcrypt.h>
 
 static void
-naslerror(naslctxt *parm, const char *s)
+naslerror(naslctxt *parm, int *error_counter, const char *s)
 {
   (void) parm;
+  (*error_counter)++;
   g_message ("%s", s);
+  g_message ("Parse error at or near line %d", LNB);
 }
 
 static GSList * inc_dirs = NULL;
@@ -1439,8 +1450,12 @@ mylex (YYSTYPE *lvalp, void *parm)
 }
 
 static int
-nasllex(YYSTYPE * lvalp, void * parm)
+nasllex(YYSTYPE * lvalp, void * parm, int * err_c)
 {
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
+  (void) err_c;
+  #pragma GCC diagnostic pop
   int	x = mylex (lvalp, parm);
   return x;
 }

--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -548,8 +548,8 @@ naslerror(naslctxt *parm, int *error_counter, const char *s)
 {
   (void) parm;
   (*error_counter)++;
-  g_message ("%s", s);
-  g_message ("Parse error at or near line %d", LNB);
+  g_message ("Parse error at or near line %d:", LNB);
+  g_message ("    %s", s);
 }
 
 static GSList * inc_dirs = NULL;


### PR DESCRIPTION
**What**:
Change: support error recovery during nasl parsing
Jira: SC-169

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Now is possible to detect more than one syntax error during the parsing.
Without the patch, only the first error was shown and the file must be parsed once for each error.$ cat linter-test.nasl


<!-- Why are these changes necessary? -->

**How**:

For testing, run the following nasl script with `openvas-nasl-lint linter-test.nasl`

```
display ("AAAAAA")
a = "1234";
display("bbbbbb")
d = 1234;
display("CCCCCC");
display("DDDDDD);
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
