### PR TITLE
[main] Handle User-Agent sent to the parent process via IPC SC-655

### DIFF
--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -76,6 +76,7 @@ set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 
 ## Pass-throughs
+add_definitions (-DOPENVAS_MISC_VERSION="${PROJECT_VERSION_STRING}")
 
 include_directories (${GLIB_INCLUDE_DIRS} ${GLIB_JSON_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS}
@@ -84,7 +85,8 @@ include_directories (${GLIB_INCLUDE_DIRS} ${GLIB_JSON_INCLUDE_DIRS}
 # Library
 
 set (FILES bpf_share.c ftp_funcs.c vendorversion.c network.c plugutils.c pcap.c
-     scan_id.c strutils.c table_driven_lsc.c ipc.c ipc_pipe.c ipc_openvas.c)
+     scan_id.c strutils.c table_driven_lsc.c ipc.c ipc_openvas.c ipc_pipe.c
+     user_agent.c)
 
 
 # On windows we are always PIC and stack-protector is replaces by DEP

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -279,7 +279,7 @@ ipc_data_to_json (struct ipc_data *data)
 struct ipc_data *
 ipc_data_from_json (const char *json, size_t len)
 {
-  JsonParser *parser;
+  JsonParser *parser = NULL;
   JsonReader *reader = NULL;
 
   GError *err = NULL;

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -42,7 +42,7 @@ ipc_data_type_from_hostname (const char *source, size_t source_len,
                              const char *hostname, size_t hostname_len)
 {
   struct ipc_data *data = NULL;
-  struct ipc_hostname *hnd = NULL;
+  ipc_hostname_t *hnd = NULL;
   if (source == NULL || hostname == NULL)
     return NULL;
   if ((data = calloc (1, sizeof (*data))) == NULL)
@@ -62,7 +62,7 @@ failure_exit:
 }
 
 static void
-ipc_hostname_destroy (struct ipc_hostname *data)
+ipc_hostname_destroy (ipc_hostname_t *data)
 {
   if (data == NULL)
     return;
@@ -85,7 +85,7 @@ struct ipc_data *
 ipc_data_type_from_user_agent (const char *user_agent, size_t user_agent_len)
 {
   struct ipc_data *data = NULL;
-  struct ipc_user_agent *uad = NULL;
+  ipc_user_agent_t *uad = NULL;
   gchar *ua_str = NULL;
 
   if (user_agent == NULL)
@@ -116,7 +116,7 @@ failure_exit:
  * @param data The user agent data structure to be free()'ed
  */
 static void
-ipc_user_agent_destroy (struct ipc_user_agent *data)
+ipc_user_agent_destroy (ipc_user_agent_t *data)
 {
   if (data == NULL)
     return;
@@ -163,8 +163,8 @@ ipc_data_to_json (struct ipc_data *data)
   JsonGenerator *gen;
   JsonNode *root;
   gchar *json_str;
-  struct ipc_hostname *hn = NULL;
-  struct ipc_user_agent *ua = NULL;
+  ipc_hostname_t *hn = NULL;
+  ipc_user_agent_t *ua = NULL;
 
   if (data == NULL)
     return NULL;
@@ -229,8 +229,8 @@ ipc_data_from_json (const char *json, size_t len)
   GError *err = NULL;
   struct ipc_data *ret = NULL;
   void *data = NULL;
-  struct ipc_user_agent *ua;
-  struct ipc_hostname *hn;
+  ipc_user_agent_t *ua;
+  ipc_hostname_t *hn;
 
   enum ipc_data_type type = -1;
 

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -27,7 +27,6 @@
  */
 #define G_LOG_DOMAIN "lib  misc"
 
-
 // Hostname
 
 /**
@@ -71,7 +70,6 @@ ipc_hostname_destroy (struct ipc_hostname *data)
   g_free (data->source);
   g_free (data);
 }
-
 
 // User-Agent
 
@@ -125,7 +123,6 @@ ipc_user_agent_destroy (struct ipc_user_agent *data)
   g_free (data->user_agent);
   g_free (data);
 }
-
 
 // General IPC data functios
 

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -48,6 +48,7 @@ struct ipc_user_agent
 
 typedef struct ipc_user_agent ipc_user_agent_t;
 
+// ipc_data is used to send / retrieve a given data of the union member
 struct ipc_data
 {
   enum ipc_data_type type;
@@ -75,6 +76,13 @@ ipc_get_data_type_from_data (ipc_data_t *data)
   return IPC_DT_ERROR;
 }
 
+/**
+ * @brief Get the hostname from IPC data
+ *
+ * @param data Data structure of IPC_DT_HOSNAME type.
+ *
+ * @Return a string containing the hostname, NULL on error.
+ */
 gchar *
 ipc_get_hostname_from_data (ipc_data_t *data)
 {
@@ -84,6 +92,13 @@ ipc_get_hostname_from_data (ipc_data_t *data)
   return data->ipc_hostname->hostname;
 }
 
+/**
+ * @brief Get the vhost hostname source from IPC data.
+ *
+ * @param data Data structure of IPC_DT_HOSNAME type.
+ *
+ * @Return a string containing the vhost hostname source, NULL on error.
+ */
 gchar *
 ipc_get_hostname_source_from_data (ipc_data_t *data)
 {
@@ -93,6 +108,13 @@ ipc_get_hostname_source_from_data (ipc_data_t *data)
   return data->ipc_hostname->source;
 }
 
+/**
+ * @brief Get the User-Agent from IPC data
+ *
+ * @param data Data structure of IPC_DT_USER_AGENT type.
+ *
+ * @Return a string containing the User-Agent, NULL on error.
+ */
 gchar *
 ipc_get_user_agent_from_data (ipc_data_t *data)
 {
@@ -136,6 +158,11 @@ failure_exit:
   return NULL;
 }
 
+/**
+ * @brief Free ipc_hostname_t data
+ *
+ * @param data The hostname data structure to be free()'ed
+ */
 static void
 ipc_hostname_destroy (ipc_hostname_t *data)
 {

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -19,13 +19,69 @@
  */
 #include "ipc_openvas.h"
 
-#include <glib.h> /* for g_error */
 #include <json-glib/json-glib.h>
 #undef G_LOG_DOMAIN
 /**
  * @brief GLib logging domain.
  */
 #define G_LOG_DOMAIN "lib  misc"
+
+// Data types definitions
+
+// ipc_hostname is used to send / retrieve new hostnames.
+struct ipc_hostname
+{
+  char *source;        // source value
+  char *hostname;      // hostname value
+  size_t source_len;   // length of source
+  size_t hostname_len; // length of hostname
+};
+
+typedef struct ipc_hostname ipc_hostname_t;
+
+// ipc_user_agent is used to send / retrieve the User-Agent.
+struct ipc_user_agent
+{
+  char *user_agent;      // user_agent value
+  size_t user_agent_len; // length of user_agent
+};
+
+typedef struct ipc_user_agent ipc_user_agent_t;
+
+struct ipc_data
+{
+  enum ipc_data_type type;
+  union
+  {
+    ipc_user_agent_t *ipc_user_agent;
+    ipc_hostname_t *ipc_hostname;
+  };
+};
+
+// Functions to access the structures
+enum ipc_data_type
+ipc_get_data_type_from_data (ipc_data_t *data)
+{
+  return data->type;
+}
+
+gchar *
+ipc_get_hostname_from_data (ipc_data_t *data)
+{
+  return data->ipc_hostname->hostname;
+}
+
+gchar *
+ipc_get_hostname_source_from_data (ipc_data_t *data)
+{
+  return data->ipc_hostname->source;
+}
+
+gchar *
+ipc_get_user_agent_from_data (ipc_data_t *data)
+{
+  return data->ipc_user_agent->user_agent;
+}
 
 // Hostname
 
@@ -233,7 +289,6 @@ ipc_data_from_json (const char *json, size_t len)
 
   enum ipc_data_type type = -1;
 
-
   if ((ret = calloc (1, sizeof (*ret))) == NULL)
     goto cleanup;
 
@@ -249,7 +304,7 @@ ipc_data_from_json (const char *json, size_t len)
     {
       goto cleanup;
     }
-  
+
   type = json_reader_get_int_value (reader);
   json_reader_end_member (reader);
 

--- a/misc/ipc_openvas.c
+++ b/misc/ipc_openvas.c
@@ -78,18 +78,27 @@ ipc_get_data_type_from_data (ipc_data_t *data)
 gchar *
 ipc_get_hostname_from_data (ipc_data_t *data)
 {
+  if (data == NULL || (ipc_get_data_type_from_data (data) != IPC_DT_HOSTNAME))
+    return NULL;
+
   return data->ipc_hostname->hostname;
 }
 
 gchar *
 ipc_get_hostname_source_from_data (ipc_data_t *data)
 {
+  if (data == NULL || (ipc_get_data_type_from_data (data) != IPC_DT_HOSTNAME))
+    return NULL;
+
   return data->ipc_hostname->source;
 }
 
 gchar *
 ipc_get_user_agent_from_data (ipc_data_t *data)
 {
+  if (data == NULL || (ipc_get_data_type_from_data (data) != IPC_DT_USER_AGENT))
+    return NULL;
+
   return data->ipc_user_agent->user_agent;
 }
 

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -32,7 +32,11 @@ enum ipc_data_type
 struct ipc_data
 {
   enum ipc_data_type type;
-  void *data;
+  union {
+    ipc_user_agent_t *ipc_user_agent;
+    ipc_hostname_t *ipc_hostname;
+
+  };
 };
 
 struct ipc_data *

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -8,7 +8,8 @@
 // ipc_data_type defines
 enum ipc_data_type
 {
-  IPC_DT_HOSTNAME,
+  IPC_DT_ERROR = -1,
+  IPC_DT_HOSTNAME = 0,
   IPC_DT_USER_AGENT,
 };
 

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -11,12 +11,16 @@ struct ipc_hostname
   size_t hostname_len; // length of hostname
 };
 
+typedef struct ipc_hostname ipc_hostname_t;
+
 // ipc_user_agent is used to send / retrieve the User-Agent.
 struct ipc_user_agent
 {
   char *user_agent;      // user_agent value
   size_t user_agent_len; // length of user_agent
 };
+
+typedef struct ipc_user_agent ipc_user_agent_t;
 
 // ipc_data_type defines
 enum ipc_data_type

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -11,10 +11,19 @@ struct ipc_hostname
   size_t hostname_len; // length of hostname
 };
 
+// ipc_user_agent is used to send / retrieve the User-Agent.
+struct ipc_user_agent
+{
+  char *user_agent;      // user_agent value
+  size_t user_agent_len; // length of user_agent
+};
+
+
 // ipc_data_type defines
 enum ipc_data_type
 {
   IPC_DT_HOSTNAME,
+  IPC_DT_USER_AGENT,
 };
 
 struct ipc_data
@@ -26,6 +35,9 @@ struct ipc_data
 struct ipc_data *
 ipc_data_type_from_hostname (const char *source, size_t source_len,
                              const char *hostname, size_t hostname_len);
+
+struct ipc_data *
+ipc_data_type_from_user_agent (const char *user_agent, size_t user_agent_len);
 
 void
 ipc_data_destroy (struct ipc_data *data);

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -18,7 +18,6 @@ struct ipc_user_agent
   size_t user_agent_len; // length of user_agent
 };
 
-
 // ipc_data_type defines
 enum ipc_data_type
 {

--- a/misc/ipc_openvas.h
+++ b/misc/ipc_openvas.h
@@ -1,26 +1,9 @@
 #ifndef MISC_IPC_OPENVAS_H
 #define MISC_IPC_OPENVAS_H
+
 #include "ipc.h"
 
-// ipc_hostname is used to send / retrieve new hostnames.
-struct ipc_hostname
-{
-  char *source;        // source value
-  char *hostname;      // hostname value
-  size_t source_len;   // length of source
-  size_t hostname_len; // length of hostname
-};
-
-typedef struct ipc_hostname ipc_hostname_t;
-
-// ipc_user_agent is used to send / retrieve the User-Agent.
-struct ipc_user_agent
-{
-  char *user_agent;      // user_agent value
-  size_t user_agent_len; // length of user_agent
-};
-
-typedef struct ipc_user_agent ipc_user_agent_t;
+#include <glib.h>
 
 // ipc_data_type defines
 enum ipc_data_type
@@ -29,30 +12,36 @@ enum ipc_data_type
   IPC_DT_USER_AGENT,
 };
 
-struct ipc_data
-{
-  enum ipc_data_type type;
-  union {
-    ipc_user_agent_t *ipc_user_agent;
-    ipc_hostname_t *ipc_hostname;
+typedef struct ipc_data ipc_data_t;
 
-  };
-};
+// prototypes for getting internal ipc_data_t information
+enum ipc_data_type
+ipc_get_data_type_from_data (ipc_data_t *data);
 
-struct ipc_data *
+gchar *
+ipc_get_hostname_from_data (ipc_data_t *data);
+
+gchar *
+ipc_get_hostname_source_from_data (ipc_data_t *data);
+
+gchar *
+ipc_get_user_agent_from_data (ipc_data_t *data);
+
+// prototypes for handling of ipc_data_t and json
+ipc_data_t *
 ipc_data_type_from_hostname (const char *source, size_t source_len,
                              const char *hostname, size_t hostname_len);
 
-struct ipc_data *
+ipc_data_t *
 ipc_data_type_from_user_agent (const char *user_agent, size_t user_agent_len);
 
 void
-ipc_data_destroy (struct ipc_data *data);
+ipc_data_destroy (ipc_data_t *data);
 
 const char *
-ipc_data_to_json (struct ipc_data *data);
+ipc_data_to_json (ipc_data_t *data);
 
-struct ipc_data *
+ipc_data_t *
 ipc_data_from_json (const char *json, size_t len);
 
 #endif

--- a/misc/user_agent.c
+++ b/misc/user_agent.c
@@ -1,0 +1,109 @@
+/* Copyright (C) 2009-2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @file user_agent.c
+ * @brief Functions to set and get the User-Agent.
+ */
+
+#include "user_agent.h"
+
+#include "vendorversion.h"
+#include "plugutils.h"    /* plug_get_host_fqdn */
+#include "ipc_openvas.h"
+
+#include <gvm/base/prefs.h> /* for prefs_get */
+#include <glib.h>
+
+/**
+ * @brief user-agent, or NULL.
+ */
+static gchar *user_agent = NULL;
+
+
+/**
+ * @brief Create and set the global User-Agent variable.
+ *
+ * @description Gets the User-Agent from the globals_settings.nasl
+ * script preferences. If it is not set, it uses the Vendor version.
+ * In case that there is no Vendor version, it creates one with a fix string
+ * and the nasl library version.
+ */
+static void
+user_agent_create ()
+{
+  gchar *ua = NULL;
+  
+  ua = get_plugin_preference ("1.3.6.1.4.1.25623.1.0.12288",
+                                  "HTTP User-Agent", -1);
+  if (!ua || strlen (g_strstrip (ua)) == 0)
+    {
+      g_free (ua);
+      if (!vendor_version_get () || *vendor_version_get () == '\0')
+        ua = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; OpenVAS-VT %s)",
+                              OPENVAS_MISC_VERSION);
+      else
+        ua = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; %s)",
+                              vendor_version_get ());
+    }
+
+  user_agent = ua;
+}
+
+/**
+ * @brief Set user-agent
+ *
+ * Set the global user agent. 
+ * This function overwrite the existing UA.
+ * Null or empty string are not allowed.
+ *
+ * @param[in]  ua  user-agent to be set.
+ *
+ * Return the old User-Agent. It must be free by the caller
+ */
+gchar *
+user_agent_set (const gchar *ua)
+{
+  gchar *ua_aux = NULL;
+
+  ua_aux = g_strdup (user_agent);
+  if (!ua || strlen (ua) == 0)
+    {
+      g_free (user_agent);
+      user_agent = g_strdup (ua);
+    }
+  
+  g_message ("The User-Agent %s has been overwritten with %s", ua_aux, user_agent);
+
+  return ua_aux;
+}
+
+/**
+ * @brief Get user-agent.
+ *
+ * @return Get user-agent.
+ */
+const gchar *
+user_agent_get ()
+{
+  if (!user_agent || user_agent[0] == '\0') 
+    user_agent_create ();
+  
+  return user_agent ? user_agent : "";
+}

