### PR TITLE
Refactor: uniform include guards

### DIFF
--- a/misc/bpf_share.h
+++ b/misc/bpf_share.h
@@ -23,8 +23,8 @@
  * @brief Header file for module bpf_share.
  */
 
-#ifndef OPENVAS_BPF_SHARE_H
-#define OPENVAS_BPF_SHARE_H
+#ifndef MISC_BPF_SHARE_H
+#define MISC_BPF_SHARE_H
 
 #include <sys/types.h>
 

--- a/misc/ftp_funcs.h
+++ b/misc/ftp_funcs.h
@@ -23,8 +23,8 @@
  * @brief Header file for module ftp_funcs.
  */
 
-#ifndef OPENVAS_FTP_FUNCS_H
-#define OPENVAS_FTP_FUNCS_H
+#ifndef MISC_FTP_FUNCS_H
+#define MISC_FTP_FUNCS_H
 
 #include <arpa/inet.h>
 #include <sys/param.h>

--- a/misc/network.h
+++ b/misc/network.h
@@ -23,8 +23,8 @@
  * @brief Header file for module network.
  */
 
-#ifndef OPENVAS_NETWORK_H
-#define OPENVAS_NETWORK_H
+#ifndef MISC_NETWORK_H
+#define MISC_NETWORK_H
 
 #include "scanneraux.h"
 

--- a/misc/nvt_categories.h
+++ b/misc/nvt_categories.h
@@ -27,8 +27,8 @@
  * ACT_SCANNER are in principle executed first).
  */
 
-#ifndef _NVT_CATEGORIES_H
-#define _NVT_CATEGORIES_H
+#ifndef MISC_NVT_CATEGORIES_H
+#define MISC_NVT_CATEGORIES_H
 
 /**
  * @brief NVT 'Categories', influence execution order of NVTs.
@@ -48,4 +48,4 @@ typedef enum
   ACT_END,
 } nvt_category;
 
-#endif /* _NVT_CATEGORIES_H */
+#endif /* MISC_NVT_CATEGORIES_H */

--- a/misc/pcap_openvas.h
+++ b/misc/pcap_openvas.h
@@ -23,8 +23,8 @@
  * @brief Header file for module pcap.
  */
 
-#ifndef OPENVAS_PCAP_H
-#define OPENVAS_PCAP_H
+#ifndef MISC_PCAP_OPENVAS_H
+#define MISC_PCAP_OPENVAS_H
 
 #include <arpa/inet.h>
 #include <pcap.h>

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -23,8 +23,8 @@
  * @brief Header file for module plugutils.
  */
 
-#ifndef OPENVAS_PLUGUTILS_H
-#define OPENVAS_PLUGUTILS_H
+#ifndef MISC_PLUGUTILS_H
+#define MISC_PLUGUTILS_H
 
 #include "scanneraux.h" /* for struct script_infos */
 

--- a/misc/scan_id.c
+++ b/misc/scan_id.c
@@ -1,3 +1,22 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 #include "scan_id.h"
 
 #include <stdlib.h>

--- a/misc/scan_id.h
+++ b/misc/scan_id.h
@@ -1,5 +1,24 @@
-#ifndef SCANID_H
-#define SCANID_H
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef MISC_SCANID_H
+#define MISC_SCANID_H
 
 int
 set_scan_id (const char *);

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -22,8 +22,8 @@
  * @brief Auxiliary structures for scanner.
  */
 
-#ifndef _OPENVAS_SCANNERAUX_H
-#define _OPENVAS_SCANNERAUX_H
+#ifndef MISC_SCANNERAUX_H
+#define MISC_SCANNERAUX_H
 
 #include <glib.h>
 #include <gvm/base/nvti.h>
@@ -53,4 +53,4 @@ struct script_infos
   int denial_port;
   int alive;
 };
-#endif /* not _OPENVAS_SCANNERAUX_H */
+#endif /* not MISC_SCANNERAUX_H */

