### PR TITLE
Remove: remove MD5 support from feed integrity check

### DIFF
--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -616,12 +616,6 @@ load_checksums (kb_t kb)
   snprintf (filename, sizeof (filename), "%s/sha256sums", base);
   if (g_file_get_contents (filename, &fbuffer, &flen, NULL))
     checksum_algorithm = GCRY_MD_SHA256;
-  else
-    {
-      snprintf (filename, sizeof (filename), "%s/md5sums", base);
-      if (g_file_get_contents (filename, &fbuffer, &flen, NULL))
-        checksum_algorithm = GCRY_MD_MD5;
-    }
   if (checksum_algorithm == GCRY_MD_NONE)
     {
       g_warning ("No plugins checksums file");
@@ -644,12 +638,7 @@ load_checksums (kb_t kb)
       g_warning ("%s: Couldn't read file %s", __func__, filename);
       return;
     }
-  if (checksum_algorithm == GCRY_MD_MD5)
-    {
-      kb_del_items (kb, "md5sums:*");
-      prefix = "md5sums";
-    }
-  else
+  if (checksum_algorithm == GCRY_MD_SHA256)
     {
       kb_del_items (kb, "sha256sums:*");
       prefix = "sha256sums";
@@ -696,7 +685,7 @@ file_checksum (const char *filename, int algorithm)
   char *content = NULL, digest[128], *result;
   size_t len = 0, i, alglen;
 
-  assert (algorithm == GCRY_MD_MD5 || algorithm == GCRY_MD_SHA256);
+  assert (algorithm == GCRY_MD_SHA256);
   if (!filename || !g_file_get_contents (filename, &content, &len, NULL))
     return NULL;
 
@@ -799,8 +788,6 @@ init_nasl_ctx(naslctxt* pc, const char* name)
   load_checksums (pc->kb);
   if (checksum_algorithm == GCRY_MD_NONE)
     return -1;
-  else if (checksum_algorithm == GCRY_MD_MD5)
-    snprintf (key_path, sizeof (key_path), "md5sums:%s", filename);
   else if (checksum_algorithm == GCRY_MD_SHA256)
     snprintf (key_path, sizeof (key_path), "sha256sums:%s", filename);
   else


### PR DESCRIPTION
**What**:
Since long, SHA256 is the default algorithm to check the nasl scripts checksum.

Jira SC-558
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was deprecated and not used anymore
<!-- Why are these changes necessary? -->

**How**:
Run the plugin upload with signature check enabled, and in redis you must see the sha256 hashes loaded, as before. Unless you have a special setup without sha256sum support, there should not be changes in respect with the current behaviour.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
