### PR TITLE
Fix: duplicate results

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -380,6 +380,42 @@ msg_type_to_str (msg_t type)
 }
 
 /**
+ * @brief Check if the current main kb corresponds to the
+ *        original scan main kb.
+ * @description Compares the scan id in globals, set at the beginning
+ *              of the scan, with the one found in the main kb.
+ *              It helps to detect that the kb was not taken by another
+ *              task/scan, and that the current plugins does not stores
+ *              results in a wrong kb.
+ *
+ * @param desc    The script infos where to get settings.
+ * @param main_kb Current main kb.
+ *
+ * @return 0 on success, -1 on inconsistency.
+ */
+
+int
+check_kb_inconsistency (struct scan_globals *globals, kb_t main_kb)
+{
+  const char *original_scan_id;
+  char *current_scan_id;
+
+  original_scan_id = globals->scan_id;
+  current_scan_id = kb_item_get_str (main_kb, ("internal/scanid"));
+
+  if (!g_strcmp0 (original_scan_id, current_scan_id))
+    {
+      g_free (current_scan_id);
+      return 0;
+    }
+
+  g_warning ("KB inconsitency. %s writing into %s KB", original_scan_id,
+             current_scan_id);
+  g_free (current_scan_id);
+  return -1;
+}
+
+/**
  * @brief Post a security message (e.g. LOG, NOTE, WARNING ...).
  *
  * @param oid   The oid of the NVT

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -472,8 +472,10 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
       g_string_free (action_str, TRUE);
       return;
     }
+
   kb = plug_get_results_kb (desc);
-  kb_item_push_str (kb, "internal/results", data);
+  if (check_kb_inconsistency (desc->globals, kb) == 0)
+    kb_item_push_str (kb, "internal/results", data);
   g_free (data);
   g_free (buffer);
   g_string_free (action_str, TRUE);

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -388,7 +388,7 @@ msg_type_to_str (msg_t type)
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param desc    The script infos where to get settings.
+ * @param globals The script infos where to get settings.
  * @param main_kb Current main kb.
  *
  * @return 0 on success, -1 on inconsistency.

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -147,6 +147,9 @@ host_get_port_state_udp (struct script_infos *, int);
  * Inter Plugins Communication functions
  */
 
+int
+check_kb_inconsistency (struct scan_globals *, kb_t);
+
 void
 plug_set_key (struct script_infos *, char *, int, const void *);
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -53,7 +53,7 @@
 #include <gvm/util/mqtt.h>
 #include <gvm/util/nvticache.h> /* for nvticache_t */
 #include <pthread.h>
-#include <stdlib.h>   /* for exit() */
+#include <signal.h>
 #include <string.h>   /* for strlen() */
 #include <sys/wait.h> /* for waitpid() */
 #include <unistd.h>   /* for close() */
@@ -426,6 +426,7 @@ run_table_driven_lsc (const char *scan_id, kb_t kb, const char *ip_str,
       return -1;
     }
   /* Get the OS release. TODO: have a list with supported OS. */
+
   os_release = kb_item_get_str (kb, "ssh/login/release_notus");
   /* Get the package list. Currently only rpm support */
   package_list = kb_item_get_str (kb, "ssh/login/package_list_notus");
@@ -637,6 +638,8 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   /* Used for the status */
   int num_plugs, forks_retry = 0, all_plugs_launched = 0;
   char ip_str[INET6_ADDRSTRLEN];
+  struct scheduler_plugin *plugin;
+  pid_t parent, me;
 
   addr6_to_str (ip, ip_str);
   openvas_signal (SIGUSR2, set_check_new_vhosts_flag);
@@ -653,9 +656,6 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   num_plugs = plugins_scheduler_count_active (sched);
   for (;;)
     {
-      struct scheduler_plugin *plugin;
-      pid_t parent;
-
       /* Check that our father is still alive */
       parent = getppid ();
       if (parent <= 1 || process_alive (parent) == 0)
@@ -664,8 +664,22 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
           return;
         }
 
+      if (check_kb_inconsistency (globals, main_kb) != 0)
+        {
+          // As long as we don't have a proper communication channel
+          // to our ancestors we just kill our parent and ourselves
+          // (but let our grandparents live).
+          // To prevent duplicate results we don't let ACT_END run.
+          me = getpid ();
+          kill (parent, SIGQUIT);
+          // just in case
+          kill (me, SIGQUIT);
+          return;
+        }
+
       if (scan_is_stopped ())
         plugins_scheduler_stop (sched);