--- a/misc/strutils.h
+++ b/misc/strutils.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef MISC2_STRUTILS_H__
-#define MISC2_STRUTILS_H__
+#ifndef MISC_STRUTILS_H
+#define MISC_STRUTILS_H
 
 #include <glib.h>
 

--- a/misc/support.h
+++ b/misc/support.h
@@ -22,8 +22,8 @@
  * @brief Support macros for special platforms.
  */
 
-#ifndef _OPENVAS_MISC_SUPPORT_H
-#define _OPENVAS_MISC_SUPPORT_H
+#ifndef MISC_SUPPORT_H
+#define MISC_SUPPORT_H
 
 // This structure does not exist on MacOS or FreeBSD systems
 #ifndef s6_addr32
@@ -44,4 +44,4 @@
 #define g_pattern_spec_match_string g_pattern_match_string
 #endif
 
-#endif /* not _OPENVAS_MISC_SUPPORT_H */
+#endif /* not MISC_SUPPORT_H */

--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -1,4 +1,4 @@
-/* Portions Copyright (C) 2021-2022 Greenbone Networks GmbH
+/* Copyright (C) 2021-2022 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/misc/table_driven_lsc.h
+++ b/misc/table_driven_lsc.h
@@ -22,8 +22,8 @@
  * @brief Header file for module table_driven_lsc.
  */
 
-#ifndef TABLE_DRIVEN_LSC_H
-#define TABLE_DRIVEN_LSC_H
+#ifndef MISC_TABLE_DRIVEN_LSC_H
+#define MISC_TABLE_DRIVEN_LSC_H
 
 #include <glib.h>
 
@@ -35,4 +35,4 @@ gchar *
 get_status_of_table_driven_lsc_from_json (const char *, const char *,
                                           const char *, int);
 
-#endif // TABLE_DRIVEN_LSC_H
+#endif // MISC_TABLE_DRIVEN_LSC_H

--- a/misc/vendorversion.h
+++ b/misc/vendorversion.h
@@ -22,8 +22,8 @@
  * @brief Header file: vendor version functions prototypes.
  */
 
-#ifndef _OPENVAS_VENDORVERSION_H
-#define _OPENVAS_VENDORVERSION_H
+#ifndef MISC_VENDORVERSION_H
+#define MISC_VENDORVERSION_H
 
 #include <glib.h>
 
@@ -33,4 +33,4 @@ vendor_version_get (void);
 void
 vendor_version_set (const gchar *);
 
-#endif /* not _OPENVAS_VENDORVERSION_H */
+#endif /* not MISC_VENDORVERSION_H */

--- a/nasl/byteorder.h
+++ b/nasl/byteorder.h
@@ -22,8 +22,8 @@
  * @brief Unix SMB/CIFS implementation. SMB Byte handling
  */
 
-#ifndef _BYTEORDER_H
-#define _BYTEORDER_H
+#ifndef NASL_BYTEORDER_H
+#define NASL_BYTEORDER_H
 
 /*
    This file implements macros for machine independent short and
@@ -179,4 +179,4 @@ it also defines lots of intermediate macros, just ignore those :-)
 #define ALIGN4(p, base) ((p) + ((4 - (PTR_DIFF ((p), (base)) & 3)) & 3))
 #define ALIGN2(p, base) ((p) + ((2 - (PTR_DIFF ((p), (base)) & 1)) & 1))
 
-#endif /* _BYTEORDER_H */
+#endif /* NASL_BYTEORDER_H */

--- a/nasl/capture_packet.h
+++ b/nasl/capture_packet.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef CAPTURE_PACKET_H
-#define CAPTURE_PACKET_H
+#ifndef NASL_CAPTURE_PACKET_H
+#define NASL_CAPTURE_PACKET_H
 
 #include <netinet/in.h>
 #include <netinet/ip6.h>

