### PR TITLE
Fix: set transport again if falls back in a unecrypted connection

### DIFF
--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -1542,7 +1542,8 @@ retry_stream_connection (int test_ssl, struct script_infos *desc, int port,
           g_debug ("%s: unable to establish a TLS connection to %s; falling "
                    "back to unencrypted connection",
                    __func__, plug_get_host_fqdn (desc));
-          cnx = open_stream_connection (desc, port, OPENVAS_ENCAPS_IP, timeout);
+          *trp = OPENVAS_ENCAPS_IP;
+          cnx = open_stream_connection (desc, port, *trp, timeout);
         }
     }
 


### PR DESCRIPTION
**What**:
In case of falling back in a unencrypted connection, set the transport to OPENVAS_ENCAPS_IP (1) again.
Jira: SC-664

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The transport was kept as OPENVAS_ENCAPS_TLScustom (9)
<!-- Why are these changes necessary? -->

**How**:
Run an authenticated scan against a windows. The scan config can be a base ScanConfig + smb_login.nasl.
Without the patch the login is not successful, with patch is possible to login agian.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
