### PR TITLE
Fix smb3 cryptions

### DIFF
--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -2095,7 +2095,7 @@ nasl_smb3kdf (lex_ctxt *lexic)
       return NULL;
     }
 
-  resultlen = lvalue;
+  resultlen = lvalue / 8;
   result = g_malloc0 (resultlen);
   if ((error = gcry_mac_read (hd, result, &resultlen)))
     {

--- a/nasl/nasl_crypto2.c
+++ b/nasl/nasl_crypto2.c
@@ -1871,7 +1871,7 @@ crypt_data (lex_ctxt *lexic, int cipher, int mode, int crypt)
   gcry_cipher_close (hd);
   retc = alloc_typed_cell (CONST_DATA);
   retc->x.str_val = result;
-  retc->size = strlen (result);
+  retc->size = resultlen;
   return retc;
 }
 


### PR DESCRIPTION
**What**:
Fixes various issues with cryption functions regarding SMBv3
- SC-620
  - fixing the size value of the returned treecell of the crypt function

- SC-621
  - using the correct size for the result for the smb3kdf which is the L value divided by 8 (L value is the size in bits)

- SC-622
  - fix the buffer used in the Key Derivation Function (of smb3kdf) as it needs the r and L value in big endian notation

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
SMBv3 and SMBv3.1.1


<!-- Why are these changes necessary? -->

**How**:
Run the following scripts with the command `openvas-nasl -X localhost <script.nasl>`
Script for SC-620:
```
key = "764efa883dda1e11";
data = raw_string( 0xfe, 0x53, 0x4d, 0x42, 0x40, 0x00, 0x40);
iv = "012345678901+";


encrypt = aes128_ccm_encrypt(key : key, iv : iv, data : data);
decrypt = aes128_ccm_decrypt(key : key, iv : iv, data : encrypt, len : strlen(data));

display(data);
display(encrypt);
display(decrypt);
```

Script for SC-621:
```
# This should produce a 16 Bit key.

key = "Aqqeqqwafwq5Sewdw";
label = "SMB2AESCCM\0";
ctx = "ServerIn \0";
encrypt = smb3kdf(key : key, label : label, ctx : ctx, lvalue: 128);
display(encrypt);

# This should produce a 32 Bit key.
key = "Aqqeqqwafwq5SewdwAqqeqqwafwq5Sewdw";
label = "SMBC2SCipherKey\0";
ctx = ".CL...3..@.....16.o..$e2 ..5N...3..d...R_.?-me..........d5m.....";
encrypt = smb3kdf(key : key, label : label, ctx : ctx, lvalue: 256);
display(encrypt);
```

Script for SC-622:
```
# The following part relates to this example: https://docs.microsoft.com/en-us/archive/blogs/openspecification/encryption-in-smb-3-0-a-protocol-perspective#test-vector

# This is the session key
key = raw_string(0xB4,0x54,0x67,0x71,0xB5,0x15,0xF7,0x66,0xA8,0x67,0x35,0x53,0x2D,0xD6,0xC4,0xF0);
display(key);

# The SMB2AESCMAC with terminating null character input. Length must be 12 Bytes for this example
label = raw_string(0x53, 0x4D, 0x42, 0x32, 0x41, 0x45, 0x53, 0x43, 0x4D, 0x41, 0x43, 0x00);
display(label);

# The SmbSign with terminating null character input. Length must be 8 Bytes for this example
ctx = raw_string(0x53, 0x6D, 0x62, 0x53, 0x69, 0x67, 0x6E, 0x00);
display(ctx);

encrypt = smb3kdf(key:key, label: label, ctx:ctx, lvalue: 128);
display(hexstr(encrypt));

# What we get:    9e460f5a225198d2263d18a6bb2d4a75
# What we want: 0xF773CD23C18FD1E08EE510CADA7CF852
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
