### PR TITLE
Fix "Nmap scan type requires root privileges" error with container

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -30,3 +30,6 @@ COPY --from=build /install/ /
 RUN ldconfig
 # allow openvas to access raw sockets and all kind of network related tasks
 RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas
+# allow nmap to run UDP propes without root permissions
+ENV NMAP_PRIVILEGED=1
+RUN setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/nmap


### PR DESCRIPTION
**What**:

Fix "Nmap scan type requires root privileges" error with container

**Why**:

When running a port list including udp the `nmap -sU` command will be
run. This command requires additional privileges. Therefore set the
required capabilities on the nmap executable.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] PR merge commit message adjusted
