### PR TITLE
Fix: initialize global_max_hosts and global_max_checks from config file

### DIFF
--- a/src/openvas.c
+++ b/src/openvas.c
@@ -420,6 +420,7 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
 
   set_default_openvas_prefs ();
   prefs_config (config_file);
+  set_globals_from_preferences ();
 
   if (prefs_get ("vendor_version") != NULL)
     vendor_version_set (prefs_get ("vendor_version"));


### PR DESCRIPTION
**What**:
Fix: initialize global_max_hosts and global_max_checks from config file

Jira: SC-696
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
the settings were not initialized and the defaults (hardcoded) where set instead. Therefore if the client sent a max_checks and max_hosts grather than defaults, the setting was not applied, since the settings from the configuration file were not taken.

<!-- Why are these changes necessary? -->

**How**:
Hardcoded defaults are `max_hosts = 15` and `max_checks = 10`.
- Set in the configuration file `max_hosts = 30` and `max_checks = 15`.
- set in the task configuration `max_hosts = 25` and `max_checks = 13`. (greather than defaults and lower than in the config file)
- run the scan and check the logs.

Repeat the test with and without the patch. 

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
