### PR TITLE
Remove: wincmd (winexe) dependency

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -33,7 +33,6 @@ pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.4)
 
 pkg_check_modules (OPENVAS_WMICLIENT libopenvas_wmiclient>=1.0.5)
-pkg_check_modules (OPENVAS_WINCMD libopenvas_wincmd>=1.0.5)
 
 message (STATUS "Looking for pcap...")
 find_library (PCAP pcap)

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -55,7 +55,6 @@ pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
 pkg_check_modules (LIBGVM_UTIL REQUIRED libgvm_util>=22.4)
 
 pkg_check_modules (OPENVAS_WMICLIENT libopenvas_wmiclient>=1.0.5)
-pkg_check_modules (OPENVAS_WINCMD libopenvas_wincmd>=1.0.5)
 
 # for 'nasl' binary
 pkg_check_modules (LIBSSH REQUIRED libssh>=0.6.0)
@@ -178,10 +177,6 @@ if (NOT OPENVAS_WMICLIENT_FOUND)
   set (FILES smb_interface_stub.c wmi_interface_stub.c ${FILES})
 endif (NOT OPENVAS_WMICLIENT_FOUND)
 
-if (NOT OPENVAS_WINCMD_FOUND)
-  set (FILES smb_interface_stub.c ${FILES})
-endif (NOT OPENVAS_WINCMD_FOUND)
-
 if (KSBA)
   add_definitions (-DHAVE_LIBKSBA)
 endif (KSBA)
@@ -219,7 +214,7 @@ target_link_libraries (openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS}
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m
                          ${LIBGVM_BASE_LDFLAGS}
                          ${LIBGVM_UTIL_LDFLAGS}
-                         ${OPENVAS_WMICLIENT_LDFLAGS} ${OPENVAS_WINCMD_LDFLAGS}
+                         ${OPENVAS_WMICLIENT_LDFLAGS}
                          ${GNUTLS_LDFLAGS} ${PCAP_LDFLAGS} ${LIBSSH_LDFLAGS}
                          ${KSBA_LDFLAGS} ${SNMP_LDFLAGS}
                          ${LINKER_HARDENING_FLAGS})

--- a/nasl/openvas_smb_interface.h
+++ b/nasl/openvas_smb_interface.h
@@ -44,7 +44,5 @@ char *
 smb_file_GroupSID (SMB_HANDLE, const char *);
 char *
 smb_file_TrusteeRights (SMB_HANDLE, const char *);
-int
-wincmd (int argc, char *argv[], char **res);
 
 #endif

--- a/nasl/smb_interface_stub.c
+++ b/nasl/smb_interface_stub.c
@@ -151,21 +151,3 @@ smb_file_TrusteeRights (SMB_HANDLE handle, const char *filename)
   (void) filename;
   return NULL;
 }
-
-/**
- * @brief Command Execution in Windows
- *
- * @param[in] argc - Connection strings
- *
- * @param[in] argv - Number of arguments
- *
- * @return, 0 on success, -1 on failure
- */
-int
-wincmd (int argc, char *argv[], char **res)
-{
-  (void) argc;
-  (void) argv;
-  (void) res;
-  return -1;
-}


### PR DESCRIPTION
**What**:
Fixes a issue with the newest Version of smb-openvas, in which the openvas-scanner was not able to compile. This PR removes the dependency to the deleted wincmd (winexe) module of openvas-smb.
SC-572

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
openvas-scanner was unable to compile with the latest openvas-smb version

<!-- Why are these changes necessary? -->

**How**:
Try to compile. Maybe start a scan which uses the smb stuff to check if something broke.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