--- a/nasl/charset.h
+++ b/nasl/charset.h
@@ -25,8 +25,8 @@
 
 /* MODIFICATION: This has only those functions that cater to the requirements of
  * OpenVAS, remaining functions are removed*/
-#ifndef __CHARSET_H__
-#define __CHARSET_H__
+#ifndef NASL_CHARSET_H
+#define NASL_CHARSET_H
 
 #include "smb.h"
 

--- a/nasl/exec.h
+++ b/nasl/exec.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef EXEC_H_INCLUDED
-#define EXEC_H_INCLUDED
+#ifndef NASL_EXEC_H
+#define NASL_EXEC_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/hmacmd5.h
+++ b/nasl/hmacmd5.h
@@ -26,8 +26,8 @@
  * for ntlmv2.
  */
 
-#ifndef _HMAC_MD5_H
-#define _HMAC_MD5_H
+#ifndef NASL_HMACMD5_H
+#define NASL_HMACMD5_H
 
 #include "md5.h"
 
@@ -83,4 +83,4 @@ hmac_md5_final (uchar *digest, HMACMD5Context *ctx);
 void
 hmac_md5 (uchar key[16], uchar *data, int data_len, uchar *digest);
 
-#endif /* _HMAC_MD5_H */
+#endif /* NASL_HMACMD5_H */

--- a/nasl/iconv.h
+++ b/nasl/iconv.h
@@ -22,8 +22,8 @@
  * @brief Unix SMB/CIFS implementation. iconv memory system include wrappers
  */
 
-#ifndef _system_iconv_h
-#define _system_iconv_h
+#ifndef NASL_ICONV_H
+#define NASL_ICONV_H
 
 #if !defined(HAVE_ICONV) && defined(HAVE_ICONV_H)
 #define HAVE_ICONV

--- a/nasl/lint.h
+++ b/nasl/lint.h
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef LINT_H_INCLUDED
-#define LINT_H_INCLUDED
+#ifndef NASL_LINT_H
+#define NASL_LINT_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/md4.h
+++ b/nasl/md4.h
@@ -23,6 +23,10 @@
  *
  * A implementation of MD4 designed for use in the SMB authentication protocol
  */
+#ifndef NASL_MD4_H
+#define NASL_MD4_H
 
 void
 mdfour_ntlmssp (unsigned char *out, const unsigned char *in, int n);
+
+#endif

--- a/nasl/md5.h
+++ b/nasl/md5.h
@@ -18,8 +18,8 @@
 /* This code slightly modified to fit into Samba by
    abartlet@samba.org Jun 2001 */
 
-#ifndef MD5_H
-#define MD5_H
+#ifndef NASL_MD5_H
+#define NASL_MD5_H
 #ifndef HEADER_MD5_H
 /* Try to avoid clashes with OpenSSL */
 #define HEADER_MD5_H
@@ -57,4 +57,4 @@ MD5Update (struct MD5Context *context, unsigned char const *buf, unsigned len);
 void
 MD5Final (unsigned char digest[16], struct MD5Context *context);
 
-#endif /* !MD5_H */
+#endif /* !NASL_MD5_H */

--- a/nasl/nasl.h
+++ b/nasl/nasl.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef __LIB_NASL_H__
-#define __LIB_NASL_H__
+#ifndef NASL_H
+#define NASL_H
 
 #include "../misc/scanneraux.h"
 

--- a/nasl/nasl_builtin_plugins.h
+++ b/nasl/nasl_builtin_plugins.h
@@ -22,8 +22,8 @@
  * @brief Header file for built-in plugins.
  */
 
-#ifndef _NASL_BUILTIN_PLUGINS_H
-#define _NASL_BUILTIN_PLUGINS_H
+#ifndef NASL_NASL_BUILTIN_PLUGINS_H
+#define NASL_NASL_BUILTIN_PLUGINS_H
 #include "nasl_lex_ctxt.h"
 #include "nasl_tree.h"
 tree_cell *
