### PR TITLE
Dockerfile: Add missing dependencies for VT execution

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     bison \
     libjson-glib-1.0-0 \
     libksba8 \
+    nmap \
+    snmp \
+    netdiag \
+    pnscan \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=feed /opt/greenbone/feed/plugins /var/lib/openvas/plugins
 COPY --from=build /install/ /


### PR DESCRIPTION
**What**:
Add dependencies to Dockerfile for `nmap`, `snmp`, `netdiag` and `pnscan`.

**Why**:

The docker images is missing some important dependencies for the execution of some VTs.
See https://community.greenbone.net/t/hint-verify-the-availability-of-scanner-helper-tools-of-your-gse-source-package-installation/1358 for details.

**How**:

Tested by scanning a target with the locally build container.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
