### PR TITLE
Change: more useful logging for socket_negotiate_ssl

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -868,9 +868,12 @@ socket_negotiate_ssl (int fd, openvas_encaps_t transport,
       if (!connection_failed_msg_sent)
         {
           g_message ("Function socket_negotiate_ssl called from %s: "
-                     "SSL/TLS connection (host: %s) failed.",
+                     "SSL/TLS connection (host: %s, ip: %s) failed.",
                      nasl_get_plugin_filename (),
-                     hostname ? hostname : "unknown");
+                     plug_get_host_fqdn (args) ? plug_get_host_fqdn (args)
+                                               : "unknown",
+                     plug_get_host_ip_str (args) ? plug_get_host_ip_str (args)
+                                                 : "unknown");
           connection_failed_msg_sent = TRUE;
         }
       g_free (hostname);


### PR DESCRIPTION
**What**:
More useful logs when calling `socket_negotiate_ssl()`
SC-625

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The log
```
Mar 22 18:35:21 s-greenscan openvas[14761]: Function socket_negotiate_ssl called from gb_ssl_tls_renegotiation_dos_CVE-2011-1473_CVE-2011-5094.nasl: SSL/TLS connection (host: unknown) failed.
```
in which the host is "unknown" is not really useful.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
