### PR TITLE
Change: extend nasl_wmi_connect*() functions.

### DIFF
--- a/nasl/nasl_wmi.c
+++ b/nasl/nasl_wmi.c
@@ -176,7 +176,7 @@ nasl_wmi_connect (lex_ctxt *lexic)
   argv[3] = g_strdup_printf ("//%s%s", ip, options ? options : "");
   argv[4] = g_strdup (ns);
   g_free (ip);
-  g_message ("Using sign option!!!");
+
   tree_cell *retc = alloc_typed_cell (CONST_INT);
   handle = wmi_connect (argc, argv);
   if (!handle)

--- a/nasl/nasl_wmi.c
+++ b/nasl/nasl_wmi.c
@@ -150,6 +150,7 @@ nasl_wmi_connect (lex_ctxt *lexic)
   IMPORT (username);
   IMPORT (password);
   IMPORT (ns);
+  IMPORT (options);
 
   if (ns == NULL)
     ns = "root\\cimv2";
@@ -172,10 +173,10 @@ nasl_wmi_connect (lex_ctxt *lexic)
   argv[0] = g_strdup ("wmic");
   argv[1] = g_strdup ("-U");
   argv[2] = g_strdup_printf ("%s%%%s", username, password);
-  argv[3] = g_strdup_printf ("//%s", ip);
+  argv[3] = g_strdup_printf ("//%s%s", ip, options ? options : "");
   argv[4] = g_strdup (ns);
   g_free (ip);
-
+  g_message ("Using sign option!!!");
   tree_cell *retc = alloc_typed_cell (CONST_INT);
   handle = wmi_connect (argc, argv);
   if (!handle)
@@ -292,6 +293,8 @@ nasl_wmi_connect_rsop (lex_ctxt *lexic)
   char *ip;
   IMPORT (username);
   IMPORT (password);
+  IMPORT (options);
+
   char *argv[4];
   WMI_HANDLE handle;
   int argc = 4;
@@ -314,7 +317,7 @@ nasl_wmi_connect_rsop (lex_ctxt *lexic)
   argv[0] = g_strdup ("wmic");
   argv[1] = g_strdup ("-U");
   argv[2] = g_strdup_printf ("%s%%%s", username, password);
-  argv[3] = g_strdup_printf ("//%s", ip);
+  argv[3] = g_strdup_printf ("//%s%s", ip, options ? options : "");
   g_free (ip);
 
   tree_cell *retc = alloc_typed_cell (CONST_INT);
@@ -403,6 +406,8 @@ nasl_wmi_connect_reg (lex_ctxt *lexic)
   char *ip;
   IMPORT (username);
   IMPORT (password);
+  IMPORT (options);
+
   char *argv[4];
   WMI_HANDLE handle;
   int argc = 4;
@@ -425,7 +430,7 @@ nasl_wmi_connect_reg (lex_ctxt *lexic)
   argv[0] = g_strdup ("wmic");
   argv[1] = g_strdup ("-U");
   argv[2] = g_strdup_printf ("%s%%%s", username, password);
-  argv[3] = g_strdup_printf ("//%s", ip);
+  argv[3] = g_strdup_printf ("//%s%s", ip, options ? options : "");
   g_free (ip);
 
   tree_cell *retc = alloc_typed_cell (CONST_INT);


### PR DESCRIPTION
**What**:
Change: extend nasl_wmi_connect*() functions.
Resolve greenbone/openvas-smb#41

Jira: SC-568

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Now accept an optional 'options' parameter which accept options like [sign,seal] or [spnego] [ntlm]. See openvas-smb/samba/librpc/rpc/dcerpc_util.c for more options.

<!-- Why are these changes necessary? -->

**How**:
`sudo openvas-nasl -X -d -D -i /home/jnicola/install/var/lib/openvas/vts/scripts wmiacces.nasl -t 192.168.1.1 --kb="SMB/login=DOMAIN\USER" --kb="SMB/password=PASS"`

```
host    = get_host_ip();
usrname = get_kb_item( "SMB/login" );
passwd  = get_kb_item( "SMB/password" );
display(11);
if( ! host || ! usrname || ! passwd ) exit( 0 );

domain = get_kb_item( "SMB/domain" );
if( domain ) usrname = domain + '\\' + usrname;

opts = "[sign]";
handle = wmi_connect( host:host, username:usrname, password:passwd, options:opts);

if( ! handle ) exit( 0 );

a = wmi_query( wmi_handle:handle, query:"select * from Win32_ComputerSystem");
display (a);

wmi_close( wmi_handle:handle );

set_kb_item( name:"WMI/access_successful", value:TRUE );
set_kb_item( name:"SMB_or_WMI/access_successful", value:TRUE );

```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
