### PR TITLE
Fix: use main_kb to verify scan_id for inconsistencies

### DIFF
--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -146,8 +146,11 @@ host_get_port_state_udp (struct script_infos *, int);
 /*
  * Inter Plugins Communication functions
  */
-
 int check_kb_inconsistency (kb_t);
+
+void set_main_kb (kb_t);
+kb_t
+get_main_kb (void);
 
 int
 kb_check_push_str (kb_t, const char *, const char *);

--- a/misc/scanneraux.h
+++ b/misc/scanneraux.h
@@ -43,8 +43,8 @@ struct script_infos
 {
   struct scan_globals *globals;
   struct ipc_context *ipc_context;
-  kb_t key;
-  kb_t results;
+  kb_t key;     // nvt_kb
+  kb_t results; // main_kb
   nvti_t *nvti;
   char *oid;
   char *name;

--- a/src/attack.c
+++ b/src/attack.c
@@ -111,7 +111,9 @@ connect_main_kb (kb_t *main_kb)
 
   *main_kb = kb_direct_conn (prefs_get ("db_address"), i);
   if (main_kb)
-    return 0;
+    {
+      return 0;
+    }
 
   g_warning ("Not possible to get the main kb connection.");
   return -1;

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -220,9 +220,13 @@ overwrite_openvas_prefs_with_prefs_from_client (struct scan_globals *globals)
     return -1;
 
   snprintf (key, sizeof (key), "internal/%s/scanprefs", globals->scan_id);
+
   kb = kb_find (prefs_get ("db_address"), key);
   if (!kb)
     return -1;
+  // 2022-10-19: currently internal/%s/scanprefs are set by ospd which is the
+  // main_kb in our context
+  set_main_kb (kb);
 
   res = kb_item_get_all (kb, key);
   if (!res)

--- a/src/processes.c
+++ b/src/processes.c
@@ -25,6 +25,7 @@
 
 #include "processes.h"
 
+#include "../misc/plugutils.h"
 #include "debug_utils.h" /* for init_sentry() */
 #include "sighand.h"
 
@@ -88,7 +89,7 @@ procs_cleanup_children (void)
  *
  */
 static void
-clean_procs ()
+clean_procs (void)
 {
   ipc_destroy_contexts (ipcc);
   ipcc = NULL;
@@ -138,7 +139,7 @@ terminate_process (pid_t pid)
  *
  */
 void
-procs_terminate_childs ()
+procs_terminate_childs (void)
 {
   if (ipcc == NULL)
     return;
@@ -174,7 +175,7 @@ init_child_signal_handlers (void)
 }
 
 static void
-pre_fork_fun_call (struct ipc_context *ctx, void *args)
+pre_fn_call (struct ipc_context *ctx, void *args)
 {
   (void) ctx;
   (void) args;
@@ -188,11 +189,12 @@ pre_fork_fun_call (struct ipc_context *ctx, void *args)
   mqtt_reset ();
   init_sentry ();
   srand48 (getpid () + getppid () + (long) time (NULL));
+
   g_debug ("%s: exit", __func__);
 }
 
 static void
-post_fork_fun_call (struct ipc_context *ctx, void *args)
+post_fn_call (struct ipc_context *ctx, void *args)
 {
   (void) ctx;
   (void) args;
@@ -240,8 +242,8 @@ create_ipc_process (ipc_process_func func, void *args)
   if (ipcc == NULL)
     ipcc = ipc_contexts_init (10);
 
-  ec.pre_func = (ipc_process_func) &pre_fork_fun_call;
-  ec.post_func = (ipc_process_func) &post_fork_fun_call;
+  ec.pre_func = (ipc_process_func) &pre_fn_call;
+  ec.post_func = (ipc_process_func) &post_fn_call;
   ec.func = (ipc_process_func) func;
   ec.func_arg = args;
   // check for exited processes and clean file descriptor


### PR DESCRIPTION
This commit fixes the issue that the inconsistencies were not
necessarily checked against the shared database between ospd and
openvas.

Since ospd sets the scanner id into redis before calling openvas it is
necessary to use the main_kb to verify the locally set scanid with the
one in the database.

This is done by globally storing the main_kb via plugutils `set_main_kb`
and getting it via `get_main_kb`.

Fixes: SC-647