### PR TITLE
rs use peek

### DIFF
--- a/rust/nasl-syntax/src/grouping_extension.rs
+++ b/rust/nasl-syntax/src/grouping_extension.rs
@@ -45,7 +45,7 @@ impl<'a> Grouping for Lexer<'a> {
 
     fn parse_block(&mut self, token: Token) -> Result<Statement, SyntaxError> {
         let mut results = vec![];
-        while let Some(token) = self.peek(0) {
+        while let Some(token) = self.peek() {
             if token.category() == Category::RightCurlyBracket {
                 self.token();
                 return Ok(Statement::Block(results));

--- a/rust/nasl-syntax/src/infix_extension.rs
+++ b/rust/nasl-syntax/src/infix_extension.rs
@@ -371,7 +371,7 @@ mod test {
     #[test]
     fn repeat_call() {
         assert_eq!(
-            result("lol() x 2;"),
+            result("x() x 2;"),
             Operator(
                 X,
                 vec![

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -45,7 +45,7 @@ impl<'a> Lexer<'a> {
             return Err(unclosed_token!(token));
         }
         let r#else: Option<Statement> = {
-            match self.peek(0) {
+            match self.peek() {
                 Some(token) => match token.category() {
                     Category::Identifier(Some(Keyword::Else)) => {
                         self.token();
@@ -146,7 +146,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn parse_return(&mut self) -> Result<(End, Statement), SyntaxError> {
-        let token = self.peek(0);
+        let token = self.peek();
         if let Some(token) = token {
             if matches!(token.category(), Category::Semicolon) {
                 self.token();
@@ -276,7 +276,7 @@ impl<'a> Lexer<'a> {
         &mut self,
         keyword: Token,
     ) -> Result<(End, Statement), SyntaxError> {
-        match self.peek(0) {
+        match self.peek() {
             Some(token) => match token.category() {
                 Category::LeftBrace => {
                     self.token();

--- a/rust/nasl-syntax/src/lexer.rs
+++ b/rust/nasl-syntax/src/lexer.rs
@@ -139,7 +139,7 @@ impl<'a> Lexer<'a> {
                     continue;
                 }
             }
-            // Due to peeking it can end up in and endlessloop
+            // Due to peeking it can end up in an endless loop
             return Err(unexpected_token!(token));
         }
 

--- a/rust/nasl-syntax/src/lexer.rs
+++ b/rust/nasl-syntax/src/lexer.rs
@@ -57,19 +57,9 @@ impl<'a> Lexer<'a> {
         None
     }
 
-    /// Returns next token of tokenizer
-    pub(crate) fn peek(&mut self, n: usize) -> Option<Token> {
-        let mut peeker = self.tokenizer.clone();
-        for _ in 0..n {
-            for token in peeker.by_ref() {
-                if token.category() == Category::Comment {
-                    continue;
-                }
-                break;
-            }
-        }
-
-        for token in peeker {
+    /// Returns peeks token of tokenizer
+    pub(crate) fn peek(&mut self) -> Option<Token> {
+        for token in self.tokenizer.clone(){
             if token.category() == Category::Comment {
                 continue;
             }
@@ -113,7 +103,7 @@ impl<'a> Lexer<'a> {
         }
 
         let mut end_statement = End::Continue;
-        while let Some(token) = self.peek(0){
+        while let Some(token) = self.peek(){
             if abort(token.category()) {
                 self.token();
                 end_statement = End::Done(token.category());

--- a/rust/nasl-syntax/src/lexer.rs
+++ b/rust/nasl-syntax/src/lexer.rs
@@ -144,8 +144,13 @@ impl<'a> Lexer<'a> {
                 if let End::Done(cat) = end {
                     end_statement = End::Done(cat);
                     break;
+                } else {
+                    // jump to the next without handling it as an error
+                    continue;
                 }
             }
+            // Due to peeking it can end up in and endlessloop
+            return Err(unexpected_token!(token));
         }
 
         Ok((end_statement, left))

--- a/rust/nasl-syntax/src/operation.rs
+++ b/rust/nasl-syntax/src/operation.rs
@@ -53,6 +53,7 @@ impl Operation {
             | Category::Less
             | Category::GreaterEqual
             | Category::LessEqual
+            | Category::X
             | Category::StarStar => Some(Operation::Operator(token.category())),
             Category::Equal
             | Category::MinusEqual

--- a/rust/nasl-syntax/src/variable_extension.rs
+++ b/rust/nasl-syntax/src/variable_extension.rs
@@ -25,7 +25,7 @@ impl<'a> CommaGroup for Lexer<'a> {
     ) -> Result<(End, Vec<Statement>), SyntaxError> {
         let mut params = vec![];
         let mut end = End::Continue;
-        while let Some(token) = self.peek(0) {
+        while let Some(token) = self.peek() {
             if token.category() == category {
                 self.token();
                 end = End::Done(category);
@@ -57,7 +57,7 @@ impl<'a> Variables for Lexer<'a> {
         }
         use End::*;
 
-        if let Some(nt) = self.peek(0) {
+        if let Some(nt) = self.peek() {
             match nt.category() {
                 Category::LeftParen => {
                     self.token();

--- a/rust/nasl-syntax/tests/parsing.rs
+++ b/rust/nasl-syntax/tests/parsing.rs
@@ -5,6 +5,16 @@ mod test {
     use nasl_syntax::parse;
 
     #[test]
+    fn change_to_peek() {
+        let code = r###"
+send_packet( udp, pcap_active:FALSE ) x 200;
+        "###;
+        for stmt in parse(code) {
+            stmt.unwrap();
+        }
+    }
+
+    #[test]
     fn stack_overflow() {
         let code = r###"
 req = raw_string(0x00, 0x00, 0x03, 0x14, 0x08, 0x14, 0xff, 0x9f,


### PR DESCRIPTION
 Refactor: instead of using unhandled token peek the token instead.

To make the parsing a little bit easier to handle and a bit faster
compared to storing an unhandled token the lexer uses peek functionality
instead of advancing and storing unhandled token.

Depends on https://github.com/greenbone/openvas-scanner/pull/1236 https://github.com/greenbone/openvas-scanner/pull/1237