### PR TITLE
Change: consider a malformed regex as a nasl parse error for built-in RE_MATCH and RE_NOMATCH

### DIFF
--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -27,6 +27,7 @@
 #define YYLEX_ERRC err_c
 
 #define LNB	(((naslctxt*)parm)->line_nb)
+#define ERRC	err_c
 
 #include <ctype.h> /* for isalpha */
 #include <pcap.h> /* for islocalhost */
@@ -460,8 +461,8 @@ expr: '(' expr ')' { $$ = $2; }
 	| post_pre_incr
 	| expr MATCH expr { $$ = alloc_expr_cell(LNB, COMP_MATCH, $1, $3); }
 	| expr NOMATCH expr { $$ = alloc_expr_cell(LNB, COMP_NOMATCH, $1, $3); }
-	| expr RE_MATCH string { $$ = alloc_RE_cell(LNB, COMP_RE_MATCH, $1, $3); }
-	| expr RE_NOMATCH string { $$ = alloc_RE_cell(LNB, COMP_RE_NOMATCH, $1, $3); }
+	| expr RE_MATCH string { $$ = alloc_RE_cell(LNB, COMP_RE_MATCH, $1, $3, ERRC); }
+	| expr RE_NOMATCH string { $$ = alloc_RE_cell(LNB, COMP_RE_NOMATCH, $1, $3, ERRC); }
 	| expr '<' expr { $$ = alloc_expr_cell(LNB, COMP_LT, $1, $3); }
 	| expr '>' expr { $$ = alloc_expr_cell(LNB, COMP_GT, $1, $3); }
 	| expr EQ expr  { $$ = alloc_expr_cell(LNB, COMP_EQ, $1, $3); }

--- a/nasl/nasl_tree.c
+++ b/nasl/nasl_tree.c
@@ -45,7 +45,7 @@ alloc_typed_cell (int typ)
 }
 
 tree_cell *
-alloc_RE_cell (int lnb, int t, tree_cell *l, char *re_str)
+alloc_RE_cell (int lnb, int t, tree_cell *l, char *re_str, int *err_c)
 {
   regex_t *re = g_malloc0 (sizeof (regex_t));
   int e;
@@ -65,6 +65,7 @@ alloc_RE_cell (int lnb, int t, tree_cell *l, char *re_str)
       nasl_perror (NULL, "Line %d: Cannot compile regex: %s (error %d: %s)\n",
                    lnb, re_str, e, errbuf);
       g_free (re);
+      *err_c = *err_c + 1;
     }
   g_free (re_str);
   return c;

--- a/nasl/nasl_tree.h
+++ b/nasl/nasl_tree.h
@@ -122,7 +122,7 @@ typedef struct TC
 tree_cell *
 alloc_expr_cell (int, int, tree_cell *, tree_cell *);
 tree_cell *
-alloc_RE_cell (int, int, tree_cell *, char *);
+alloc_RE_cell (int, int, tree_cell *, char *, int *);
 tree_cell *
 alloc_typed_cell (int);
 int


### PR DESCRIPTION
**What**:
consider a malformed regex as a nasl parse error for built-in RE_MATCH and RE_NOMATCH
Jira: SC-175

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When the nasl script with a malformed regex is parsed, the parser logs a parse error. When the file is parsed via openvas-nasl-ling, the log message is shown but the error count is still 0. Now the malformed regex count +1 for the linter.

<!-- Why are these changes necessary? -->

**How**:
```
model = "X300WG";
if (model =~ "^(X300WG|Xx2[0-9]{2}"){}
```
```
$ openvas-nasl-lint regex_issue_reproducer.nasl
lib  nasl-Message: 05:04:39.771: [827796]()(regex_issue_reproducer.nasl:0) Line 18: Cannot compile regex: NASL.+Test( (error 8: Unmatched ( or \()

lib  nasl-Message: 05:04:39.771: regex_issue_reproducer.nasl. There were 1 parse errors.

Error while processing regex_issue_reproducer.nasl.
1 errors found
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
