### PR TITLE
Fix: process handler deadlock and signal handler

### DIFF
--- a/src/processes.c
+++ b/src/processes.c
@@ -204,6 +204,8 @@ procs_init (int max)
   num_procs = 0;
   openvas_signal (SIGCHLD, clear_child);
   openvas_signal (SIGTERM, terminate);
+  openvas_signal (SIGINT, terminate);
+  openvas_signal (SIGQUIT, terminate);
   initialized = 1;
 }
 
@@ -212,6 +214,9 @@ init_child_signal_handlers (void)
 {
   /* SIGHUP is only for reloading main scanner process. */
   openvas_signal (SIGHUP, SIG_IGN);
+  openvas_signal (SIGTERM, make_em_die);
+  openvas_signal (SIGINT, make_em_die);
+  openvas_signal (SIGQUIT, make_em_die);
   openvas_signal (SIGSEGV, sighand_segv);
   openvas_signal (SIGPIPE, SIG_IGN);
 }
@@ -236,7 +241,9 @@ create_process (process_func_t func, void *args)
       while (!procs[++pos].terminated)
         ;
     }
+  gvm_log_lock ();
   pid_t pid = fork ();
+  gvm_log_unlock ();
   if (!pid)
     {
       initialized = 0;


### PR DESCRIPTION
**What**:
The PR #1165 contained two major errors. A lock to prevent a deadlock and handling signals in case the module is not initialized


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