@@ -35,4 +35,4 @@ plugin_run_openvas_tcp_scanner (lex_ctxt *);
 tree_cell *
 plugin_run_synscan (lex_ctxt *);
 
-#endif /* not _NASL_BUILTIN_PLUGINS_H */
+#endif /* not NASL_NASL_BUILTIN_PLUGINS_H */

--- a/nasl/nasl_cert.h
+++ b/nasl/nasl_cert.h
@@ -24,8 +24,8 @@
  * This file contains the protos for \ref nasl_cert.c
  */
 
-#ifndef NASL_CERT_H
-#define NASL_CERT_H
+#ifndef NASL_NASL_CERT_H
+#define NASL_NASL_CERT_H
 
 #include "nasl_lex_ctxt.h"
 
@@ -38,4 +38,4 @@ nasl_cert_close (lex_ctxt *lexic);
 tree_cell *
 nasl_cert_query (lex_ctxt *lexic);
 
-#endif /*NASL_CERT_H*/
+#endif /*NASL_NASL_CERT_H*/

--- a/nasl/nasl_cmd_exec.h
+++ b/nasl/nasl_cmd_exec.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_UNSAFE_H
-#define NASL_UNSAFE_H
+#ifndef NASL_NASL_CMD_EXEC_H
+#define NASL_NASL_CMD_EXEC_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_crypto.h
+++ b/nasl/nasl_crypto.h
@@ -20,8 +20,8 @@
  * MODIFICATION: added definitions for implementing NTLMSSP features
  */
 
-#ifndef NASL_CRYPTO_H
-#define NASL_CRYPTO_H
+#ifndef NASL_NASL_CRYPTO_H
+#define NASL_NASL_CRYPTO_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_crypto2.h
+++ b/nasl/nasl_crypto2.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_CRYPTO2_H
-#define NASL_CRYPTO2_H
+#ifndef NASL_NASL_CRYPTO2_H
+#define NASL_NASL_CRYPTO2_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_crypto_helper.h
+++ b/nasl/nasl_crypto_helper.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_CRYPTO_HELPER_H
-#define NASL_CRYPTO_HELPER_H
+#ifndef NASL_NASL_CRYPTO_HELPER_H
+#define NASL_NASL_CRYPTO_HELPER_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_debug.h
+++ b/nasl/nasl_debug.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_DEBUG_H__
-#define NASL_DEBUG_H__
+#ifndef NASL_NASL_DEBUG_H
+#define NASL_NASL_DEBUG_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_frame_forgery.h
+++ b/nasl/nasl_frame_forgery.h
@@ -22,8 +22,8 @@
  * @brief Header file for module nasl_frame_forgery.
  */
 
-#ifndef NASL_FRAME_FORGERY_H
-#define NASL_FRAME_FORGERY_H
+#ifndef NASL_NASL_FRAME_FORGERY_H
+#define NASL_NASL_FRAME_FORGERY_H
 
 #include "nasl_lex_ctxt.h"
 
@@ -42,4 +42,4 @@ nasl_send_frame (lex_ctxt *);
 tree_cell *
 nasl_dump_frame (lex_ctxt *);
 
-#endif // NASL_FRAME_FORGERY_H
+#endif // NASL_NASL_FRAME_FORGERY_H

--- a/nasl/nasl_func.h
+++ b/nasl/nasl_func.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_FUNC_H_INCLUDED
-#define NASL_FUNC_H_INCLUDED
+#ifndef NASL_NASL_FUNC_H
+#define NASL_NASL_FUNC_H
 
 /**
  * Type for a built-in nasl function.

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _NASL_CTX_H
-#define _NASL_CTX_H
+#ifndef NASL_NASL_GLOBAL_CTX_H
+#define NASL_NASL_GLOBAL_CTX_H
 
 /* for FILE */
 #include "nasl_tree.h"

