### PR TITLE
Refactor: store host_pid in globals on attack_host

### DIFF
--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -34,6 +34,7 @@ struct scan_globals
   GHashTable *files_translation;
   GHashTable *files_size_translation;
   char *scan_id;
+  pid_t host_pid;
 };
 
 struct host_info;

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -139,7 +139,7 @@ add_hostname (lex_ctxt *lexic)
   kb_check_push_str (lexic->script_infos->key, "internal/vhosts", lower);
   snprintf (buffer, sizeof (buffer), "internal/source/%s", lower);
   kb_check_push_str (lexic->script_infos->key, buffer, source);
-  host_pid = kb_item_get_int (lexic->script_infos->key, "internal/hostpid");
+  host_pid = lexic->script_infos->globals->host_pid;
   if (host_pid > 0)
     kill (host_pid, SIGUSR2);
 

--- a/src/attack.c
+++ b/src/attack.c
@@ -643,7 +643,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   openvas_signal (SIGUSR2, set_check_new_vhosts_flag);
   host_kb = kb;
   host_vhosts = vhosts;
-  kb_check_set_int (kb, "internal/hostpid", getpid ());
+  globals->host_pid = getpid ();
   host_set_time (main_kb, ip_str, "HOST_START");
   kb_lnk_reset (main_kb);
   setproctitle ("openvas: testing %s", ip_str);


### PR DESCRIPTION
Instead of pushing the host pid into redis and use the main_kb store it
into globals. That way we spare a redis request.
