### PR TITLE
Fix case sensitive linting

### DIFF
--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -161,10 +161,9 @@ reverse_search (GSList **def_func_tree, GSList *finfo)
 static gint
 list_cmp (gconstpointer lelem, gconstpointer data)
 {
-  if (!lelem || !data)
-    return -1;
-
-  return (strcasecmp (lelem, data));
+  if (data)
+    return (g_strcmp0 (lelem, data));
+  return -1;
 }
 
 /**

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -122,7 +122,7 @@ list_cmp1 (gconstpointer lelem, gconstpointer data)
 /**
  * @brief Check if an undefined called function is needed or not.
  *        This is the case in which the function is called from a
- *        neested and defined function but never called.
+ *        nested and defined function but never called.
  * @return 1 if the function is needed, 0 otherwise.
  */
 static gint


### PR DESCRIPTION
**What**:
This PR reverts some changes from https://github.com/greenbone/openvas-scanner/pull/728, to be exact the changes from the commit https://github.com/greenbone/openvas-scanner/commit/f1237133f446938247eaab1a3e3a545b66f1408d.
SC-584

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The nasl linter was not able to detect undeclared variables in case of different letter cases, e.g. for the linter cpe and CPE was the same variable name even though it is not.


<!-- Why are these changes necessary? -->

**How**:
Run `openvas-nasl-lint test.nasl ` before and after with this small script:
```
CPE = "foo";
display(cpe);
exit(0);
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
