### PR TITLE
Fix: determine SSL/TLS support on services

### DIFF
--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -1494,18 +1494,18 @@ may_be_time (time_t *rtime)
 
 static int
 retry_stream_connection (int test_ssl, struct script_infos *desc, int port,
-                         int timeout)
+                         int timeout, int *trp)
 {
   const char *p = "NORMAL:+ARCFOUR-128:%COMPAT";
   const char *lp = "LEGACY:%COMPAT:%UNSAFE_RENEGOTIATION";
-  int cnx, trp;
+  int cnx;
 
   if (test_ssl)
-    trp = OPENVAS_ENCAPS_TLScustom;
+    *trp = OPENVAS_ENCAPS_TLScustom;
   else
-    trp = OPENVAS_ENCAPS_IP;
+    *trp = OPENVAS_ENCAPS_IP;
 
-  cnx = open_stream_connection (desc, port, trp, timeout);
+  cnx = open_stream_connection (desc, port, *trp, timeout);
   if (test_ssl)
     {
       switch (cnx)
@@ -1515,7 +1515,7 @@ retry_stream_connection (int test_ssl, struct script_infos *desc, int port,
           g_debug ("%s: NO_PRIORITY_FLAGS failed, retrying with "
                    "INSECURE_DH_PRIME_BITS",
                    __func__);
-          cnx = open_stream_connection_ext (desc, port, trp, timeout, p,
+          cnx = open_stream_connection_ext (desc, port, *trp, timeout, p,
                                             INSECURE_DH_PRIME_BITS);
           if (cnx >= 0)
             {
@@ -1525,7 +1525,7 @@ retry_stream_connection (int test_ssl, struct script_infos *desc, int port,
         case TLS_FATAL_ALERT:
           // retry with legacy option
           g_debug ("%s: %s failed, retrying with %s", __func__, p, lp);
-          cnx = open_stream_connection_ext (desc, port, trp, timeout, lp,
+          cnx = open_stream_connection_ext (desc, port, *trp, timeout, lp,
                                             NO_PRIORITY_FLAGS);
           if (cnx >= 0)
             {
@@ -1663,7 +1663,8 @@ plugin_do_run (struct script_infos *desc, GSList *h, int test_ssl)
                   banner = NULL;
                 }
               gettimeofday (&tv1, NULL);
-              cnx = retry_stream_connection (test_ssl, desc, port, cnx_timeout);
+              cnx = retry_stream_connection (test_ssl, desc, port, cnx_timeout,
+                                             &trp);
               gettimeofday (&tv2, NULL);
               diff_tv = DIFFTV1000 (tv2, tv1);
             }


### PR DESCRIPTION
**What**:
Scanner failed to determine SSL/TLS support on services requiring a client certificate.
Jira: SC-659
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Now the variable trp is passed to the function to be set.

<!-- Why are these changes necessary? -->

**How**:
`sudo openvas-nasl -X -B -d -i ./ -t zero.webappsecurity.com find_service.nasl --kb="Ports/tcp/443=1"`

without the patch, I have seen like the transport key stores a random integer (trp not set/initiliazed)
`lib  misc-Message: 13:59:08.804: set key Transports/TCP/443 -> 109136`

with the patch, the transport key is set with the right value:
`lib  misc-Message: 14:02:51.355: set key Transports/TCP/443 -> 9`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