--- a/nasl/nasl_host.h
+++ b/nasl/nasl_host.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_HOST_H
-#define NASL_HOST_H
+#ifndef NASL_NASL_HOST_H
+#define NASL_NASL_HOST_H
 
 #include "nasl_lex_ctxt.h" /* for lex_ctxt */
 #include "nasl_tree.h"     /* for tree_cell */

--- a/nasl/nasl_http.h
+++ b/nasl/nasl_http.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_HTTP_H
-#define NASL_HTTP_H
+#ifndef NASL_NASL_HTTP_H
+#define NASL_NASL_HTTP_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_init.h
+++ b/nasl/nasl_init.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_INIT_H
-#define NASL_INIT_H
+#ifndef NASL_NASL_INIT_H
+#define NASL_NASL_INIT_H
 #include "nasl_lex_ctxt.h"
 
 #include <glib.h>

--- a/nasl/nasl_isotime.h
+++ b/nasl/nasl_isotime.h
@@ -24,8 +24,8 @@
  * This file contains the protos for \ref nasl_isotime.c
  */
 
-#ifndef NASL_ISOTIME_H
-#define NASL_ISOTIME_H
+#ifndef NASL_NASL_ISOTIME_H
+#define NASL_NASL_ISOTIME_H
 
 #include "nasl_lex_ctxt.h"
 
@@ -44,4 +44,4 @@ nasl_isotime_print (lex_ctxt *lexic);
 tree_cell *
 nasl_isotime_add (lex_ctxt *lexic);
 
-#endif /*NASL_ISOTIME_H*/
+#endif /*NASL_NASL_ISOTIME_H*/

--- a/nasl/nasl_lex_ctxt.h
+++ b/nasl/nasl_lex_ctxt.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _NASL_LEX_CTXT_H
-#define _NASL_LEX_CTXT_H
+#ifndef NASL_NASL_LEX_CTXT_H
+#define NASL_NASL_LEX_CTXT_H
 
 #include <glib.h>
 

--- a/nasl/nasl_misc_funcs.h
+++ b/nasl/nasl_misc_funcs.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_MISC_FUNCS_H
-#define NASL_MISC_FUNCS_H
+#ifndef NASL_NASL_MISC_FUNCS_H
+#define NASL_NASL_MISC_FUNCS_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_packet_forgery.h
+++ b/nasl/nasl_packet_forgery.h
@@ -16,7 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_PACKET_FORGERY_H
+#ifndef NASL_NASL_PACKET_FORGERY_H
+#define NASL_NASL_PACKET_FORGERY_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_packet_forgery_v6.h
+++ b/nasl/nasl_packet_forgery_v6.h
@@ -22,7 +22,8 @@
  * Srinivas NL <nl.srinivas@gmail.com>
  */
 
-#ifndef NASL_PACKET_FORGERY_H
+#ifndef NASL_NASL_PACKET_FORGERY_V6_H
+#define NASL_NASL_PACKET_FORGERY_V6_H
 
 tree_cell *
 forge_ip_v6_packet (lex_ctxt *);

--- a/nasl/nasl_raw.h
+++ b/nasl/nasl_raw.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef OPENVAS_RAW_H
-#define OPENVAS_RAW_H
+#ifndef NASL_NASL_RAW_H
+#define NASL_NASL_RAW_H
 
 #ifdef __linux__
 #ifndef __BSD_SOURCE

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_SCANNER_GLUE_H
-#define NASL_SCANNER_GLUE_H
+#ifndef NASL_NASL_SCANNER_GLUE_H
+#define NASL_NASL_SCANNER_GLUE_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_signature.h
+++ b/nasl/nasl_signature.h
@@ -17,8 +17,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_SIGNATURE_H
-#define NASL_SIGNATURE_H
+#ifndef NASL_NASL_SIGNATURE_H
+#define NASL_NASL_SIGNATURE_H
+
 #include <stddef.h>
 
 int

