### PR TITLE
ipc vhost

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories (${GLIB_INCLUDE_DIRS} ${GLIB_JSON_INCLUDE_DIRS}
 # Library
 
 set (FILES bpf_share.c ftp_funcs.c vendorversion.c network.c plugutils.c pcap.c
-     scan_id.c strutils.c table_driven_lsc.c)
+     scan_id.c strutils.c table_driven_lsc.c ipc.c ipc_pipe.c ipc_openvas.c)
 
 
 # On windows we are always PIC and stack-protector is replaces by DEP

--- a/misc/ipc.c
+++ b/misc/ipc.c
@@ -1,0 +1,238 @@
+#include "ipc.h"
+
+#include "ipc_pipe.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <gvm/base/logging.h>
+#include <json-glib/json-glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "lib  misc"
+
+// default preallocation length for ipc_contexts
+#define IPC_CONTEXTS_CAP_STEP 10
+
+int
+ipc_send (struct ipc_context *context, enum ipc_relation to, const char *msg,
+          size_t len)
+{
+  (void) to;
+  if (context == NULL)
+    return -3;
+  if (msg == NULL)
+    return -2;
+  switch (context->type)
+    {
+    case IPC_PIPE:
+      return ipc_pipe_send (context->context, msg, len);
+    };
+  return -2;
+}
+
+int
+ipc_destroy (struct ipc_context *context)
+{
+  int rc = 0;
+  if (context == NULL)
+    return -1;
+  switch (context->type)
+    {
+    case IPC_PIPE:
+      rc = ipc_pipe_destroy (context->context);
+      break;
+    }
+  if (rc > -1)
+    free (context);
+  return rc;
+}
+
+char *
+ipc_retrieve (struct ipc_context *context, enum ipc_relation from)
+{
+  (void) from;
+  if (context == NULL)
+    return NULL;
+  switch (context->type)
+    {
+    case IPC_PIPE:
+      return ipc_pipe_retrieve (context->context);
+    };
+  return NULL;
+}
+
+int
+ipc_close (struct ipc_context *context)
+{
+  int rc = -1;
+  if (context == NULL || context->closed == 1)
+    return rc;
+  switch (context->type)
+    {
+    case IPC_PIPE:
+      context->closed = 1;
+      if ((rc = ipc_pipe_close (context->context)) > -1)
+        context->closed = 1;
+    }
+  return rc;
+}
+
+struct ipc_context *
+ipc_init (enum ipc_protocol type, enum ipc_relation relation)
+{
+  struct ipc_context *ctx = NULL;
+  void *context = NULL;
+  (void) relation;
+  if ((ctx = calloc (1, sizeof (*ctx))) == NULL)
+    goto exit;
+  ctx->type = type;
+  switch (type)
+    {
+    case IPC_PIPE:
+      context = ipc_init_pipe ();
+      break;
+    }
+  if (!context)
+    goto free_exit;
+  ctx->context = context;
+  return ctx;
+
+free_exit:
+  if (ctx != NULL)
+    free (ctx);
+exit:
+  return NULL;
+}
+
+struct ipc_context *
+ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context *exec_ctx)
+{
+  struct ipc_context *pctx = NULL, *cctx = NULL;
+  pid_t pid;
+  if (exec_ctx == NULL || exec_ctx->func == NULL)
+    return NULL;
+  switch (type)
+    {
+    case IPC_PIPE:
+      if ((pctx = ipc_init (type, IPC_MAIN)) == NULL)
+        {
+          return NULL;
+        }
+    }
+
+  gvm_log_lock ();
+  pid = fork ();
+  gvm_log_unlock ();
+  if (pid < 0)
+    {
+      return NULL;
+    }
+  // we are the child process and execute given function
+  if (pid == 0)
+    {
+      if (pctx != NULL)
+        cctx = pctx;
+      else if ((cctx = ipc_init (type, IPC_CHILD)) == NULL)
+        {
+          exit (1);
+        }
+
+      if (exec_ctx->pre_func != NULL)
+        (*exec_ctx->pre_func) (cctx, exec_ctx->pre_arg);
+      (*exec_ctx->func) (cctx, exec_ctx->func_arg);
+      if (exec_ctx->post_func != NULL)
+        (*exec_ctx->post_func) (cctx, exec_ctx->pre_arg);
+      switch (type)
+        {
+        case IPC_PIPE:
+          ipc_destroy (pctx);
+          break;
+        }
+      free (exec_ctx);
+      // we want to cleanup file handle
+      exit (0);
+    }
+
+  if (pctx == NULL)
+    {
+      if ((pctx = malloc (sizeof (*pctx))) == NULL)
+        {
+          return NULL;
+        }
+      pctx->relation = IPC_MAIN;
+      pctx->type = type;
+      pctx->context = exec_ctx->shared_context;
+    }
+  // we are the parent process and return the id of the child process for
+  // observation
+  pctx->pid = pid;
+  return pctx;
+}
+
+struct ipc_contexts *
+ipc_contexts_init (int cap)
+{
+  struct ipc_contexts *ctxs = NULL;
+  if ((ctxs = malloc (sizeof (*ctxs))) == NULL)
+    goto exit;
+  ctxs->len = 0;
+  ctxs->cap = cap > 0 ? cap : IPC_CONTEXTS_CAP_STEP;
+  if ((ctxs->ctxs = malloc (ctxs->cap * sizeof (*ctxs->ctxs))) == NULL)
+    goto free_and_exit;
+exit:
+  return ctxs;
+free_and_exit:
+  if (ctxs == NULL)
+    free (ctxs);
+  return NULL;
+}
+
+struct ipc_contexts *
+ipc_add_context (struct ipc_contexts *ctxs, struct ipc_context *ctx)
+{
+  if (ctxs == NULL)
+    goto exit_error;
+  if (ctx == NULL)
+    goto exit_error;
+  if (ctxs->len == ctxs->cap)
+    {
+      ctxs->cap = ctxs->cap + IPC_CONTEXTS_CAP_STEP;
+      ctxs->ctxs = realloc (ctxs->ctxs, ctxs->cap * sizeof (*ctxs->ctxs));
+      if (ctxs->ctxs == NULL)
+        {
+          // NOTE: the caller must free ctxs->ctxs in this case.
+          goto exit_error;
+        }
+    }
+  ctxs->ctxs[ctxs->len] = *ctx;
+  ctxs->len += 1;
+  return ctxs;
+exit_error:
+  return NULL;
+}
+
+int
+ipc_destroy_contexts (struct ipc_contexts *ctxs)
+{
+  int i, rc = 0;
+  if (ctxs == NULL)
+    return rc;
+  for (i = 0; i < ctxs->len; i++)
+    {
+      if (ipc_close (&ctxs->ctxs[i]) < 0)
+        rc = -1;
+    }
+  free (ctxs->ctxs);
+  free (ctxs);
+  return rc;
+}

