### PR TITLE
Fix: openvas-nasl should not exit when forked

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1624,7 +1624,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
 {
   naslctxt ctx;
   nasl_func *pf;
-  int err = 0, to, process_id;
+  int err = 0, to;
   tree_cell *ret;
   lex_ctxt *lexic;
   gchar *old_dir;
@@ -1698,7 +1698,6 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
 
   lexic->recv_timeout = to;
 
-  process_id = getpid ();
   if (mode & NASL_LINT)
     {
       /* ret is set to the number of errors the linter finds.
@@ -1757,8 +1756,5 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
 
   nasl_clean_ctx (&ctx);
   free_lex_ctxt (lexic);
-  if (process_id != getpid ())
-    exit (0);
-
   return err;
 }

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -349,7 +349,7 @@ main (int argc, char **argv)
     {
       struct in6_addr ip6;
       kb_t kb;
-      int rc, i = 0;
+      int rc;
 
       if (prefs_get_bool ("expand_vhosts"))
         gvm_host_add_reverse_lookup (host);
@@ -361,7 +361,7 @@ main (int argc, char **argv)
         exit (1);
 
       script_infos = init (&ip6, host->vhosts, kb);
-      while (nasl_filenames[i])
+      for (int i = 0; nasl_filenames[i] != NULL; i++)
         {
           script_infos->name = nasl_filenames[i];
           if (both_modes || with_safe_checks)
@@ -370,7 +370,6 @@ main (int argc, char **argv)
               if (!nvti)
                 {
                   err++;
-                  i++;
                   continue;
                 }
               else if (with_safe_checks
@@ -379,7 +378,6 @@ main (int argc, char **argv)
                   printf ("%s isn't safe\n", nasl_filenames[i]);
                   nvti_free (nvti);
                   err++;
-                  i++;
                   continue;
                 }
               nvti_free (nvti);
@@ -404,7 +402,6 @@ main (int argc, char **argv)
 
           if (exec_nasl_script (script_infos, mode) < 0)
             err++;
-          i++;
         }
       g_free (script_infos->globals);
       g_free (script_infos);


### PR DESCRIPTION
When executing openvas-nasl and calling a function that forks the
process then it will happen that the plugin execution is stopped
and other plugins won't be executed afterwards.

To verify it create two nasl plugins:

```
host = get_host_name();
display(strcat("starting ", host));
exit(0);
```
hostname.nasl

```
display("you should see me");
exit( 0);
```
log.nasl

and execute them in the order hostname.nasl log.nasl with openvas-nasl.

`openvas-nasl -X hostname.nasl log.nasl`

jira: SC-617