### PR TITLE
Fix: nasl lint error count

### DIFF
--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -72,10 +72,13 @@ process_file (const gchar *filepath, int mode, struct script_infos *script_args)
   ret = exec_nasl_script (script_args, mode);
   if (ret != 0)
     {
-      g_print ("Error while processing %s.\n", filepath);
       if (ret == -1)
-        return 1;
-      return ret;
+        {
+          g_print ("Error while processing %s.\n", filepath);
+          return 1;
+        }
+      g_print ("%d errors while processing %s.\n", ret, filepath);
+      return ret != 0;
     }
   return 0;
 }


### PR DESCRIPTION
**What**:
A small fix for the count of erroneous scripts.
SC-597

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Before it counted the total errors found but said its the number of erroneous scripts. Now the behavior should be as expected with the total number of scripts containing errors.

<!-- Why are these changes necessary? -->

**How**:
Just test `openvas-nasl-lint` with some erroneous scripts.
This following script contains 12 errors:
```c#
display(foo);
display(bar);
```
The old patch version printed
```none
lib  nasl-Message: 17:07:23.057: [14372](test.nasl:1) The variable foo was not declared
lib  nasl-Message: 17:07:23.057: [14372](test.nasl:2) The variable bar was not declared
Error while processing test.nasl.
2 scripts with one or more errors found
```

The new one counts the errors in each script and the total number of erroneous scripts:
```none
lib  nasl-Message: 17:06:06.955: [13152](test.nasl:1) The variable foo was not declared
lib  nasl-Message: 17:06:06.955: [13152](test.nasl:2) The variable bar was not declared
2 errors while processing test.nasl.
1 scripts with one or more errors found
```

Test with multiple correct and erroneous scripts with a single lint call.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