--- a/misc/ipc.c
+++ b/misc/ipc.c
@@ -128,7 +128,8 @@ ipc_close (struct ipc_context *context)
  * @brief initializes a new context.
  *
  * @param type the protocol type to be initialized
- * @param relation the relation of the context to be initialized when supported by the type.
+ * @param relation the relation of the context to be initialized when supported
+ * by the type.
  *
  * @return a heap initialized context or NULL on failure.
  */
@@ -233,7 +234,8 @@ ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context exec_ctx)
 /**
  * @brief initializes ipc_contexts with a given preallocated capacity.
  *
- * @param cap to size to be preallocated, if 0 it will not preallocate but allocate on each enw entry.
+ * @param cap to size to be preallocated, if 0 it will not preallocate but
+ * allocate on each enw entry.
  *
  * @return a heap initialized contexts or NULL on failure.
  */

--- a/misc/ipc.c
+++ b/misc/ipc.c
@@ -115,11 +115,11 @@ exit:
 }
 
 struct ipc_context *
-ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context *exec_ctx)
+ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context exec_ctx)
 {
   struct ipc_context *pctx = NULL, *cctx = NULL;
   pid_t pid;
-  if (exec_ctx == NULL || exec_ctx->func == NULL)
+  if (exec_ctx.func == NULL)
     return NULL;
   switch (type)
     {
@@ -147,19 +147,17 @@ ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context *exec_ctx)
           exit (1);
         }
 
-      if (exec_ctx->pre_func != NULL)
-        (*exec_ctx->pre_func) (cctx, exec_ctx->pre_arg);
-      (*exec_ctx->func) (cctx, exec_ctx->func_arg);
-      if (exec_ctx->post_func != NULL)
-        (*exec_ctx->post_func) (cctx, exec_ctx->pre_arg);
+      if (exec_ctx.pre_func != NULL)
+        (*exec_ctx.pre_func) (cctx, exec_ctx.pre_arg);
+      (*exec_ctx.func) (cctx, exec_ctx.func_arg);
+      if (exec_ctx.post_func != NULL)
+        (*exec_ctx.post_func) (cctx, exec_ctx.pre_arg);
       switch (type)
         {
         case IPC_PIPE:
           ipc_destroy (pctx);
           break;
         }
-      free (exec_ctx);
-      // we want to cleanup file handle
       exit (0);
     }
 
@@ -171,7 +169,7 @@ ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context *exec_ctx)
         }
       pctx->relation = IPC_MAIN;
       pctx->type = type;
-      pctx->context = exec_ctx->shared_context;
+      pctx->context = exec_ctx.shared_context;
     }
   // we are the parent process and return the id of the child process for
   // observation

--- a/misc/ipc.c
+++ b/misc/ipc.c
@@ -23,14 +23,26 @@
 // default preallocation length for ipc_contexts
 #define IPC_CONTEXTS_CAP_STEP 10
 
