### PR TITLE
Refactor: tidy up exit calls

### DIFF
--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -61,12 +61,6 @@ extern char *
 nasl_version (void);
 
 static void
-sighandler ()
-{
-  exit (0);
-}
-
-static void
 my_gnutls_log_func (int level, const char *text)
 {
   fprintf (stderr, "[%d] (%d) %s", getpid (), level, text);
@@ -289,8 +283,6 @@ main (int argc, char **argv)
       fprintf (stderr, "** WARNING : packet forgery will not work\n");
       fprintf (stderr, "** as NASL is not running as root\n");
     }
-  signal (SIGINT, sighandler);
-  signal (SIGTERM, sighandler);
   signal (SIGPIPE, SIG_IGN);
 
   if (source_iface && gvm_source_iface_init (source_iface))

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -2585,7 +2585,7 @@ plugin_run_find_service (lex_ctxt *lexic)
               nvticache_reset ();
               signal (SIGTERM, _exit);
               plugin_do_run (desc, sons_args[i], test_ssl);
-              exit (0);
+              _exit (0);
             }
           else
             {

--- a/src/processes.c
+++ b/src/processes.c
@@ -113,7 +113,7 @@ create_process (process_func_t function, void *argument)
       srand48 (getpid () + getppid () + (long) time (NULL));
       (*function) (argument);
       gvm_close_sentry ();
-      exit (0);
+      _exit (0);
     }
   if (pid < 0)
     g_warning ("Error : could not fork ! Error : %s", strerror (errno));

--- a/src/sighand.c
+++ b/src/sighand.c
@@ -132,7 +132,6 @@ print_trace (void)
 void
 sighand_segv (int given_signal)
 {
-  signal (SIGSEGV, _exit);
   print_trace ();
   make_em_die (SIGTERM);
   gvm_close_sentry ();


### PR DESCRIPTION
**What**:
In case a child process exits, it should exit with _exit. Calling exit instead it will execute atexit and on_exit calls. This can lead to errors in other processes as it will e.g. remove files and streams set in stdio.h.
SC-564

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