--- a/misc/user_agent.c
+++ b/misc/user_agent.c
@@ -24,12 +24,12 @@
 
 #include "user_agent.h"
 
-#include "vendorversion.h"
-#include "plugutils.h"    /* plug_get_host_fqdn */
 #include "ipc_openvas.h"
+#include "plugutils.h" /* plug_get_host_fqdn */
+#include "vendorversion.h"
 
-#include <gvm/base/prefs.h> /* for prefs_get */
 #include <glib.h>
+#include <gvm/base/prefs.h> /* for prefs_get */
 
 /**
  * @brief user-agent, or NULL.
@@ -45,10 +45,8 @@ send_user_agent_via_ipc (struct ipc_context *ipc_context)
   ua = ipc_data_type_from_user_agent (user_agent, strlen (user_agent));
   json = ipc_data_to_json (ua);
   ipc_data_destroy (ua);
-  if (ipc_send (ipc_context, IPC_MAIN, json, strlen (json))
-      < 0)
+  if (ipc_send (ipc_context, IPC_MAIN, json, strlen (json)) < 0)
     g_warning ("Unable to send %s to host process", user_agent);
-
 }
 /**
  * @brief Create and set the global User-Agent variable.
@@ -62,9 +60,9 @@ static void
 user_agent_create ()
 {
   gchar *ua = NULL;
-  
-  ua = get_plugin_preference ("1.3.6.1.4.1.25623.1.0.12288",
-                                  "HTTP User-Agent", -1);
+
+  ua = get_plugin_preference ("1.3.6.1.4.1.25623.1.0.12288", "HTTP User-Agent",
+                              -1);
   if (!ua || strlen (g_strstrip (ua)) == 0)
     {
       g_free (ua);
@@ -82,7 +80,7 @@ user_agent_create ()
 /**
  * @brief Set user-agent
  *
- * Set the global user agent. 
+ * Set the global user agent.
  * This function overwrite the existing UA.
  * Null or empty string are not allowed.
  *
@@ -101,7 +99,7 @@ user_agent_set (const gchar *ua)
       g_free (user_agent);
       user_agent = g_strdup (ua);
     }
-  
+
   return ua_aux;
 }
 
@@ -113,13 +111,12 @@ user_agent_set (const gchar *ua)
 const gchar *
 user_agent_get (struct ipc_context *ipc_context)
 {
-
-  g_usleep(20*1000*1000);
-  if (!user_agent || user_agent[0] == '\0') 
+  g_usleep (20 * 1000 * 1000);
+  if (!user_agent || user_agent[0] == '\0')
     {
       user_agent_create ();
       send_user_agent_via_ipc (ipc_context);
     }
-  
+
   return user_agent ? user_agent : "";
 }

--- a/misc/user_agent.h
+++ b/misc/user_agent.h
@@ -1,0 +1,36 @@
+/* Copyright (C) 2009-2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @file user_agent.h
+ * @brief Header file: user agent functions prototypes.
+ */
+
+#ifndef MISC_USERAGENT_H
+#define MISC_USERAGENT_H
+
+#include <glib.h>
+
+const gchar *
+user_agent_get (void);
+
+gchar *
+user_agent_set (const gchar *);
+
+#endif /* not MISC_USERAGENT_H */