+
       plugin = plugins_scheduler_next (sched);
       if (plugin != NULL && plugin != PLUG_RUNNING)
         {

--- a/src/attack.c
+++ b/src/attack.c
@@ -135,13 +135,19 @@ set_kb_readable (int host_kb_index)
  * @param[in] status Status to set.
  */
 static void
-set_scan_status (char *status)
+set_scan_status (struct scan_globals *globals, char *status)
 {
   kb_t main_kb = NULL;
   char buffer[96];
   char *scan_id = NULL;
 
   connect_main_kb (&main_kb);
+
+  if (check_kb_inconsistency (globals, main_kb) != 0)  
+    {
+        kb_lnk_reset (main_kb);
+        return;
+    }
   scan_id = kb_item_get_str (main_kb, ("internal/scanid"));
   snprintf (buffer, sizeof (buffer), "internal/%s", scan_id);
   kb_item_set_str (main_kb, buffer, status, 0);
@@ -1184,7 +1190,7 @@ attack_network (struct scan_globals *globals)
       kb_lnk_reset (main_kb);
       g_warning ("Invalid port list. Ports must be in the range [1-65535]. "
                  "Scan terminated.");
-      set_scan_status ("finished");
+      set_scan_status (globals, "finished");
 
       return;
     }
@@ -1509,5 +1515,6 @@ stop:
   if (alive_hosts_list)
     gvm_hosts_free (alive_hosts_list);
 
-  set_scan_status ("finished");
+  set_scan_status (globals, "finished");
 }
+

--- a/src/attack.c
+++ b/src/attack.c
@@ -25,10 +25,10 @@
 
 #include "attack.h"
 
-#include "../misc/network.h"          /* for auth_printf */
+#include "../misc/network.h"        /* for auth_printf */
+#include "../misc/nvt_categories.h" /* for ACT_INIT */
+#include "../misc/pcap_openvas.h"   /* for v6_is_local_ip */
 #include "../misc/plugutils.h"
-#include "../misc/nvt_categories.h"   /* for ACT_INIT */
-#include "../misc/pcap_openvas.h"     /* for v6_is_local_ip */
 #include "../misc/table_driven_lsc.h" /*for make_table_driven_lsc_info_json_str */
 #include "../nasl/nasl_debug.h"       /* for nasl_*_filename */
 #include "hosts.h"
@@ -143,10 +143,10 @@ set_scan_status (struct scan_globals *globals, char *status)
 
   connect_main_kb (&main_kb);
 
-  if (check_kb_inconsistency (globals, main_kb) != 0)  
+  if (check_kb_inconsistency (globals, main_kb) != 0)
     {
-        kb_lnk_reset (main_kb);
-        return;
+      kb_lnk_reset (main_kb);
+      return;
     }
   scan_id = kb_item_get_str (main_kb, ("internal/scanid"));
   snprintf (buffer, sizeof (buffer), "internal/%s", scan_id);
@@ -223,8 +223,8 @@ comm_send_status (kb_t main_kb, char *ip_str, int curr, int max)
 }
 
 static void
