### PR TITLE
Change: nasl linter error count message

### DIFF
--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -221,7 +221,7 @@ main (int argc, char **argv)
   if (nvt_files != NULL)
     err += process_files (nvt_files, mode, script_infos);
 
-  g_print ("%d errors found\n", err);
+  g_print ("%d scripts with one or more errors found\n", err);
 
   g_free (script_infos);
 


### PR DESCRIPTION


**What**:
Change: nasl linter error count message
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Now has the format "%d scripts with one or more errors where found\n" instead of "%d errors found", because it counts scripts errors and not total errors (a script can have more than one error)
<!-- Why are these changes necessary? -->

**How**:
Run the nasl linter against some script with errors.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
