### PR TITLE
Don't add VTs from an experimental image

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -6,7 +6,6 @@ COPY . /source
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install 
 
-FROM greenbone/community-feed-vts AS feed
 FROM greenbone/gvm-libs:$VERSION
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
**What**:

Don't add VTs from an experimental image

**Why**:

The openvas-scanner image should not come with VTs.
It should be as small as possible. If we need VTs for community users
via a docker image it is best to ship it as a separate image.


**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
