### PR TITLE
Add: openvas-nasl-lint informs about include error on function calls

### DIFF
--- a/nasl/lint.h
+++ b/nasl/lint.h
@@ -23,6 +23,15 @@
 
 #include "nasl_lex_ctxt.h"
 
+enum nasl_lint_feature_flags
+{
+  NLFF_NONE = 0,
+  NLFF_STRICT_INCLUDES = 1
+};
+
+void
+nasl_lint_feature_flags (int flags);
+
 tree_cell *
 nasl_lint (lex_ctxt *lexic, tree_cell *st);
 

--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -22,6 +22,7 @@
  * @brief Source of the NASL linter of OpenVAS.
  */
 
+#include "lint.h"
 #include "nasl.h" /* exec_nasl_script */
 
 #include <gio/gio.h> /* g_file_... */
@@ -165,13 +166,16 @@ main (int argc, char **argv)
 {
   int mode = 0;
   int err = 0;
+  int fflag = 0;
   static gboolean debug = FALSE;
   static gchar *include_dir = NULL;
   static gchar *nvt_file_list = NULL;
+  static unsigned char strict_includes = 0;
   static const gchar **nvt_files = NULL;
   struct script_infos *script_infos = g_malloc0 (sizeof (struct script_infos));
   GError *error = NULL;
   GOptionContext *option_context;
+
   static GOptionEntry entries[] = {
     {"debug", 'd', 0, G_OPTION_ARG_NONE, &debug, "Output debug log messages.",
      NULL},
@@ -181,6 +185,8 @@ main (int argc, char **argv)
      "Search for includes in <dir>", "<dir>"},
     {G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &nvt_files,
      "Absolute path to one or more nasl scripts", "NASL_FILE..."},
+    {"strict-includes", 0, 0, G_OPTION_ARG_NONE, &strict_includes,
+     "Enables check for strict include order.", NULL},
     {NULL, 0, 0, 0, NULL, NULL, NULL}};
 
   option_context =
@@ -191,6 +197,8 @@ main (int argc, char **argv)
       g_error ("%s\n\n", error->message);
     }
   g_option_context_free (option_context);
+  fflag |= strict_includes;
+  nasl_lint_feature_flags (fflag);
 
   mode |= NASL_COMMAND_LINE;
   /* signing mode */

--- a/nasl/nasl_debug.h
+++ b/nasl/nasl_debug.h
@@ -48,6 +48,9 @@ nasl_get_filename (const char *);
 void
 nasl_set_function_name (const char *);
 
+int
+nasl_get_include_order (const char *);
+
 const char *
 nasl_get_function_name (void);
 #endif

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -20,17 +20,21 @@
 #define _NASL_CTX_H
 
 /* for FILE */
+#include "nasl_tree.h"
+
 #include <gvm/util/kb.h>
 #include <stdio.h>
 
 typedef struct
 {
   int line_nb;
+  char *name;
   int always_signed; /**< If set disable signature check during scans and feed
                         upload. */
   int exec_descr; /**< Tell grammar that is a feed upload process or a running a
                      scan process. */
   int index;
+  unsigned int include_order;
   tree_cell *tree;
   char *buffer;
   kb_t kb;

--- a/nasl/nasl_tree.h
+++ b/nasl/nasl_tree.h
@@ -105,8 +105,10 @@ typedef struct TC
 {
   short type;
   short line_nb;
+  char *name;
   short ref_count; /* Cell is freed when count reaches zero */
   int size;
+  int include_order;
   union
   {
     char *str_val;


### PR DESCRIPTION
When linting a `main.nasl` as

```
include ("2.inc");
include ("1.inc");

hello();
```

Based on `2.inc`:

```
function hello() {
    hi();
    display("hello");
}
```

Based on `1.inc`:

```
function hi() {
    display("hi");
}
```

`openvas-nasl-lint --strict-includes main.nasl` will identify the include order and printing:

```
lib  nasl-Message: 13:33:42.763: [1166407](main.nasl:0) 2.inc must be included after 1.inc (usage of hi).
lib  nasl-Message: 13:33:42.763: [1166407](main.nasl:2) The included file '2.inc' is never used.
lib  nasl-Message: 13:33:42.764: [1166407](main.nasl:2) The included file '1.inc' is never used.
4 errors while processing main.nasl.
1 scripts with one or more errors found
```

There is a decision to not enforce strict-includes as of now to allow a grace period for nasl scripts. 