+/**
+ * @brief sends given msg to the target based on the given context
+ *
+ * @param context the ipc_context to be used; must be previously
+ * initialized via ipc_init.
+ *
+ * @param to the target direction of the message when it is supported by the
+ * given ipc_context.
+ * @param msg the message to send
+ * @param len the length of msg
+ *
+ * @return bytes written, -2 when the context or msg or context type is unknown,
+ * -1 on write error
+ */
 int
 ipc_send (struct ipc_context *context, enum ipc_relation to, const char *msg,
           size_t len)
 {
   (void) to;
-  if (context == NULL)
-    return -3;
-  if (msg == NULL)
+  if (context == NULL || msg == NULL)
     return -2;
   switch (context->type)
     {
@@ -40,6 +52,13 @@ ipc_send (struct ipc_context *context, enum ipc_relation to, const char *msg,
   return -2;
 }
 
+/**
+ * @brief destroys given context
+ *
+ * @param context the ipc_context to be destroyed.
+ *
+ * @return 0 on success, -1 on context null or failure to destroy
+ */
 int
 ipc_destroy (struct ipc_context *context)
 {
@@ -57,6 +76,17 @@ ipc_destroy (struct ipc_context *context)
   return rc;
 }
 
+/**
+ * @brief retrieves data for the relation based on the context
+ *
+ * @param context the ipc_context to be used; must be previously
+ * initialized via ipc_init.
+ *
+ * @param to the recieving direction of the message when it is supported by the
+ * given ipc_context.
+ *
+ * @return a heap initialized data or NULL
+ */
 char *
 ipc_retrieve (struct ipc_context *context, enum ipc_relation from)
 {
@@ -71,6 +101,13 @@ ipc_retrieve (struct ipc_context *context, enum ipc_relation from)
   return NULL;
 }
 
+/**
+ * @brief closes given context
+ *
+ * @param context the ipc_context to be  closed
+ *
+ * @return -1 when context is either NULL or already closed or 0 on success.
+ */
 int
 ipc_close (struct ipc_context *context)
 {
@@ -87,6 +124,14 @@ ipc_close (struct ipc_context *context)
   return rc;
 }
 
+/**
+ * @brief initializes a new context.
+ *
+ * @param type the protocol type to be initialized
+ * @param relation the relation of the context to be initialized when supported by the type.
+ *
+ * @return a heap initialized context or NULL on failure.
+ */
 struct ipc_context *
 ipc_init (enum ipc_protocol type, enum ipc_relation relation)
 {
@@ -114,6 +159,14 @@ exit:
   return NULL;
 }
 
+/**
+ * @brief runs given functions with the given protocol type.
+ *
+ * @param type the protocol type to be initialized
+ * @param exec_ctx the execution context to be executed.
+ *
+ * @return a heap initialized context or NULL on failure.
+ */
 struct ipc_context *
 ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context exec_ctx)
 {
@@ -177,6 +230,13 @@ ipc_exec_as_process (enum ipc_protocol type, struct ipc_exec_context exec_ctx)
   return pctx;
 }
 
+/**
+ * @brief initializes ipc_contexts with a given preallocated capacity.
+ *
+ * @param cap to size to be preallocated, if 0 it will not preallocate but allocate on each enw entry.
+ *
+ * @return a heap initialized contexts or NULL on failure.
+ */
 struct ipc_contexts *
 ipc_contexts_init (int cap)
 {
@@ -195,6 +255,14 @@ free_and_exit:
   return NULL;
 }
 
+/**
+ * @brief adds a given context to contexts
+ *
+ * @param ctxs the context holder array to be used to add a new ctx
+ * @param ctx the context to be added to ctxs
+ *
+ * @return a pointer to the given ctxs or NULL on failure.
+ */
 struct ipc_contexts *
 ipc_add_context (struct ipc_contexts *ctxs, struct ipc_context *ctx)
 {
@@ -219,6 +287,13 @@ exit_error:
   return NULL;
 }
 
+/**
+ * @brief destroys given contexts
+ *
+ * @param ctxs the context holder array to be destroyed.
+ *
+ * @return 0 on success or -1 on failure.
+ */
 int
 ipc_destroy_contexts (struct ipc_contexts *ctxs)
 {

--- a/misc/ipc.h
+++ b/misc/ipc.h
@@ -1,0 +1,89 @@
+#ifndef IPC_H
+#define IPC_H
+
+#include <sys/types.h>
+
+enum ipc_protocol
+{
+  IPC_PIPE
+};
+
+enum ipc_relation
+{
+  IPC_MAIN,
+  IPC_CHILD
+};
+
+/**
+ * ipc_context contains information about an inter process communication
+ * process.
+ *
+ * @param type indicates what type of ipc it represents
+ * @param pid is set on ipc_exec_as_process and contains the pid of the child
+ * process.
+ * @param context contextual data for ipc. Is only used internally.
+ */
+struct ipc_context
+{
+  enum ipc_protocol type;
+  enum ipc_relation relation;
+  unsigned int closed;
+  pid_t pid;
+  void *context;
+};
+
+struct ipc_contexts
+{
+  int len;
+  int cap;
+  struct ipc_context *ctxs;
+};
+
+typedef void (*ipc_process_func) (struct ipc_context *, void *);
+
+struct ipc_exec_context
+{
+  // function to be executed before func is executed
+  ipc_process_func pre_func;
+  // function to be executed
+  ipc_process_func func;
+  // function to be executed after func is executed
+  ipc_process_func post_func;
+  void *pre_arg;        // argument for pre_func
+  void *func_arg;       // argument for func
+  void *post_arg;       // argument for post_func
+  void *shared_context; // context to be included in ipc_context
+};
+
+// ipc_process_func is a type for the function to be executed.
+
+int
+ipc_send (struct ipc_context *context, enum ipc_relation to, const char *msg,
+          size_t len);
+
+char *
+ipc_retrieve (struct ipc_context *context, enum ipc_relation from);
+
+int
+ipc_destroy (struct ipc_context *context);
+
+int
+ipc_close (struct ipc_context *context);
+
+struct ipc_context *
+ipc_exec_as_process (enum ipc_protocol type,
+                     struct ipc_exec_context *exec_context);
+
+struct ipc_context *
+ipc_init (enum ipc_protocol protocol, enum ipc_relation relation);
+
+struct ipc_contexts *
+ipc_contexts_init (int len);
+
+struct ipc_contexts *
+ipc_add_context (struct ipc_contexts *ctxs, struct ipc_context *ctx);
+
+int
+ipc_destroy_contexts (struct ipc_contexts *ctxs);
+
+#endif

--- a/misc/ipc.h
+++ b/misc/ipc.h
@@ -1,5 +1,5 @@
-#ifndef IPC_H
-#define IPC_H
+#ifndef MISC_IPC_H
+#define MISC_IPC_H
 
 #include <sys/types.h>
 

--- a/misc/ipc.h
+++ b/misc/ipc.h
@@ -72,7 +72,7 @@ ipc_close (struct ipc_context *context);
 
 struct ipc_context *
 ipc_exec_as_process (enum ipc_protocol type,
-                     struct ipc_exec_context *exec_context);
+                     struct ipc_exec_context exec_context);
 
 struct ipc_context *
 ipc_init (enum ipc_protocol protocol, enum ipc_relation relation);

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -1,0 +1,180 @@
+#include "ipc_openvas.h"
+
+#include <glib.h> /* for g_error */
+#include <json-glib/json-glib.h>
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib logging domain.
+ */
+#define G_LOG_DOMAIN "lib  misc"
+
+struct ipc_data *
+ipc_data_type_from_hostname (const char *source, size_t source_len,
+                             const char *hostname, size_t hostname_len)
+{
+  struct ipc_data *data = NULL;
+  struct ipc_hostname *hnd = NULL;
+  if (source == NULL || hostname == NULL)
+    return NULL;
+  if ((data = calloc (1, sizeof (*data))) == NULL)
+    return NULL;
+  data->type = IPC_DT_HOSTNAME;
+  if ((hnd = calloc (1, sizeof (*hnd))) == NULL)
+    goto failure_exit;
+  hnd->hostname = g_strdup (hostname);
+  hnd->source = g_strdup (source);
+  hnd->hostname_len = hostname_len;
+  hnd->source_len = source_len;
+  data->data = hnd;
+  return data;
+failure_exit:
+  free (data);
+  return NULL;
+}
+
+void
+ipc_hostname_destroy (struct ipc_hostname *data)
+{
+  if (data == NULL)
+    return;
+  g_free (data->hostname);
+  g_free (data->source);
+  g_free (data);
+}
+
+void
+ipc_data_destroy (struct ipc_data *data)
+{
+  if (data == NULL)
+    return;
+  switch (data->type)
+    {
+    case IPC_DT_HOSTNAME:
+      ipc_hostname_destroy (data->data);
+      break;
+    }
+  g_free (data);
+}
+
+const char *
+ipc_data_to_json (struct ipc_data *data)
+{
+  JsonBuilder *builder;
+  JsonGenerator *gen;
+  JsonNode *root;
+  gchar *json_str;
+  struct ipc_hostname *hn = NULL;
+  if (data == NULL)
+    return NULL;
+
+  builder = json_builder_new ();
+
+  json_builder_begin_object (builder);
+
+  json_builder_set_member_name (builder, "type");
+  builder = json_builder_add_int_value (builder, data->type);
+  switch (data->type)
+    {
+    case IPC_DT_HOSTNAME:
+      hn = data->data;
+      json_builder_set_member_name (builder, "source");
+      builder = json_builder_add_string_value (builder, hn->source);
+      json_builder_set_member_name (builder, "hostname");
+      builder = json_builder_add_string_value (builder, hn->hostname);
+
+      break;
+    }
+
+  json_builder_end_object (builder);
+
+  gen = json_generator_new ();
+  root = json_builder_get_root (builder);
+  json_generator_set_root (gen, root);
+  json_str = json_generator_to_data (gen, NULL);
+
+  json_node_free (root);
+  g_object_unref (gen);
+  g_object_unref (builder);
+
+  if (json_str == NULL)
+    g_warning ("%s: Error while creating JSON.", __func__);
+
+  return json_str;
+}
+
+struct ipc_data *
+ipc_data_from_json (const char *json, size_t len)
+{
+  JsonParser *parser;
+  JsonReader *reader = NULL;
+
+  GError *err = NULL;
+  struct ipc_data *ret = NULL;
+  void *data = NULL;
+  struct ipc_hostname *hn;
+
+  enum ipc_data_type type = -1;
+
+  parser = json_parser_new ();
+  if (!json_parser_load_from_data (parser, json, len, &err))
+    {
+      goto cleanup;
+    }
+
+  reader = json_reader_new (json_parser_get_root (parser));
+
+  if (!json_reader_read_member (reader, "type"))
+    {
+      goto cleanup;
+    }
+  type = json_reader_get_int_value (reader);
+  json_reader_end_member (reader);
+  switch (type)
+    {
+    case IPC_DT_HOSTNAME:
+      if ((hn = calloc (1, sizeof (*hn))) == NULL)
+        goto cleanup;
+      if (!json_reader_read_member (reader, "hostname"))
+        {
+          goto cleanup;
+        }
+      hn->hostname = g_strdup (json_reader_get_string_value (reader));
+      hn->hostname_len = strlen (hn->hostname);
+      json_reader_end_member (reader);
+      if (!json_reader_read_member (reader, "source"))
+        {
+          goto cleanup;
+        }
+      hn->source = g_strdup (json_reader_get_string_value (reader));
+      hn->source_len = strlen (hn->source);
+      json_reader_end_member (reader);
+      data = hn;
+      break;
+    }
+  if ((ret = calloc (1, sizeof (*ret))) == NULL)
+    goto cleanup;
+  ret->type = type;
+  ret->data = data;
+cleanup:
+  if (reader)
+    g_object_unref (reader);
+  g_object_unref (parser);
+  if (err != NULL)
+    {
+      g_warning ("%s: Unable to parse json (%s). Reason: %s", __func__, json,
+                 err->message);
+    }
+  if (ret == NULL)
+    {
+      if (data != NULL)
+        {
+          switch (type)
+            {
+            case IPC_DT_HOSTNAME:
+              ipc_hostname_destroy (data);
+              break;
+            }
+        }
+    }
+  return ret;
+}

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -8,6 +8,14 @@
  */
 #define G_LOG_DOMAIN "lib  misc"
 
+/**
+ * @brief initializes ipc_data for a hostname data.
+ *
+ * @param source the source of the hostname
+ * @param hostname the name of the host
+ *
+ * @return a heap initialized ipc_data or NULL on failure.
+ */
 struct ipc_data *
 ipc_data_type_from_hostname (const char *source, size_t source_len,
                              const char *hostname, size_t hostname_len)
@@ -32,7 +40,7 @@ failure_exit:
   return NULL;
 }
 
