### PR TITLE
Fix: missing NASL dependency netstat

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     pnscan \
     libbsd0 \
     rsync \
+    # net-tools is required by some nasl plugins.
+    # nasl_pread: Failed to execute child process “netstat” (No such file or directory)
+    net-tools \
     # for openvas-smb support
     python3-impacket \
     libgnutls30 \


### PR DESCRIPTION
A direct call of netstat from NASL is done in:
- ./pre2008/netstat_portscan.nasl
therefore it is required in the Docker image if a user wants to execute
this script.