--- a/nasl/nasl_smb.h
+++ b/nasl/nasl_smb.h
@@ -24,8 +24,8 @@
  * This file contains the protos for \ref nasl_smb.c
  */
 
-#ifndef _NASL_NASL_SMB_H
-#define _NASL_NASL_SMB_H
+#ifndef NASL_NASL_SMB_H
+#define NASL_NASL_SMB_H
 
 /* for lex_ctxt */
 #include "nasl_lex_ctxt.h"

--- a/nasl/nasl_snmp.h
+++ b/nasl/nasl_snmp.h
@@ -21,8 +21,9 @@
  * @file nasl_snmp.h
  * @brief Headers of an API for SNMP used by NASL scripts.
  */
-#ifndef NASL_SNMP_H
-#define NASL_SNMP_H
+#ifndef NASL_NASL_SNMP_H
+#define NASL_NASL_SNMP_H
+
 #include "nasl_lex_ctxt.h"
 #include "nasl_tree.h"
 tree_cell *

--- a/nasl/nasl_socket.h
+++ b/nasl/nasl_socket.h
@@ -24,8 +24,8 @@
  *----------------------------------------------------------------------*/
 
 /*--------------------------------------------------------------------------*/
-#ifndef NASL_SOCKET_H
-#define NASL_SOCKET_H
+#ifndef NASL_NASL_SOCKET_H
+#define NASL_NASL_SOCKET_H
 
 #include "nasl_lex_ctxt.h"
 #include "nasl_tree.h"

--- a/nasl/nasl_ssh.h
+++ b/nasl/nasl_ssh.h
@@ -24,8 +24,8 @@
  * This file contains the protos for \ref nasl_ssh.c
  */
 
-#ifndef NASL_SSH_H
-#define NASL_SSH_H
+#ifndef NASL_NASL_SSH_H
+#define NASL_NASL_SSH_H
 
 #include "nasl_lex_ctxt.h"
 
@@ -77,4 +77,4 @@ nasl_ssh_get_host_key (lex_ctxt *lexic);
 tree_cell *
 nasl_sftp_enabled_check (lex_ctxt *);
 
-#endif /*NASL_SSH_H*/
+#endif /*NASL_NASL_SSH_H*/

--- a/nasl/nasl_text_utils.h
+++ b/nasl/nasl_text_utils.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_TEXT_UTILS_H
-#define NASL_TEXT_UTILS_H
+#ifndef NASL_NASL_TEXT_UTILS_H
+#define NASL_NASL_TEXT_UTILS_H
 
 #include "nasl_lex_ctxt.h"
 

