### PR TITLE
Fix: use newdir as a path in message when verification failure

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1646,7 +1646,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   if (g_chdir (newdir) != 0)
     {
       g_message ("%s: Not able to open nor to locate it in include paths",
-                 name);
+                 newdir);
       g_free (old_dir);
       g_free (newdir);
       return -1;


### PR DESCRIPTION
Instead of printing the file path it should print the dir paths since
g_chdir is used to verify dir rights not file rights.
