### PR TITLE
Add: SMB3KDF for SMB3 support

### DIFF
--- a/nasl/nasl_crypto2.h
+++ b/nasl/nasl_crypto2.h
@@ -102,6 +102,9 @@ nasl_aes128_ccm_encrypt (lex_ctxt *lexic);
 tree_cell *
 nasl_aes128_ccm_decrypt (lex_ctxt *lexic);
 
+tree_cell *
+nasl_smb3kdf (lex_ctxt *lexic);
+
 int
 generate_script_signature (char *);
 #endif

--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -309,6 +309,7 @@ static init_func libfuncs[] = {
   {"aes256_gcm_encrypt", nasl_aes256_gcm_encrypt},
   {"aes128_ccm_encrypt", nasl_aes128_ccm_encrypt},
   {"aes128_ccm_decrypt", nasl_aes128_ccm_decrypt},
+  {"smb3kdf", nasl_smb3kdf},
   {"des_ede_cbc_encrypt", nasl_des_ede_cbc_encrypt},
   {"open_rc4_cipher", nasl_open_rc4_cipher},
   {"close_stream_cipher", nasl_close_stream_cipher},


### PR DESCRIPTION
**What**:
Adding the SMB3KDF as a nasl function.
SC-603

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To support SMB3

<!-- Why are these changes necessary? -->

**How**:
Tested with a small script:
```c#
key = "/B?E(H+MbQeThWmZ";
label = "SMB2AESCCM";
ctx = "ServerIn";

encrypt = smb3kdf(key : key, label : label, ctx : ctx, lvalue: 128);

display(encrypt);
```
Run it with `openvas-nasl -X localhost smb3kdf.nasl`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