-void
+static void
 ipc_hostname_destroy (struct ipc_hostname *data)
 {
   if (data == NULL)
@@ -42,6 +50,12 @@ ipc_hostname_destroy (struct ipc_hostname *data)
   g_free (data);
 }
 
+/**
+ * @brief destroys ipc_data.
+ *
+ * @param data the ipc_data to be destroyed.
+ *
+ */
 void
 ipc_data_destroy (struct ipc_data *data)
 {
@@ -56,6 +70,13 @@ ipc_data_destroy (struct ipc_data *data)
   g_free (data);
 }
 
+/**
+ * @brief transforms ipc_data to a json string
+ *
+ * @param data the ipc_data to be transformed.
+ *
+ * @return a heap allocated achar array containing the json or NULL on failure.
+ */
 const char *
 ipc_data_to_json (struct ipc_data *data)
 {
@@ -102,6 +123,14 @@ ipc_data_to_json (struct ipc_data *data)
   return json_str;
 }
 
+/**
+ * @brief transforms json string to a ipc_data struct
+ *
+ * @param json the json representation to be transformed.
+ * @param len the length of the json representation
+ *
+ * @return a heap allocated ipc_data or NULL on failure.
+ */
 struct ipc_data *
 ipc_data_from_json (const char *json, size_t len)
 {

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -1,3 +1,22 @@
+/* Portions Copyright (C) 2009-2022 Greenbone Networks GmbH
+ * Portions Copyright (C) 2006 Software in the Public Interest, Inc.
+ * Based on work Copyright (C) 1998 - 2006 Tenable Network Security, Inc.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 #include "ipc_openvas.h"
 
 #include <glib.h> /* for g_error */

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -1,0 +1,42 @@
+#ifndef IPC_OPENVAS_H
+#define IPC_OPENVAS_H
+#include "ipc.h"
+
+// ipc_hostname is used to send / retrieve new hostnames.
+struct ipc_hostname
+{
+  char *source;        // source value
+  char *hostname;      // hostname value
+  size_t source_len;   // length of source
+  size_t hostname_len; // length of hostname
+};
+
+// ipc_data_type defines
+enum ipc_data_type
+{
+  IPC_DT_HOSTNAME,
+};
+
+struct ipc_data
+{
+  enum ipc_data_type type;
+  void *data;
+};
+
+struct ipc_data *
+ipc_data_type_from_hostname (const char *source, size_t source_len,
+                             const char *hostname, size_t hostname_len);
+
+void
+ipc_hostname_destroy (struct ipc_hostname *data);
+
+void
+ipc_data_destroy (struct ipc_data *data);
+
+const char *
+ipc_data_to_json (struct ipc_data *data);
+
+struct ipc_data *
+ipc_data_from_json (const char *json, size_t len);
+
+#endif

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -1,5 +1,5 @@
-#ifndef IPC_OPENVAS_H
-#define IPC_OPENVAS_H
+#ifndef MISC_IPC_OPENVAS_H
+#define MISC_IPC_OPENVAS_H
 #include "ipc.h"
 
 // ipc_hostname is used to send / retrieve new hostnames.

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -28,9 +28,6 @@ ipc_data_type_from_hostname (const char *source, size_t source_len,
                              const char *hostname, size_t hostname_len);
 
 void
-ipc_hostname_destroy (struct ipc_hostname *data);
-
-void
 ipc_data_destroy (struct ipc_data *data);
 
 const char *

--- a/misc/ipc_pipe.c
+++ b/misc/ipc_pipe.c
@@ -12,7 +12,8 @@
 #define IPC_MAX_BUFFER 4096
 
 /**
- * @brief sends given msg via the given context. Do not use this method directly, use ipc_send of ipc.h instead.
+ * @brief sends given msg via the given context. Do not use this method
+ * directly, use ipc_send of ipc.h instead.
  *
  * @param context the ipc_pipe_context to be used; must be previously
  * initialized via ipc_pipe_init.
@@ -32,7 +33,8 @@ ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len)
 }
 
 /**
- * @brief retrieves message from the given context. Do not use this method directly, use ipc_retrieve of ipc.h instead.
+ * @brief retrieves message from the given context. Do not use this method
+ * directly, use ipc_retrieve of ipc.h instead.
  *
  * @param context the ipc_pipe_context to be used; must be previously
  * initialized via ipc_pipe_init.
@@ -66,7 +68,8 @@ ipc_pipe_retrieve (struct ipc_pipe_context *context)
 }
 
 /**
- * @brief closes given context. Do not use this method directly, use ipc_close of ipc.h instead.
+ * @brief closes given context. Do not use this method directly, use ipc_close
+ * of ipc.h instead.
  *
  * @param context the ipc_pipe_context to be closed.
  *
@@ -90,7 +93,8 @@ exit:
 }
 
 /**
- * @brief destroys given context. Do not use this method directly, use ipc_destroy of ipc.h instead.
+ * @brief destroys given context. Do not use this method directly, use
+ * ipc_destroy of ipc.h instead.
  *
  * @param context the ipc_pipe_context to be destroyed.
  *
@@ -113,7 +117,8 @@ exit:
 }
 
 /**
- * @brief initializes a new context. Do not use this method directly, use ipc_init of ipc.h instead.
+ * @brief initializes a new context. Do not use this method directly, use
+ * ipc_init of ipc.h instead.
  *
  * @return a heap allocated ipc_pipe_context or NULL on failure.
  */

--- a/misc/ipc_pipe.c
+++ b/misc/ipc_pipe.c
@@ -11,6 +11,17 @@
 
 #define IPC_MAX_BUFFER 4096
 
+/**
+ * @brief sends given msg via the given context. Do not use this method directly, use ipc_send of ipc.h instead.
+ *
+ * @param context the ipc_pipe_context to be used; must be previously
+ * initialized via ipc_pipe_init.
+ *
+ * @param msg the message to send
+ * @param len the length of msg
+ *
+ * @return bytes written, 1 on write error
+ */
 int
 ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len)
 {
@@ -20,12 +31,19 @@ ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len)
   return wr;
 }
 
