### PR TITLE
Fix: enable notus only if mqtt is enabled

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -734,7 +734,8 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
       pluginlaunch_wait_for_free_process (main_kb, kb);
     }
 
-  if (!scan_is_stopped () && prefs_get_bool ("table_driven_lsc"))
+  if (!scan_is_stopped () && prefs_get_bool ("table_driven_lsc")
+      && prefs_get_bool ("mqtt_enabled"))
     {
       g_message ("Running LSC via Notus for %s", ip_str);
       if (run_table_driven_lsc (globals->scan_id, kb, ip_str, NULL))

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -445,6 +445,7 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
       else
         {
           g_message ("%s: INIT MQTT: SUCCESS", __func__);
+          prefs_set ("mqtt_enabled", "yes");
         }
     }
 


### PR DESCRIPTION
**What**:
Small fix to disable notus scan, when MQTT is not able to establish a connection to a broker.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some cases this behavior led to a segmentation fault.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
