### PR TITLE
Allow to run notus-scanner in conjunction with the openvas-scanner container

### DIFF
--- a/.docker/openvas.conf
+++ b/.docker/openvas.conf
@@ -1,0 +1,2 @@
+table_driven_lsc = yes
+mqtt_server_uri = tcp://mqtt-broker:1883

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,14 +1,18 @@
 ARG VERSION=unstable
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
+
 FROM ${REPOSITORY}-build:$VERSION AS build
+
 COPY . /source
+
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
-RUN DESTDIR=/install cmake --build /build -- install 
+RUN DESTDIR=/install cmake --build /build -- install
 
 FROM greenbone/community-feed-vts AS feed
 
 FROM greenbone/gvm-libs:$VERSION
+
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     bison \
     libjson-glib-1.0-0 \
@@ -20,8 +24,11 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     pnscan \
     libbsd0 \
     && rm -rf /var/lib/apt/lists/*
+
+COPY .docker/openvas.conf /etc/openvas/
 COPY --from=feed /opt/greenbone/feed/plugins /var/lib/openvas/plugins
 COPY --from=build /install/ /
+
 RUN ldconfig
 # allow openvas to access raw sockets and all kind of network related tasks
 RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.docker/
 .github/
 .vscode/
 .mergify.yml


### PR DESCRIPTION
**What**:

Add an openvas config to the openvas-scanner container to allow starting
the notus-scanner.

**Why**:

It must be able to run notus-scanner in a container environment.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
