### PR TITLE
Refactor: clean every tree_cell

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1711,7 +1711,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
       else if (lintret != FAKE_CELL && lintret->x.i_val > 0)
         {
           err = lintret->x.i_val;
-          g_free (lintret);
+		  //deref_cell(lintret);
         }
     }
   else if (!(mode & NASL_EXEC_PARSE_ONLY))
@@ -1756,7 +1756,9 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   g_free (old_dir);
 
   nasl_clean_ctx (&ctx);
+  // TODO move to process_file of lint to have a litner only integration
   free_lex_ctxt (lexic);
+  clean_up_tree_cells();
   if (process_id != getpid ())
     exit (0);
 

--- a/nasl/lint.c
+++ b/nasl/lint.c
@@ -666,7 +666,6 @@ static tree_cell *
 make_call_func_list (lex_ctxt *lexic, tree_cell *st, GSList **called_funcs)
 {
   int i;
-  tree_cell *ret = FAKE_CELL;
   nasl_func *pf = NULL;
 
   switch (st->type)
@@ -681,12 +680,12 @@ make_call_func_list (lex_ctxt *lexic, tree_cell *st, GSList **called_funcs)
       /* fallthrough */
 
     default:
-      for (i = 0; i < 4; i++)
+      for (i = 0; i < 4; i++) {
+		  printf("%s: checking %d\n", __func__, i);
         if (st->link[i] != NULL && st->link[i] != FAKE_CELL)
-          if ((ret = make_call_func_list (lexic, st->link[i], called_funcs))
-              == NULL)
-            return NULL;
-      return ret;
+          make_call_func_list (lexic, st->link[i], called_funcs);
+	  }
+      return FAKE_CELL;
     }
 }
 
@@ -884,6 +883,7 @@ nasl_lint (lex_ctxt *lexic, tree_cell *st)
     {
       ret = alloc_typed_cell (NODE_VAR);
       ret->x.i_val = get_errors_cnt ();
+	  ret->x.str_val = NULL;
     }
 
   return ret;

--- a/nasl/nasl-lint.c
+++ b/nasl/nasl-lint.c
@@ -23,6 +23,7 @@
  */
 
 #include "nasl.h" /* exec_nasl_script */
+#include "nasl_tree.h"
 
 #include <gio/gio.h> /* g_file_... */
 #include <glib.h>    /* gchar, g_malloc, g_error, g_print, ... */
@@ -67,7 +68,7 @@ process_file (const gchar *filepath, int mode, struct script_infos *script_args)
 {
   int ret;
 
-  g_debug ("Processing %s", filepath);
+  printf ("Processing %s\n", filepath);
   script_args->name = (char *) filepath;
   ret = exec_nasl_script (script_args, mode);
   if (ret != 0)
@@ -119,6 +120,7 @@ process_file_list (const gchar *list_file, int mode,
     }
   g_object_unref (nvt_list);
 
+
   return err;
 }
 
@@ -129,14 +131,14 @@ process_file_list (const gchar *list_file, int mode,
  * @return The amount of errors found in the given scripts
  */
 static int
-process_files (const gchar **files, int mode, struct script_infos *script_args)
+process_files (gchar **files, int mode, struct script_infos *script_args)
 {
   int n = 0;
   int err = 0;
   while (files[n])
     {
       err += process_file (files[n], mode, script_args);
-      n++;
+      g_free(files[n++]);
     }
   return err;
 }
@@ -168,7 +170,7 @@ main (int argc, char **argv)
   static gboolean debug = FALSE;
   static gchar *include_dir = NULL;
   static gchar *nvt_file_list = NULL;
-  static const gchar **nvt_files = NULL;
+  static gchar **nvt_files = NULL;
   struct script_infos *script_infos = g_malloc0 (sizeof (struct script_infos));
   GError *error = NULL;
   GOptionContext *option_context;
@@ -221,8 +223,10 @@ main (int argc, char **argv)
     err += process_file_list (nvt_file_list, mode, script_infos);
 
   /* process the files from the command line */
-  if (nvt_files != NULL)
+  if (nvt_files != NULL) {
     err += process_files (nvt_files, mode, script_infos);
+	g_free(nvt_files);
+  }
 
   g_print ("%d scripts with one or more errors found\n", err);
 

--- a/nasl/nasl_tree.h
+++ b/nasl/nasl_tree.h
@@ -106,6 +106,7 @@ typedef struct TC
   short type;
   short line_nb;
   short ref_count; /* Cell is freed when count reaches zero */
+  unsigned int cache_index; /* internally used to identify on cleanup */
   int size;
   union
   {
@@ -125,6 +126,10 @@ tree_cell *
 alloc_RE_cell (int, int, tree_cell *, char *, int *);
 tree_cell *
 alloc_typed_cell (int);
+
+void
+clean_up_tree_cells (void);
+
 int
 nasl_is_leaf (const tree_cell *);
 char *


### PR DESCRIPTION
To clean every tree_cell a cache and a cleanp function is introduced.

WIP:
- currently linter is trying to reuse a previous included file
