### PR TITLE
Fix: PLugin process keeps scanning after manually stopping task

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -1451,7 +1451,9 @@ attack_network (struct scan_globals *globals)
   /* Every host is being tested... We have to wait for the processes
    * to terminate. */
   while (hosts_read () == 0)
-    ;
+    if (scan_is_stopped () == 1)
+      killpg (getpid (), SIGUSR1);
+
   g_debug ("Test complete");
 
 scan_stop:


### PR DESCRIPTION
**What**:
Jira: SC-626

Fix: PLugin process keeps scanning after manually stopping task
This patch ensure that the pluginlaunch_stop() will be called also in this special case,
sending the SIGTERM signal to the plugin process group, terminating the plugins child as well
in case it has forked.

Also, ensure that host process received the stop signal, once the scan task was stopped and waits for the hosts process to finish. It will resend the stop signal to the still running host process.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
SIGUSR1 signal is sent during scan stop to all host processes, it will
call pluginlaunch_stop ();
There is a very special situation, when the last plugin of the last host
in the scan task is running, we wait for it to finish and it is not possible anymore to
check if the scan is stopped or not.

This patch ensure that the pluginlaunch_stop
<!-- Why are these changes necessary? -->

**How**:
Run a "base" scan config against a host which take longer to finish the port scanning. Stop the scan without the patch won't stop the scan. With the patch, the scan stops as expected.
Run a F&F scan against a network and stop the scan. It should stop faster than before.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