--- a/misc/user_agent.h
+++ b/misc/user_agent.h
@@ -25,10 +25,12 @@
 #ifndef MISC_USERAGENT_H
 #define MISC_USERAGENT_H
 
+#include "ipc.h"
+
 #include <glib.h>
 
 const gchar *
-user_agent_get (void);
+user_agent_get (struct ipc_context *);
 
 gchar *
 user_agent_set (const gchar *);

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -18,7 +18,7 @@
 
 #include "nasl_http.h"
 
-#include "../misc/plugutils.h"    /* plug_get_host_fqdn */
+#include "../misc/plugutils.h"  /* plug_get_host_fqdn */
 #include "../misc/user_agent.h" /* for user_agent_get */
 #include "exec.h"
 #include "nasl_debug.h"
@@ -111,7 +111,7 @@ _http_req (lex_ctxt *lexic, char *keyword)
       if (hostname == NULL)
         return NULL;
 
-      ua = g_strdup (user_agent_get ());
+      ua = g_strdup (user_agent_get (lexic->script_infos->ipc_context));
       /* Servers should not have a problem with port 80 or 443 appended.
        * RFC2616 allows to omit the port in which case the default port for
        * that service is assumed.

--- a/nasl/nasl_http.c
+++ b/nasl/nasl_http.c
@@ -18,8 +18,8 @@
 
 #include "nasl_http.h"
 
-#include "../misc/plugutils.h"     /* plug_get_host_fqdn */
-#include "../misc/vendorversion.h" /* for vendor_version_get */
+#include "../misc/plugutils.h"    /* plug_get_host_fqdn */
+#include "../misc/user_agent.h" /* for user_agent_get */
 #include "exec.h"
 #include "nasl_debug.h"
 #include "nasl_func.h"
