### PR TITLE
openvas-smb support in container image

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -19,4 +19,12 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     libpcap-dev \
     libssh-gcrypt-dev \
     libbsd-dev \
+    # for linking openvas-smb (libopenvas_wmiclient)
+    libgnutls30 \
+    libgssapi3-heimdal \
+    libkrb5-26-heimdal \
+    libasn1-8-heimdal \
+    libroken18-heimdal \
+    libhdb9-heimdal \
+    libpopt0 \
     && rm -rf /var/lib/apt/lists/*

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -2,9 +2,12 @@ ARG VERSION=stable
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
 
+FROM greenbone/openvas-smb AS openvas-smb
+
 FROM ${REPOSITORY}-build:$VERSION AS build
 
 COPY . /source
+COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -25,10 +25,21 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     pnscan \
     libbsd0 \
     rsync \
+    # for openvas-smb support
+    python3-impacket \
+    libgnutls30 \
+    libgssapi3-heimdal \
+    libkrb5-26-heimdal \
+    libasn1-8-heimdal \
+    libroken18-heimdal \
+    libhdb9-heimdal \
+    libpopt0 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY .docker/openvas.conf /etc/openvas/
 COPY --from=build /install/ /
+COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
+COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/
 
 RUN ldconfig
 # allow openvas to access raw sockets and all kind of network related tasks


### PR DESCRIPTION
**What**:

Provide openvas-scanner container image with openvas-smb support

DEVOPS-375

**Why**:

Users should be able to scan Windows machines with the docker containers.

**How**:

Build the images locally.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