+/**
+ * @brief retrieves message from the given context. Do not use this method directly, use ipc_retrieve of ipc.h instead.
+ *
+ * @param context the ipc_pipe_context to be used; must be previously
+ * initialized via ipc_pipe_init.
+ *
+ * @return a heap allocated char array or NULL on failure.
+ */
 char *
 ipc_pipe_retrieve (struct ipc_pipe_context *context)
 {
   char *result = NULL;
   int rfd, rr, pf;
-  // 0 means parent, everything else child
   rfd = context->fd[0];
   pf = fcntl (rfd, F_GETFL, 0);
   if (pf < 0 && errno != EBADF)
@@ -47,6 +65,13 @@ ipc_pipe_retrieve (struct ipc_pipe_context *context)
     }
 }
 
+/**
+ * @brief closes given context. Do not use this method directly, use ipc_close of ipc.h instead.
+ *
+ * @param context the ipc_pipe_context to be closed.
+ *
+ * @return 0 on success, -1 on failure.
+ */
 int
 ipc_pipe_close (struct ipc_pipe_context *context)
 {
@@ -64,6 +89,13 @@ exit:
   return rc;
 }
 
+/**
+ * @brief destroys given context. Do not use this method directly, use ipc_destroy of ipc.h instead.
+ *
+ * @param context the ipc_pipe_context to be destroyed.
+ *
+ * @return 0 on success, -1 on failure.
+ */
 int
 ipc_pipe_destroy (struct ipc_pipe_context *context)
 {
@@ -80,6 +112,11 @@ exit:
   return rc;
 }
 