@@ -110,20 +110,8 @@ _http_req (lex_ctxt *lexic, char *keyword)
       hostname = plug_get_host_fqdn (script_infos);
       if (hostname == NULL)
         return NULL;
-      /* global_settings.nasl */
-      ua = get_plugin_preference ("1.3.6.1.4.1.25623.1.0.12288",
-                                  "HTTP User-Agent", -1);
-      if (!ua || strlen (g_strstrip (ua)) == 0)
-        {
-          g_free (ua);
-          if (!vendor_version_get () || *vendor_version_get () == '\0')
-            ua = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; OpenVAS-VT %s)",
-                                  OPENVAS_NASL_VERSION);
-          else
-            ua = g_strdup_printf ("Mozilla/5.0 [en] (X11, U; %s)",
-                                  vendor_version_get ());
-        }
 
+      ua = g_strdup (user_agent_get ());
       /* Servers should not have a problem with port 80 or 443 appended.
        * RFC2616 allows to omit the port in which case the default port for
        * that service is assumed.

--- a/src/attack.c
+++ b/src/attack.c
@@ -488,9 +488,9 @@ read_ipc (struct ipc_context *ctx)
                   gchar *old_ua = NULL;
                   old_ua =
                     user_agent_set (ipc_get_user_agent_from_data (idata));
-                  g_message (
-                    "%s: The User-Agent %s has been overwritten with %s",
-                    __func__, old_ua, ipc_get_user_agent_from_data (idata));
+                  g_debug ("%s: The User-Agent %s has been overwritten with %s",
+                           __func__, old_ua,
+                           ipc_get_user_agent_from_data (idata));
                   g_free (old_ua);
                 }
               break;

--- a/src/attack.c
+++ b/src/attack.c
@@ -470,14 +470,14 @@ read_ipc (struct ipc_context *ctx)
           switch (idata->type)
             {
             case IPC_DT_HOSTNAME:
-              if ((ihost = (struct ipc_hostname *) idata->data) == NULL)
+              if ((ihost = idata->ipc_hostname) == NULL)
                 g_warning ("%s: ihost data is NULL ignoring new vhost",
                            __func__);
               else
                 append_vhost (ihost->hostname, ihost->source);
               break;
             case IPC_DT_USER_AGENT:
-              if ((iuser_agent = (struct ipc_user_agent *) idata->data) == NULL)
+              if ((iuser_agent = idata->ipc_user_agent) == NULL)
                 g_warning (
                   "%s: iuser_agent data is NULL, ignoring new user agent",
                   __func__);

--- a/src/attack.c
+++ b/src/attack.c
@@ -478,14 +478,16 @@ read_ipc (struct ipc_context *ctx)
               break;
             case IPC_DT_USER_AGENT:
               if ((iuser_agent = (struct ipc_user_agent *) idata->data) == NULL)
-                g_warning ("%s: iuser_agent data is NULL, ignoring new user agent",
-                           __func__);
+                g_warning (
+                  "%s: iuser_agent data is NULL, ignoring new user agent",
+                  __func__);
               else
                 {
                   gchar *old_ua = NULL;
                   old_ua = user_agent_set (iuser_agent->user_agent);
-                  g_message ("%s: The User-Agent %s has been overwritten with %s", __func__,
-                             old_ua, iuser_agent->user_agent);
+                  g_message (
+                    "%s: The User-Agent %s has been overwritten with %s",
+                    __func__, old_ua, iuser_agent->user_agent);
                   g_free (old_ua);
                 }
               break;

--- a/src/attack.c
+++ b/src/attack.c
@@ -467,6 +467,9 @@ read_ipc (struct ipc_context *ctx)
         {
           switch (ipc_get_data_type_from_data (idata))
             {
+            case IPC_DT_ERROR:
+              g_warning ("%s: Unknown data type.", __func__);
+              break;
             case IPC_DT_HOSTNAME:
               if (ipc_get_hostname_from_data (idata) == NULL)
                 g_warning ("%s: ihost data is NULL ignoring new vhost",

--- a/src/attack.c
+++ b/src/attack.c
@@ -459,35 +459,35 @@ static void
 read_ipc (struct ipc_context *ctx)
 {
   char *result;
-  struct ipc_data *idata;
-  struct ipc_hostname *ihost;
-  struct ipc_user_agent *iuser_agent;
+  ipc_data_t *idata;
 
   while ((result = ipc_retrieve (ctx, IPC_MAIN)) != NULL)
     {
       if ((idata = ipc_data_from_json (result, strlen (result))) != NULL)
         {
-          switch (idata->type)
+          switch (ipc_get_data_type_from_data (idata))
             {
             case IPC_DT_HOSTNAME:
-              if ((ihost = idata->ipc_hostname) == NULL)
+              if (ipc_get_hostname_from_data (idata) == NULL)
                 g_warning ("%s: ihost data is NULL ignoring new vhost",
                            __func__);
               else
-                append_vhost (ihost->hostname, ihost->source);
+                append_vhost (ipc_get_hostname_from_data (idata),
+                              ipc_get_hostname_source_from_data (idata));
               break;
             case IPC_DT_USER_AGENT:
-              if ((iuser_agent = idata->ipc_user_agent) == NULL)
+              if (ipc_get_user_agent_from_data (idata) == NULL)
                 g_warning (
                   "%s: iuser_agent data is NULL, ignoring new user agent",
                   __func__);
               else
                 {
                   gchar *old_ua = NULL;
-                  old_ua = user_agent_set (iuser_agent->user_agent);
+                  old_ua =
+                    user_agent_set (ipc_get_user_agent_from_data (idata));
                   g_message (
                     "%s: The User-Agent %s has been overwritten with %s",
-                    __func__, old_ua, iuser_agent->user_agent);
+                    __func__, old_ua, ipc_get_user_agent_from_data (idata));
                   g_free (old_ua);
                 }
               break;

--- a/src/attack.c
+++ b/src/attack.c
@@ -30,7 +30,8 @@
 #include "../misc/nvt_categories.h" /* for ACT_INIT */
 #include "../misc/pcap_openvas.h"   /* for v6_is_local_ip */
 #include "../misc/plugutils.h"