-message_to_client (struct scan_globals *globals, kb_t kb, const char *msg, const char *ip_str,
-                   const char *port, const char *type)
+message_to_client (struct scan_globals *globals, kb_t kb, const char *msg,
+                   const char *ip_str, const char *port, const char *type)
 {
   char *buf;
 
@@ -935,9 +935,11 @@ attack_start (struct attack_start_args *args)
   if (ret_host_auth < 0)
     {
       if (ret_host_auth == -1)
-        message_to_client (globals, kb, "Host access denied.", ip_str, NULL, "ERRMSG");
+        message_to_client (globals, kb, "Host access denied.", ip_str, NULL,
+                           "ERRMSG");
       else
-        message_to_client (globals, kb, "Host access denied (system-wide restriction.)",
+        message_to_client (globals, kb,
+                           "Host access denied (system-wide restriction.)",
                            ip_str, NULL, "ERRMSG");
 
       kb_item_set_str (kb, "internal/host_deny", "True", 0);
@@ -1185,8 +1187,9 @@ attack_network (struct scan_globals *globals)
     {
       connect_main_kb (&main_kb);
       message_to_client (
-                         globals, main_kb, "Invalid port list. Ports must be in the range [1-65535]",
-        NULL, NULL, "ERRMSG");
+        globals, main_kb,
+        "Invalid port list. Ports must be in the range [1-65535]", NULL, NULL,
+        "ERRMSG");
       kb_lnk_reset (main_kb);
       g_warning ("Invalid port list. Ports must be in the range [1-65535]. "
                  "Scan terminated.");
@@ -1517,4 +1520,3 @@ stop:
 
   set_scan_status (globals, "finished");
 }
-

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -26,6 +26,7 @@
 #include "hosts.h" /* for hosts_new() */
 
 #include "../misc/network.h" /* for internal_recv */
+#include "../misc/plugutils.h"
 #include "utils.h"           /* for data_left() */
 
 #include <errno.h>               /* for errno() */
@@ -73,12 +74,15 @@ extern int global_scan_stop;
  *
  */
 void
-host_set_time (kb_t kb, char *ip, char *type)
+host_set_time (struct scan_globals *globals, kb_t kb, char *ip, char *type)
 {
   char *timestr;
   char log_msg[1024];
   time_t t;
   int len;
+
+  if (check_kb_inconsistency (globals, kb) != 0)
+    return;
 
   t = time (NULL);
   char ts[26];

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -27,7 +27,7 @@
 
 #include "../misc/network.h" /* for internal_recv */
 #include "../misc/plugutils.h"
-#include "utils.h"           /* for data_left() */
+#include "utils.h" /* for data_left() */
 
 #include <errno.h>               /* for errno() */
 #include <glib.h>                /* for g_free() */

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -46,7 +46,7 @@ void
 hosts_stop_all (void);
 
 void
-host_set_time (kb_t, char *, char *);
+host_set_time (struct scan_globals *, kb_t, char *, char *);
 
 int
 host_is_currently_scanned (gvm_host_t *);

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -118,7 +118,7 @@ max_nvt_timeouts_reached ()
  *
  */
 static void
-update_running_processes (kb_t main_kb, kb_t kb)
+update_running_processes (struct scan_globals *globals, kb_t main_kb, kb_t kb)
 {
   int i;
   struct timeval now;
@@ -143,7 +143,7 @@ update_running_processes (kb_t main_kb, kb_t kb)
             {
               char *oid = processes[i].plugin->oid;
 
-              if (is_alive)
+              if (is_alive) // Alive and timed out
                 {
                   char msg[2048];
                   if (log_whole)
@@ -154,7 +154,8 @@ update_running_processes (kb_t main_kb, kb_t kb)
                               "ERRMSG|||%s||| |||general/tcp|||%s|||"
                               "NVT timed out after %d seconds.",
                               hostname, oid ? oid : " ", processes[i].timeout);
-                  kb_item_push_str (main_kb, "internal/results", msg);
+                  if (check_kb_inconsistency (globals, main_kb) == 0)
+                    kb_item_push_str (main_kb, "internal/results", msg);
 
                   /* Check for max VTs timeouts */
                   if (max_nvt_timeouts_reached ())
@@ -168,7 +169,8 @@ update_running_processes (kb_t main_kb, kb_t kb)
                                       "Host has been marked as dead. Too many "
                                       "NVT_TIMEOUTs.",
                                       hostname);
-                          kb_item_push_str (main_kb, "internal/results", msg);
+                          if (check_kb_inconsistency (globals, main_kb) == 0)
+                            kb_item_push_str (main_kb, "internal/results", msg);
                         }
                     }
 
@@ -293,7 +295,7 @@ simult_ports (const char *oid, const char *next_oid)
  * free "slot" in the processes array otherwise.
  */
 static int
-next_free_process (kb_t main_kb, kb_t kb, struct scheduler_plugin *upcoming)
+next_free_process (struct scan_globals *globals, kb_t main_kb, kb_t kb, struct scheduler_plugin *upcoming)
 {
   int r;
 
@@ -304,7 +306,7 @@ next_free_process (kb_t main_kb, kb_t kb, struct scheduler_plugin *upcoming)
         {
           while (process_alive (processes[r].pid))
             {
-              update_running_processes (main_kb, kb);
+              update_running_processes (globals, main_kb, kb);
               usleep (250000);
             }
         }
@@ -463,8 +465,8 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
   int p;
 
   /* Wait for a free slot */
-  pluginlaunch_wait_for_free_process (main_kb, kb);
-  p = next_free_process (main_kb, kb, plugin);
+  pluginlaunch_wait_for_free_process (globals, main_kb, kb);
+  p = next_free_process (globals, main_kb, kb, plugin);
   if (p < 0)
     {
       g_warning ("%s. There is currently no free slot available for starting a "
@@ -494,11 +496,11 @@ plugin_launch (struct scan_globals *globals, struct scheduler_plugin *plugin,
  * @brief Waits and 'pushes' processes until num_running_processes is 0.
  */
 void
-pluginlaunch_wait (kb_t main_kb, kb_t kb)
+pluginlaunch_wait (struct scan_globals *globals, kb_t main_kb, kb_t kb)
 {
   while (num_running_processes)
     {
-      update_running_processes (main_kb, kb);
+      update_running_processes (globals, main_kb, kb);
       if (num_running_processes)
         waitpid (-1, NULL, 0);
     }
@@ -527,11 +529,11 @@ timeout_running_processes (void)
  *        changed.
  */
 void
-pluginlaunch_wait_for_free_process (kb_t main_kb, kb_t kb)
+pluginlaunch_wait_for_free_process (struct scan_globals *globals, kb_t main_kb, kb_t kb)
 {
   if (!num_running_processes)
     return;
-  update_running_processes (main_kb, kb);
+  update_running_processes (globals, main_kb, kb);
   /* Max number of processes are still running, wait for a child to exit or
    * to timeout. */
 
@@ -554,6 +556,6 @@ pluginlaunch_wait_for_free_process (kb_t main_kb, kb_t kb)
       sigaddset (&mask, SIGCHLD);
       if (sigtimedwait (&mask, NULL, &ts) < 0 && errno != EAGAIN)
         g_warning ("%s: %s", __func__, strerror (errno));
-      update_running_processes (main_kb, kb);
+      update_running_processes (globals, main_kb, kb);
     }
 }

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -295,7 +295,8 @@ simult_ports (const char *oid, const char *next_oid)
  * free "slot" in the processes array otherwise.
  */
 static int
-next_free_process (struct scan_globals *globals, kb_t main_kb, kb_t kb, struct scheduler_plugin *upcoming)
+next_free_process (struct scan_globals *globals, kb_t main_kb, kb_t kb,
+                   struct scheduler_plugin *upcoming)
 {
   int r;
 
@@ -529,7 +530,8 @@ timeout_running_processes (void)
  *        changed.
  */
 void
-pluginlaunch_wait_for_free_process (struct scan_globals *globals, kb_t main_kb, kb_t kb)
+pluginlaunch_wait_for_free_process (struct scan_globals *globals, kb_t main_kb,
+                                    kb_t kb)
 {
   if (!num_running_processes)
     return;

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -40,8 +40,8 @@
 
 void
 pluginlaunch_init (const char *);
-void pluginlaunch_wait (kb_t, kb_t);
-void pluginlaunch_wait_for_free_process (kb_t, kb_t);
+void pluginlaunch_wait (struct scan_globals *, kb_t, kb_t);
+void pluginlaunch_wait_for_free_process (struct scan_globals *, kb_t, kb_t);
 
 void
 pluginlaunch_stop (void);

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -40,8 +40,10 @@
 
 void
 pluginlaunch_init (const char *);
-void pluginlaunch_wait (struct scan_globals *, kb_t, kb_t);
-void pluginlaunch_wait_for_free_process (struct scan_globals *, kb_t, kb_t);
+void
+pluginlaunch_wait (struct scan_globals *, kb_t, kb_t);
+void
+pluginlaunch_wait_for_free_process (struct scan_globals *, kb_t, kb_t);
 
 void
 pluginlaunch_stop (void);


### PR DESCRIPTION
**What**:
Compares the scan id in globals, set at the beginning
of the scan, with the one found in the main kb.
It helps to detect that the kb was not taken by another
task/scan, and that the current plugins does not stores
results in a wrong kb.

Jira: SC-378

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
A scan can left result in a kb, which is later taken for a new scan. This produces that results from an interrupted scan are shown in the report of a new scan. With this patch, the scanner checks the kb before leaving a new result.
<!-- Why are these changes necessary? -->

**How**:
Run a scan. The race condition is hard to reproduce.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
