### PR TITLE
Refactor: add libbsd to build and prod image

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -18,4 +18,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     libpaho-mqtt-dev \
     libpcap-dev \
     libssh-gcrypt-dev \
+    libbsd-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     snmp \
     netdiag \
     pnscan \
+    libbsd \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=feed /opt/greenbone/feed/plugins /var/lib/openvas/plugins
 COPY --from=build /install/ /


### PR DESCRIPTION
We may plan to replace proctitle_set with setproctitle for openvas.

Therefore we need libbsd.