-#include "../misc/table_driven_lsc.h" /*for make_table_driven_lsc_info_json_str */
+#include "../misc/table_driven_lsc.h" /* for make_table_driven_lsc_info_json_str */
+#include "../misc/user_agent.h"       /* for user_agent_set */
 #include "../nasl/nasl_debug.h"       /* for nasl_*_filename */
 #include "hosts.h"
 #include "pluginlaunch.h"
@@ -460,6 +461,8 @@ read_ipc (struct ipc_context *ctx)
   char *result;
   struct ipc_data *idata;
   struct ipc_hostname *ihost;
+  struct ipc_user_agent *iuser_agent;
+
   while ((result = ipc_retrieve (ctx, IPC_MAIN)) != NULL)
     {
       if ((idata = ipc_data_from_json (result, strlen (result))) != NULL)
@@ -472,6 +475,19 @@ read_ipc (struct ipc_context *ctx)
                            __func__);
               else
                 append_vhost (ihost->hostname, ihost->source);
+              break;
+            case IPC_DT_USER_AGENT:
+              if ((iuser_agent = (struct ipc_user_agent *) idata->data) == NULL)
+                g_warning ("%s: iuser_agent data is NULL, ignoring new user agent",
+                           __func__);
+              else
+                {
+                  gchar *old_ua = NULL;
+                  old_ua = user_agent_set (iuser_agent->user_agent);
+                  g_message ("%s: The User-Agent %s has been overwritten with %s", __func__,
+                             old_ua, iuser_agent->user_agent);
+                  g_free (old_ua);
+                }
               break;
             }
           ipc_data_destroy (idata);


### PR DESCRIPTION
**What**:
Via IPC, the first time that the User-Agent is built, can be sent to the parent process and stored. Later, the plugin processes inherits it and uses it.

Jira: SC-655
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently, the user agent must be taken from a script preference, and in case this is not set, it will get from the vendor. As fall back it uses the nasl library version. This will be done thousand times during a F&F scan, since it is done each time a nasl script calls an nasl_http_* function.
<!-- Why are these changes necessary? -->

**How**:
Run a F&F scan. Set vendor version in the openvas.conf or a User-Agent in the plugin preferences of global_settings.nasl.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