+/**
+ * @brief initializes a new context. Do not use this method directly, use ipc_init of ipc.h instead.
+ *
+ * @return a heap allocated ipc_pipe_context or NULL on failure.
+ */
 struct ipc_pipe_context *
 ipc_init_pipe (void)
 {

--- a/misc/ipc_pipe.c
+++ b/misc/ipc_pipe.c
@@ -15,8 +15,6 @@ int
 ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len)
 {
   int wfd, wr;
-
-  // 0 means parent, everything else child
   wfd = context->fd[1];
   wr = write (wfd, msg, len);
   return wr;

--- a/misc/ipc_pipe.c
+++ b/misc/ipc_pipe.c
@@ -1,3 +1,22 @@
+/* Portions Copyright (C) 2009-2022 Greenbone Networks GmbH
+ * Portions Copyright (C) 2006 Software in the Public Interest, Inc.
+ * Based on work Copyright (C) 1998 - 2006 Tenable Network Security, Inc.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 #include "ipc_pipe.h"
 
 #include <errno.h>

--- a/misc/ipc_pipe.c
+++ b/misc/ipc_pipe.c
@@ -1,0 +1,100 @@
+#include "ipc_pipe.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define IPC_MAX_BUFFER 4096
+
+int
+ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len)
+{
+  int wfd, wr;
+
+  // 0 means parent, everything else child
+  wfd = context->fd[1];
+  wr = write (wfd, msg, len);
+  return wr;
+}
+
+char *
+ipc_pipe_retrieve (struct ipc_pipe_context *context)
+{
+  char *result = NULL;
+  int rfd, rr, pf;
+  // 0 means parent, everything else child
+  rfd = context->fd[0];
+  pf = fcntl (rfd, F_GETFL, 0);
+  if (pf < 0 && errno != EBADF)
+    // fd is closed or invalid; we assume closed
+    return NULL;
+  fcntl (rfd, F_SETFL, pf | O_NONBLOCK);
+  if ((result = calloc (1, IPC_MAX_BUFFER)) == NULL)
+    return NULL;
+  if ((rr = read (rfd, result, IPC_MAX_BUFFER)) > 0)
+    {
+      return result;
+    }
+  else
+    {
+      free (result);
+      // if temporary unavailable or not a closed descriptor don't
+      // print an error.
+      return NULL;
+    }
+}
+
+int
+ipc_pipe_close (struct ipc_pipe_context *context)
+{
+  int rc = 0;
+  if (context == NULL)
+    {
+      rc = -1;
+      goto exit;
+    }
+  if ((rc = close (context->fd[0])) < 0)
+    goto exit;
+  if ((rc = close (context->fd[1])) < 0)
+    goto exit;
+exit:
+  return rc;
+}
+
+int
+ipc_pipe_destroy (struct ipc_pipe_context *context)
+{
+  int rc = 0;
+  if (context == NULL)
+    {
+      rc = -1;
+      goto exit;
+    }
+  if ((rc = ipc_pipe_close (context)) < 0)
+    goto exit;
+  free (context);
+exit:
+  return rc;
+}
+
+struct ipc_pipe_context *
+ipc_init_pipe (void)
+{
+  struct ipc_pipe_context *pc = NULL;
+  if ((pc = calloc (1, sizeof (*pc))) == NULL)
+    goto error;
+  if (pipe (pc->fd) == -1)
+    {
+      goto error;
+    }
+  return pc;
+error:
+  if (pc != NULL)
+    free (pc);
+  return NULL;
+}

--- a/misc/ipc_pipe.h
+++ b/misc/ipc_pipe.h
@@ -1,5 +1,5 @@
-#ifndef IPC_PIPE_H
-#define IPC_PIPE_H
+#ifndef MISC_IPC_PIPE_H
+#define MISC_IPC_PIPE_H
 
 struct ipc_pipe_context
 {

--- a/misc/ipc_pipe.h
+++ b/misc/ipc_pipe.h
@@ -1,3 +1,22 @@
+/* Portions Copyright (C) 2009-2022 Greenbone Networks GmbH
+ * Portions Copyright (C) 2006 Software in the Public Interest, Inc.
+ * Based on work Copyright (C) 1998 - 2006 Tenable Network Security, Inc.
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 #ifndef MISC_IPC_PIPE_H
 #define MISC_IPC_PIPE_H
 

--- a/misc/ipc_pipe.h
+++ b/misc/ipc_pipe.h
@@ -1,0 +1,24 @@
+#ifndef IPC_PIPE_H
+#define IPC_PIPE_H
+
+struct ipc_pipe_context
+{
+  int fd[2];
+};
+
+int
+ipc_pipe_send (struct ipc_pipe_context *context, const char *msg, int len);
+
+char *
+ipc_pipe_retrieve (struct ipc_pipe_context *context);
+
+int
+ipc_pipe_destroy (struct ipc_pipe_context *context);
+
+int
+ipc_pipe_close (struct ipc_pipe_context *context);
+
+struct ipc_pipe_context *
+ipc_init_pipe (void);
+
+#endif

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -1089,6 +1089,7 @@ plug_fork_child (kb_t kb)
 {
   pid_t pid;
 
+  // TODO change forking to official channels
   if ((pid = fork ()) == 0)
     {
       sig_n (SIGTERM, _exit);
@@ -1104,6 +1105,8 @@ plug_fork_child (kb_t kb)
       return -1;
     }
   else
+    // the parent waits for the spawned process to finish to prevent DDOS on a
+    // host when multiple vhosts got spawned
     waitpid (pid, NULL, 0);
   return 1;
 }

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -28,7 +28,6 @@
 #include <glib.h>
 #include <gvm/base/nvti.h>
 #include <gvm/util/kb.h>
-
 struct scan_globals
 {
   GHashTable *files_translation;
@@ -42,6 +41,7 @@ struct host_info;
 struct script_infos
 {
   struct scan_globals *globals;
+  struct ipc_context *ipc_context;
   kb_t key;
   kb_t results;
   nvti_t *nvti;

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -34,6 +34,7 @@ struct scan_globals
   GHashTable *files_translation;
   GHashTable *files_size_translation;
   char *scan_id;
+  pid_t host_pid;
 };
 
 struct host_info;

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -26,6 +26,7 @@ if (NOT PKG_CONFIG_FOUND)
 endif (NOT PKG_CONFIG_FOUND)
 
 pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
+pkg_check_modules (GLIB_JSON REQUIRED json-glib-1.0>=1.4.4)
 pkg_check_modules (GIO REQUIRED gio-2.0)
 pkg_check_modules (GNUTLS REQUIRED gnutls>=3.2.15)
 pkg_check_modules (LIBGVM_BASE REQUIRED libgvm_base>=22.4)
@@ -172,6 +173,8 @@ add_definitions (-DOPENVAS_NASL_VERSION="${PROJECT_VERSION_STRING}")
 add_definitions (-DOPENVAS_GPG_BASE_DIR="${OPENVAS_GPG_BASE_DIR}")
 
 include_directories (${GLIB_INCLUDE_DIRS}
+                     ${LIBOPENVAS_MISC_INCLUDE_DIRS}
+                     ${GLIB_JSON_INCLUDE_DIRS} 
                      ${GPGME_INCLUDE_DIRS}
                      ${LIBSSH_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS}
@@ -188,6 +191,8 @@ set_target_properties (openvas_nasl_shared PROPERTIES SOVERSION "${PROJECT_VERSI
 set_target_properties (openvas_nasl_shared PROPERTIES VERSION "${PROJECT_VERSION_STRING}")
 # line below is needed so it also works with no-undefined which is e.g. used by Mandriva
 target_link_libraries (openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS}
+                         ${LIBOPENVAS_MISC_LDFLAGS}
+                         ${GLIB_JSON_LDFLAGS} 
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m
                          ${LIBGVM_BASE_LDFLAGS}
                          ${LIBGVM_UTIL_LDFLAGS}
@@ -202,7 +207,7 @@ target_link_libraries (openvas-nasl openvas_nasl_shared openvas_misc_shared ${GN
 
 # Link the openvas-nasl-lint executable
 add_executable (openvas-nasl-lint nasl-lint.c)
-target_link_libraries (openvas-nasl-lint openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS} ${GIO_LDFLAGS})
+target_link_libraries (openvas-nasl-lint openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS} ${GLIB_JSON_LDFLAGS} ${GIO_LDFLAGS})
 
 ## Install
 

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -139,7 +139,7 @@ add_hostname (lex_ctxt *lexic)
   kb_check_push_str (lexic->script_infos->key, "internal/vhosts", lower);
   snprintf (buffer, sizeof (buffer), "internal/source/%s", lower);
   kb_check_push_str (lexic->script_infos->key, buffer, source);
-  host_pid = kb_item_get_int (lexic->script_infos->key, "internal/hostpid");
+  host_pid = lexic->script_infos->globals->host_pid;
   if (host_pid > 0)
     kill (host_pid, SIGUSR2);
 

--- a/nasl/nasl_host.c
+++ b/nasl/nasl_host.c
@@ -150,7 +150,6 @@ add_hostname (lex_ctxt *lexic)
     g_warning ("Unable to send %s to host process", lower);
 
 end_add_hostname:
-  ipc_data_destroy (hn);
   g_free (lower);
   g_free ((void *) json);
   return NULL;

--- a/src/attack.c
+++ b/src/attack.c
@@ -643,7 +643,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip, GSList *vhosts,
   openvas_signal (SIGUSR2, set_check_new_vhosts_flag);
   host_kb = kb;
   host_vhosts = vhosts;
-  kb_check_set_int (kb, "internal/hostpid", getpid ());
+  globals->host_pid = getpid ();
   host_set_time (main_kb, ip_str, "HOST_START");
   kb_lnk_reset (main_kb);
   setproctitle ("openvas: testing %s", ip_str);

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -611,6 +611,7 @@ openvas (int argc, char *argv[], char *env[])
       attack_network (globals);
 
       gvm_close_sentry ();
+      g_free (globals);
       return EXIT_SUCCESS;
     }
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -556,7 +556,7 @@ pluginlaunch_wait_for_free_process (kb_t main_kb, kb_t kb)
 
       int sig = sigtimedwait (&mask, NULL, &ts);
       if (sig < 0 && errno != EAGAIN)
-        g_warning ("%s: %s", __func__, strerror (errno));
+        g_warning ("%s: %s (%d)", __func__, strerror (errno), errno);
       else if (sig == SIGUSR1)
         {
           /* SIGUSR1 signal is sent during scan stop to all host processes.

--- a/src/processes.c
+++ b/src/processes.c
@@ -46,6 +46,8 @@
  */
 #define G_LOG_DOMAIN "sd   main"
 
+// holds all used ipc_contexts; it will be initialized and managed by
+// create_ipc_process.
 static struct ipc_contexts *ipcc = NULL;
 
 /**

--- a/src/processes.c
+++ b/src/processes.c
@@ -243,6 +243,11 @@ create_ipc_process (ipc_process_func func, void *args)
   return pctx->pid;
 }
 
+/**
+ * @brief returns ipc_contexts.
+ *
+ * @return the globally hold array of all ipc_context; do not manipulate them.
+ */
 const struct ipc_contexts *
 procs_get_ipc_contexts (void)
 {

--- a/src/processes.c
+++ b/src/processes.c
@@ -234,7 +234,7 @@ create_ipc_process (ipc_process_func func, void *args)
   ec.post_func = (ipc_process_func) &post_fork_fun_call;
   ec.func = (ipc_process_func) func;
   ec.func_arg = args;
-  if ((pctx = ipc_exec_as_process (IPC_PIPE, &ec)) == NULL)
+  if ((pctx = ipc_exec_as_process (IPC_PIPE, ec)) == NULL)
     {
       g_warning ("Error : could not fork ! Error : %s", strerror (errno));
       return FORKFAILED;

--- a/src/processes.h
+++ b/src/processes.h
@@ -28,8 +28,6 @@
 
 #include "../misc/ipc.h"
 
-#include "../misc/ipc.h"
-
 #include <sys/types.h> /* for pid_t */
 
 #define FORKFAILED -1

--- a/src/processes.h
+++ b/src/processes.h
@@ -26,6 +26,10 @@
 #ifndef OPENVAS_PROCESSES_H
 #define OPENVAS_PROCESSES_H
 
+#include "../misc/ipc.h"
+
+#include "../misc/ipc.h"
+
 #include <sys/types.h> /* for pid_t */
 
 #define FORKFAILED -1
@@ -45,6 +49,8 @@ int
 terminate_process (pid_t pid);
 
 pid_t
-create_process (process_func_t, void *);
+create_ipc_process (ipc_process_func func, void *args);
+const struct ipc_contexts *
+procs_get_ipc_contexts (void);
 
 #endif


### PR DESCRIPTION
jira: SC-563

dd: inter process communication

To be able to talk to send data downstream to children (and their
children) and upstream (to the parent and main process) IPC is
introduced.

This first and simplest use case is to append found vhosts via
add_hostname.

The usage of ipc is simplified by storing all children of a process in a
global variable within processes. The handling, creation, freeing etc is
done via specialized functions of processes.

There are three header files:
- ipc_pipe.h contains the definitions for pipe specific implementation
- ipc.h contains the definitions for usage
- ipc_openvas.h contains the definitions specific for openvas

This is done to make it easier to either extend IPC or replace specific
solutions without having to change the clients too much.

To test this you can add:

```
if(description)
{
  script_oid("0.0.0.0.0.0.0.0.0.3");
  script_version("2019-11-10T15:30:28+0000");
  script_name("test-add-host-name");
  script_category(ACT_SCANNER);
  script_family("my test family");  
  script_tag(name:"some", value:"tag");
  script_tag(name:"last_modification", value:"2019-11-10 15:30:28 +0000 (Tue, 10 Nov 2020)");
  script_tag(name:"creation_date", value:"2015-03-27 12:00:00 +0100 (Fri, 27 Mar 2015)");
  script_tag(name:"cvss_base", value:"0.0");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"qod_type", value:"remote_app");
  script_tag(name:"qod", value:"0");

  script_version("2021-08-19T02:25:52+0000");
  script_cve_id("CVE-0000-0000", "CVE-0000-0001");
  script_tag(name:"severity_vector", value:"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
  script_tag(name:"severity_origin", value:"NVD");
  script_tag(name:"severity_date", value:"2020-08-07 19:36:00 +0000 (Fri, 07 Aug 2020)");
  script_xref(name:"Example", value:"GB-Test-1");
  script_xref(name:"URL", value:"https://www.greenbone.net");


  script_add_preference(name:"example", type:"entry", value:"a default string value");

  script_tag(name:"vuldetect", value:"Describes what this plugin is doing to detect a vulnerability.");

  script_tag(name:"summary", value:"A short description of the problem");
  script_tag(name:"insight", value:"Some detailed insights of the problem");
  script_tag(name:"impact", value:"Some detailed about what is impacted");

  script_tag(name:"affected", value:"Affected programs, operation system, ...");

  script_tag(name:"solution", value:"Solution description");
  script_tag(name:"solution_type", value:"Type of solution (e.g. mitigation, vendor fix)");
  script_tag(name:"solution_method", value:"how to solve it (e.g. debian apt upgrade)");
  script_tag(name:"qod_type", value:"package");
  exit(0);
}

function newhostname(name) {
  add_host_name(hostname: name);
  hn = get_host_name();
  log_message(data:hn);
}

newhostname(name: "test");

exit(0);

```
as well as 

```
if(description)
{
  script_oid("0.0.0.0.0.0.0.0.0.4");
  script_version("2019-11-10T15:30:28+0000");
  script_name("test-add-host-name");
  script_category(ACT_SCANNER);
  script_family("my test family");  
  script_tag(name:"some", value:"tag");
  script_tag(name:"last_modification", value:"2019-11-10 15:30:28 +0000 (Tue, 10 Nov 2020)");
  script_tag(name:"creation_date", value:"2015-03-27 12:00:00 +0100 (Fri, 27 Mar 2015)");
  script_tag(name:"cvss_base", value:"0.0");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_tag(name:"qod_type", value:"remote_app");
  script_tag(name:"qod", value:"0");

  script_version("2021-08-19T02:25:52+0000");
  script_cve_id("CVE-0000-0000", "CVE-0000-0001");
  script_tag(name:"severity_vector", value:"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
  script_tag(name:"severity_origin", value:"NVD");
  script_tag(name:"severity_date", value:"2020-08-07 19:36:00 +0000 (Fri, 07 Aug 2020)");
  script_xref(name:"Example", value:"GB-Test-1");
  script_xref(name:"URL", value:"https://www.greenbone.net");


  script_add_preference(name:"example", type:"entry", value:"a default string value");

  script_tag(name:"vuldetect", value:"Describes what this plugin is doing to detect a vulnerability.");

  script_tag(name:"summary", value:"A short description of the problem");
  script_tag(name:"insight", value:"Some detailed insights of the problem");
  script_tag(name:"impact", value:"Some detailed about what is impacted");

  script_tag(name:"affected", value:"Affected programs, operation system, ...");

  script_tag(name:"solution", value:"Solution description");
  script_tag(name:"solution_type", value:"Type of solution (e.g. mitigation, vendor fix)");
  script_tag(name:"solution_method", value:"how to solve it (e.g. debian apt upgrade)");
  script_tag(name:"qod_type", value:"package");
  scipt_dependencies("add_host_name.nasl");
  exit(0);
}

hn = get_host_name();
log_message(data:hn);

exit(0);

```

into your plugins dir; either start ospd-openvas when not running or refresh the ospd cache by executing `openvas -u` and then go to ospd-openvas source dir into smoketest.

Within the smoketest dir you can execute:

```
go run cmd/scans/main.go --cmd "start-finish" \
   --host "10.42.0.213" \
   --policy-path /var/lib/gvm/data-objects/gvmd/22.04/scan-configs \
   --oid "0.0.0.0.0.0.0.0.0.4,0.0.0.0.0.0.0.0.0.3" \
   -u /tmp/ospd.sock
```
the openvas log should contain:
```
sd   main:   INFO:2022-08-31 07h17.28 utc:947369: append_vhost: add vhost 'test' from 'NASL'
```
and the result should contain test as hostname for `0.0.0.0.0.0.0.0.0.3` results.