### PR TITLE
Change: Use clang ccc-analyzer dummy compiler for static analysis

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,10 +27,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Configure and Scan Build
         run: |
-          cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
+          cmake -Bbuild -DCMAKE_C_COMPILER=/usr/share/clang/scan-build-11/libexec/ccc-analyzer
           scan-build -o ~/scan-build-report cmake --build build
       - name: Upload scan-build report
-        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: scan-build-report


### PR DESCRIPTION
**What**:
Use clang ccc-analyzer dummy compiler for static analysis in the build test 
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The ccc-analyzer was not set as compiler
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