--- a/nasl/nasl_tree.h
+++ b/nasl/nasl_tree.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASLTREE_H_INCLUDED
-#define NASLTREE_H_INCLUDED
+#ifndef NASL_NASL_TREE_H
+#define NASL_NASL_TREE_H
 
 enum node_type
 {

--- a/nasl/nasl_var.h
+++ b/nasl/nasl_var.h
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef NASL_VAR_H_INCLUDED
-#define NASL_VAR_H_INCLUDED
+#ifndef NASL_NASL_VAR_H
+#define NASL_NASL_VAR_H
 
 #include "nasl_tree.h"
 

--- a/nasl/nasl_wmi.h
+++ b/nasl/nasl_wmi.h
@@ -24,8 +24,8 @@
  * This file contains the protos for \ref nasl_wmi.c
  */
 
-#ifndef _NASL_NASL_WMI_H
-#define _NASL_NASL_WMI_H
+#ifndef NASL_NASL_WMI_H
+#define NASL_NASL_WMI_H
 
 /* for lex_ctxt */
 #include "nasl_lex_ctxt.h"

--- a/nasl/ntlmssp.h
+++ b/nasl/ntlmssp.h
@@ -23,8 +23,8 @@
  * (NTLMv2, NTLM2, NTLM, KEY GEN)
  */
 
-#ifndef _NTLMSSP_H_
-#define _NTLMSSP_H_
+#ifndef NASL_NTLMSSP_H
+#define NASL_NTLMSSP_H
 #include "byteorder.h"
 #include "hmacmd5.h"
 #include "md5.h"

--- a/nasl/openvas_smb_interface.h
+++ b/nasl/openvas_smb_interface.h
@@ -25,8 +25,8 @@
  * interface implementation.
  */
 
-#ifndef _NASL_OPENVAS_SMB_INTERFACE_H
-#define _NASL_OPENVAS_SMB_INTERFACE_H
+#ifndef NASL_OPENVAS_SMB_INTERFACE_H
+#define NASL_OPENVAS_SMB_INTERFACE_H
 
 typedef long int SMB_HANDLE;
 

--- a/nasl/openvas_wmi_interface.h
+++ b/nasl/openvas_wmi_interface.h
@@ -25,8 +25,8 @@
  * interface implementation.
  */
 
-#ifndef _NASL_OPENVAS_WMI_INTERFACE_H
-#define _NASL_OPENVAS_WMI_INTERFACE_H
+#ifndef NASL_OPENVAS_WMI_INTERFACE_H
+#define NASL_OPENVAS_WMI_INTERFACE_H
 
 #include <stdint.h> /* for uint32_t, uint64_t */
 

--- a/nasl/proto.h
+++ b/nasl/proto.h
@@ -16,6 +16,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef NASL_PROTO_H
+#define NASL_PROTO_H
 
 #include <sys/param.h>
 #include <time.h>
@@ -51,3 +53,5 @@ void
 lazy_initialize_conv_ntlmssp (void);
 void
 init_iconv_ntlmssp (void);
+
+#endif

--- a/nasl/smb.h
+++ b/nasl/smb.h
@@ -33,8 +33,8 @@
  *  2. malloc_ changes to malloc in SMB_MALLOC_P
  */
 
-#ifndef _SMB_H
-#define _SMB_H
+#ifndef NASL_SMB_H
+#define NASL_SMB_H
 
 #include "charset.h"
 
@@ -202,4 +202,4 @@ typedef uint64_t NTTIME;
 #endif
 /*---------------------------------------------------------------------------------*/
 
-#endif /* _SMB_H */
+#endif /* NASL_SMB_H */

--- a/nasl/smb_signing.h
+++ b/nasl/smb_signing.h
@@ -30,8 +30,8 @@
    implementation
 */
 
-#ifndef _SMB_SIGNING_H
-#define _SMB_SIGNING_H
+#ifndef NASL_SMB_SIGNING_H
+#define NASL_SMB_SIGNING_H
 
 #include "byteorder.h"
 #include "md5.h"

--- a/src/attack.h
+++ b/src/attack.h
@@ -23,8 +23,8 @@
  * @brief attack.c header.
  */
 
-#ifndef __OPENVAS_ATTACK_H__
-#define __OPENVAS_ATTACK_H__
+#ifndef OPENVAS_ATTACK_H
+#define OPENVAS_ATTACK_H
 
 #include "../misc/scanneraux.h"
 

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -22,8 +22,8 @@
  * @brief debug_utils.c headerfile.
  */
 
-#ifndef _OPENVAS_DEBUG_UTILS_H
-#define _OPENVAS_DEBUG_UTILS_H
+#ifndef OPENVAS_DEBUG_UTILS_H
+#define OPENVAS_DEBUG_UTILS_H
 
 #include <gvm/base/gvm_sentry.h> /* for gvm_sentry_init */
 

--- a/src/hosts.h
+++ b/src/hosts.h
@@ -23,8 +23,8 @@
  * @brief hosts.c header.
  */
 
-#ifndef HOSTS_H
-#define HOSTS_H
+#ifndef OPENVAS_HOSTS_H
+#define OPENVAS_HOSTS_H
 
 #include "../misc/scanneraux.h"
 

--- a/src/openvas.h
+++ b/src/openvas.h
@@ -22,10 +22,10 @@
  * @brief Headers for OpenVAS entry point.
  */
 
-#ifndef _OPENVAS_H
-#define _OPENVAS_H
+#ifndef OPENVAS_H
+#define OPENVAS_H
 
 int
 openvas (int, char **, char **);
 
-#endif /* not _OPENVAS_H */
+#endif /* not OPENVAS_H */

--- a/src/pluginlaunch.h
+++ b/src/pluginlaunch.h
@@ -23,8 +23,8 @@
  * @brief pluginlaunch.c header.
  */
 
-#ifndef __PLUGINLAUNCH_H__
-#define __PLUGINLAUNCH_H__
+#ifndef OPENVAS_PLUGINLAUNCH_H
+#define OPENVAS_PLUGINLAUNCH_H
 
 #include "pluginload.h"      /* for struct pl_class_t */
 #include "pluginscheduler.h" /* for struct plugins_scheduler_t */

--- a/src/pluginload.h
+++ b/src/pluginload.h
@@ -23,8 +23,8 @@
  * @brief pluginload.c header.
  */
 
-#ifndef _OPENVAS_PLUGINLOAD_H
-#define _OPENVAS_PLUGINLOAD_H
+#ifndef OPENVAS_PLUGINLOAD_H
+#define OPENVAS_PLUGINLOAD_H
 
 #include "../misc/network.h"
 #include "../misc/scanneraux.h"

--- a/src/pluginscheduler.h
+++ b/src/pluginscheduler.h
@@ -23,8 +23,8 @@
  * @brief header for pluginscheduler.c
  */
 
-#ifndef PLUGINSCHEDULER_H
-#define PLUGINSCHEDULER_H
+#ifndef OPENVAS_PLUGINSCHEDULER_H
+#define OPENVAS_PLUGINSCHEDULER_H
 
 #include <glib.h>
 

--- a/src/plugs_req.h
+++ b/src/plugs_req.h
@@ -23,8 +23,8 @@
  * @brief plugs_req.c header.
  */
 
-#ifndef PLUGINS_REQUIREMENTS_H__
-#define PLUGINS_REQUIREMENTS_H__
+#ifndef OPENVAS_PLUGS_REQ_H
+#define OPENVAS_PLUGS_REQ_H
 
 #include <gvm/util/kb.h> /* for struct kb_item */
 

--- a/src/processes.h
+++ b/src/processes.h
@@ -23,8 +23,8 @@
  * @brief processes.c header.
  */
 
-#ifndef _OPENVAS_THREADS_H
-#define _OPENVAS_THREADS_H
+#ifndef OPENVAS_PROCESSES_H
+#define OPENVAS_PROCESSES_H
 
 #include <sys/types.h> /* for pid_t */
 

--- a/src/sighand.h
+++ b/src/sighand.h
@@ -23,8 +23,8 @@
  * @brief headerfile for sighand.c.
  */
 
-#ifndef _OPENVAS_SIGHAND_H
-#define _OPENVAS_SIGHAND_H
+#ifndef OPENVAS_SIGHAND_H
+#define OPENVAS_SIGHAND_H
 
 void (*openvas_signal (int signum, void (*handler) (int))) (int);
 void

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,8 +23,8 @@
  * @brief utils.c headerfile.
  */
 
-#ifndef _OPENVAS_UTILS_H
-#define _OPENVAS_UTILS_H
+#ifndef OPENVAS_UTILS_H
+#define OPENVAS_UTILS_H
 
 #include "../misc/scanneraux.h"
 


### PR DESCRIPTION
There were many violation of compliant include guards across the project. This PR fixes that. Additionally a uniform include guard format is introduced with the following scheme: DIR_FILE_H
There are two exceptions:
1. If the name of the file is the same as the folder the naming scheme is FILE_H
2. For the src folder the prefix OPENVAS is used instead of SRC

fixes #446 
SC-658

If you have any opinions on the naming scheme, please feel free to comment
