### PR TITLE
rust nasl syntax tokenizer

### DIFF
--- a/rust/nasl-syntax/src/cursor.rs
+++ b/rust/nasl-syntax/src/cursor.rs
@@ -7,6 +7,7 @@ pub const EOF_CHAR: char = '\0';
 ///
 /// Next characters can be peeked via `peek` method,
 /// and position can be shifted forward via `bump` method.
+#[derive(Clone)]
 pub struct Cursor<'a> {
     /// is needed to calculate the length when e.g. tokenizing
     initial_len: usize,

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cursor;
+pub mod token;
 #[cfg(test)]
 mod tests {
     use crate::cursor::Cursor;

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -2,12 +2,46 @@ pub mod cursor;
 pub mod token;
 #[cfg(test)]
 mod tests {
-    use crate::cursor::Cursor;
+    use crate::{
+        cursor::Cursor,
+        token::{Category, Keyword, StringCategory, Token, Tokenizer},
+    };
 
     #[test]
-    fn use_a_cursor() {
+    fn use_cursor() {
         let mut cursor = Cursor::new("  \n\tdisplay(12);");
         cursor.skip_while(|c| c.is_whitespace());
         assert_eq!(cursor.advance(), Some('d'));
+    }
+
+    #[test]
+    fn use_tokenizer() {
+        let tokenizer = Tokenizer::new("local_var hello = 'World!';");
+        let all_tokens = tokenizer.collect::<Vec<Token>>();
+        assert_eq!(
+            all_tokens,
+            vec![
+                Token {
+                    category: Category::Identifier(Some(Keyword::LocalVar)),
+                    position: (0, 9)
+                },
+                Token {
+                    category: Category::Identifier(None),
+                    position: (10, 15)
+                },
+                Token {
+                    category: Category::Equal,
+                    position: (16, 17)
+                },
+                Token {
+                    category: Category::String(StringCategory::Quoteable),
+                    position: (19, 25)
+                },
+                Token {
+                    category: Category::Semicolon,
+                    position: (26, 27)
+                }
+            ]
+        );
     }
 }

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -28,16 +28,20 @@ pub enum Category {
     PipePipe,           // ||
     Bang,               // !
     BangEqual,          // !=
+    BangTilde,          // !~
     Equal,              // =
     EqualEqual,         // ==
+    EqualTilde,         // =~
     Greater,            // >
-    GreaterGreatr,      // >>
+    GreaterGreater,     // >>
     GreaterEqual,       // >=
+    GreaterLess,        // ><
     Less,               // <
     LessLess,           // <<
     LessEqual,          // <=
     Minus,              // -
     MinusMinus,         // --
+    MinusEqual,         // -=
     Plus,               // +
     PlusEqual,          // +=
     PlusPlus,           // ++
@@ -136,17 +140,31 @@ impl<'a> Iterator for Tokenizer<'a> {
             '}' => single_token!(RightCurlyBracket, start, self.cursor.len_consumed()),
             ',' => single_token!(Comma, start, self.cursor.len_consumed()),
             '.' => single_token!(Dot, start, self.cursor.len_consumed()),
-            '-' => single_token!(Minus, start, self.cursor.len_consumed()),
+            '-' => double_token!(self.cursor, start, Minus, '-', MinusMinus, '=', MinusEqual),
             '+' => double_token!(self.cursor, start, Plus, '+', PlusPlus, '=', PlusEqual),
             '%' => single_token!(Percent, start, self.cursor.len_consumed()),
             ';' => single_token!(Semicolon, start, self.cursor.len_consumed()),
-            '/' => single_token!(Slash, start, self.cursor.len_consumed()),
-            '*' => single_token!(Star, start, self.cursor.len_consumed()),
+            '/' => double_token!(self.cursor, start, Slash, '=', SlashEqual),
+            '*' => double_token!(self.cursor, start, Star, '*', StarStar, '=', StarEqual),
             ':' => single_token!(DoublePoint, start, self.cursor.len_consumed()),
             '~' => single_token!(Tilde, start, self.cursor.len_consumed()),
-            '&' => single_token!(Ampersand, start, self.cursor.len_consumed()),
-            '|' => single_token!(Pipe, start, self.cursor.len_consumed()),
+            '&' => double_token!(self.cursor, start, Ampersand, '&', AmpersandAmpersand),
+            '|' => double_token!(self.cursor, start, Pipe, '|', PipePipe),
             '^' => single_token!(Caret, start, self.cursor.len_consumed()),
+            '!' => double_token!(self.cursor, start, Bang, '=', BangEqual, '~', BangTilde),
+            '=' => double_token!(self.cursor, start, Equal, '=', EqualEqual, '~', EqualTilde),
+            '>' => double_token!(
+                self.cursor,
+                start,
+                Greater,
+                '=',
+                GreaterEqual,
+                '>',
+                GreaterGreater,
+                '<',
+                GreaterLess
+            ),
+            '<' => double_token!(self.cursor, start, Less, '=', LessEqual, '<', LessLess),
             _ => single_token!(UnknownSymbol, start, self.cursor.len_consumed()),
         }
     }
@@ -203,7 +221,32 @@ mod tests {
 
     #[test]
     fn double_token() {
-        verify_tokens!("++", vec![(Category::PlusPlus, 0, 2)]);
+        verify_tokens!("&", vec![(Category::Ampersand, 0, 1)]);
+        verify_tokens!("&&", vec![(Category::AmpersandAmpersand, 0, 2)]);
+        verify_tokens!("|", vec![(Category::Pipe, 0, 1)]);
+        verify_tokens!("||", vec![(Category::PipePipe, 0, 2)]);
+        verify_tokens!("!", vec![(Category::Bang, 0, 1)]);
+        verify_tokens!("!=", vec![(Category::BangEqual, 0, 2)]);
+        verify_tokens!("!~", vec![(Category::BangTilde, 0, 2)]);
+        verify_tokens!("=", vec![(Category::Equal, 0, 1)]);
+        verify_tokens!("==", vec![(Category::EqualEqual, 0, 2)]);
+        verify_tokens!("=~", vec![(Category::EqualTilde, 0, 2)]);
+        verify_tokens!(">", vec![(Category::Greater, 0, 1)]);
+        verify_tokens!(">>", vec![(Category::GreaterGreater, 0, 2)]);
+        verify_tokens!(">=", vec![(Category::GreaterEqual, 0, 2)]);
+        verify_tokens!("><", vec![(Category::GreaterLess, 0, 2)]);
+        verify_tokens!("<", vec![(Category::Less, 0, 1)]);
+        verify_tokens!("<<", vec![(Category::LessLess, 0, 2)]);
+        verify_tokens!("<=", vec![(Category::LessEqual, 0, 2)]);
+        verify_tokens!("-", vec![(Category::Minus, 0, 1)]);
+        verify_tokens!("--", vec![(Category::MinusMinus, 0, 2)]);
+        verify_tokens!("+", vec![(Category::Plus, 0, 1)]);
         verify_tokens!("+=", vec![(Category::PlusEqual, 0, 2)]);
+        verify_tokens!("++", vec![(Category::PlusPlus, 0, 2)]);
+        verify_tokens!("/", vec![(Category::Slash, 0, 1)]);
+        verify_tokens!("/=", vec![(Category::SlashEqual, 0, 2)]);
+        verify_tokens!("*", vec![(Category::Star, 0, 1)]);
+        verify_tokens!("**", vec![(Category::StarStar, 0, 2)]);
+        verify_tokens!("*=", vec![(Category::StarEqual, 0, 2)]);
     }
 }

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -141,10 +141,8 @@ pub enum Category {
     GreaterGreaterGreater,      // >>>
     GreaterGreaterEqual,        // >>=
     LessLessEqual,              // <<=
-    LessLessLess,               // <<<
     GreaterBangLess,            // >!<
     GreaterGreaterGreaterEqual, // >>>=
-    LessLessLessEqual,          // <<<=
     String(StringCategory),     // "...\", multiline
     Number(Base),
     IllegalNumber(Base),
@@ -263,9 +261,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     // we break out of the macro since < can be parsed to:
-    // <<<
     // <<=
-    // <<<=
     // most operators don't have triple or tuple variant
     #[inline(always)]
     fn tokenize_less(&mut self) -> Option<Token> {
@@ -281,19 +277,6 @@ impl<'a> Tokenizer<'a> {
                 self.cursor.advance();
                 let next = self.cursor.peek(0);
                 match next {
-                    '<' => {
-                        self.cursor.advance();
-                        if self.cursor.peek(0) == '=' {
-                            self.cursor.advance();
-                            return single_token!(
-                                LessLessLessEqual,
-                                start,
-                                self.cursor.len_consumed()
-                            );
-                        }
-
-                        single_token!(LessLessLess, start, self.cursor.len_consumed())
-                    }
                     '=' => {
                         self.cursor.advance();
                         single_token!(LessLessEqual, start, self.cursor.len_consumed())
@@ -596,12 +579,10 @@ mod tests {
         verify_tokens!(">>=", vec![(Category::GreaterGreaterEqual, 0, 3)]);
         verify_tokens!(">!<", vec![(Category::GreaterBangLess, 0, 3)]);
         verify_tokens!("<<=", vec![(Category::LessLessEqual, 0, 3)]);
-        verify_tokens!("<<<", vec![(Category::LessLessLess, 0, 3)]);
     }
 
     #[test]
     fn four_tuple_tokens() {
-        verify_tokens!("<<<=", vec![(Category::LessLessLessEqual, 0, 4)]);
         verify_tokens!(">>>=", vec![(Category::GreaterGreaterGreaterEqual, 0, 4)]);
     }
 

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -104,7 +104,6 @@ pub enum Category {
     LeftCurlyBracket,           // {
     RightCurlyBracket,          // }
     Comma,                      // ,
-    Hash,                       // #
     Dot,                        // .
     Percent,                    // %
     Semicolon,                  // ;

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -356,6 +356,8 @@ impl<'a> Tokenizer<'a> {
                 self.cursor.advance();
                 self.cursor.skip_while(base.verifier());
             }
+            // we verify that the cursor actually moved to prevent scenarious like
+            // 0b without any actual number in it
             if start == self.cursor.len_consumed() {
                 single_token!(Category::IllegalNumber(base), start, start)
             } else {

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -1,0 +1,181 @@
+use std::ops::Range;
+
+///! This module defines the TokenTypes as well as Token and extends Cursor with advance_token
+use crate::cursor::Cursor;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+/// Is used to identify a Token
+pub enum Category {
+    // Single-character tokens.
+    LeftParen,         // (
+    RightParen,        // )
+    LeftBrace,         // [
+    RightBrace,        // ]
+    LeftCurlyBracket,  // {
+    RightCurlyBracket, // }
+    Comma,             // ,
+    Dot,               // .
+    Minus,             // -
+    Plus,              // +
+    Percent,           // %
+    Semicolon,         // ;
+    Slash,             // /
+    Star,              // *
+    DoublePoint,       // :
+    Tilde,             // ~
+    Ampersand,         // &
+    Pipe,              // |
+    Caret,             // ^
+
+    UnknownSymbol, // used when the symbol is unknown
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+
+/// Contains the TokenType as well as the position in form of Range<usize>
+pub struct Token {
+    category: Category,
+    // using a tuple in favor of Range to have the possibility
+    // to easily copy tokens rather than clone; to create a range for lookups
+    // call range()
+    position: (usize, usize),
+}
+
+impl Token {
+    /// Returns the Category
+    pub fn category(&self) -> Category {
+        self.category
+    }
+
+    /// Returns the byte Range within original input
+    pub fn range(&self) -> Range<usize> {
+        let (start, end) = self.position;
+        Range { start, end }
+    }
+}
+
+/// Tokenizer uses a cursor to create tokens
+pub struct Tokenizer<'a> {
+    // Is used to lookup keywords
+    //code: &'a str,
+    cursor: Cursor<'a>,
+}
+
+impl<'a> Tokenizer<'a> {
+    pub fn new(code: &'a str) -> Self {
+        Tokenizer {
+            cursor: Cursor::new(code),
+        }
+    }
+}
+
+impl<'a> Iterator for Tokenizer<'a> {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cursor.skip_while(|c| c.is_whitespace());
+        let initial_pos = self.cursor.len_consumed();
+        let build_token = |category, start, end| -> Option<Token> {
+            Some(Token {
+                category,
+                position: (start, end),
+            })
+        };
+        match self.cursor.advance()? {
+            '(' => build_token(Category::LeftParen, initial_pos, self.cursor.len_consumed()),
+            ')' => build_token(
+                Category::RightParen,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+            '[' => build_token(Category::LeftBrace, initial_pos, self.cursor.len_consumed()),
+            ']' => build_token(
+                Category::RightBrace,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+            '{' => build_token(
+                Category::LeftCurlyBracket,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+            '}' => build_token(
+                Category::RightCurlyBracket,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+            ',' => build_token(Category::Comma, initial_pos, self.cursor.len_consumed()),
+            '.' => build_token(Category::Dot, initial_pos, self.cursor.len_consumed()),
+            '-' => build_token(Category::Minus, initial_pos, self.cursor.len_consumed()),
+            '+' => build_token(Category::Plus, initial_pos, self.cursor.len_consumed()),
+            '%' => build_token(Category::Percent, initial_pos, self.cursor.len_consumed()),
+            ';' => build_token(Category::Semicolon, initial_pos, self.cursor.len_consumed()),
+            '/' => build_token(Category::Slash, initial_pos, self.cursor.len_consumed()),
+            '*' => build_token(Category::Star, initial_pos, self.cursor.len_consumed()),
+            ':' => build_token(
+                Category::DoublePoint,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+            '~' => build_token(Category::Tilde, initial_pos, self.cursor.len_consumed()),
+            '&' => build_token(Category::Ampersand, initial_pos, self.cursor.len_consumed()),
+            '|' => build_token(Category::Pipe, initial_pos, self.cursor.len_consumed()),
+            '^' => build_token(Category::Caret, initial_pos, self.cursor.len_consumed()),
+            _ => build_token(
+                Category::UnknownSymbol,
+                initial_pos,
+                self.cursor.len_consumed(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_token(input: (Category, usize, usize)) -> Token {
+        let (category, start, end) = input;
+        Token {
+            category,
+            position: (start, end),
+        }
+    }
+
+    // use macro instead of a method to have correct line numbers on failure
+    macro_rules! verify_tokens {
+        ($code:expr, $expected:expr) => {
+            let actual: Vec<Token> = Tokenizer::new($code).collect();
+            let expected: Vec<Token> = $expected.iter().map(|x| build_token(*x)).collect();
+            assert_eq!(actual, expected);
+        };
+    }
+
+    #[test]
+    fn skip_white_space() {
+        verify_tokens!("     (       ", vec![(Category::LeftParen, 5, 6)]);
+    }
+
+    #[test]
+    fn single_token() {
+        verify_tokens!("(", vec![(Category::LeftParen, 0, 1)]);
+        verify_tokens!(")", vec![(Category::RightParen, 0, 1)]);
+        verify_tokens!("[", vec![(Category::LeftBrace, 0, 1)]);
+        verify_tokens!("]", vec![(Category::RightBrace, 0, 1)]);
+        verify_tokens!("{", vec![(Category::LeftCurlyBracket, 0, 1)]);
+        verify_tokens!("}", vec![(Category::RightCurlyBracket, 0, 1)]);
+        verify_tokens!(",", vec![(Category::Comma, 0, 1)]);
+        verify_tokens!(".", vec![(Category::Dot, 0, 1)]);
+        verify_tokens!("-", vec![(Category::Minus, 0, 1)]);
+        verify_tokens!("+", vec![(Category::Plus, 0, 1)]);
+        verify_tokens!("%", vec![(Category::Percent, 0, 1)]);
+        verify_tokens!(";", vec![(Category::Semicolon, 0, 1)]);
+        verify_tokens!("/", vec![(Category::Slash, 0, 1)]);
+        verify_tokens!("*", vec![(Category::Star, 0, 1)]);
+        verify_tokens!(":", vec![(Category::DoublePoint, 0, 1)]);
+        verify_tokens!("~", vec![(Category::Tilde, 0, 1)]);
+        verify_tokens!("&", vec![(Category::Ampersand, 0, 1)]);
+        verify_tokens!("|", vec![(Category::Pipe, 0, 1)]);
+        verify_tokens!("^", vec![(Category::Caret, 0, 1)]);
+    }
+}


### PR DESCRIPTION
Change: add tokenizer for single character tokens

On top of Cursor a Tokenizer is needed to tokenize the given source
code. This initial Tokenizer can handle NASL single character tokens.

A Tokenizer implements the Iterator interface and can be used as that:

```
let single_char_example = "() [ ] { } , . - + % ; / * : ~ & | ^";
let actual: Vec<Token> = Tokenizer::new(single_char_example).collect();
```

Depends on: https://github.com/greenbone/openvas-scanner/pull/1222
