### PR TITLE
Fix: plugin upload when signature check is enabled.

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -1970,7 +1970,7 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
         {
           g_message ("open_sock_tcp: %s:%d time-out.", ip_str, port);
           log_count++;
-          kb_check_set_int (kb, buffer, log_count);
+          kb_item_set_int_with_main_kb_check (kb, buffer, log_count);
         }
       if ((log_count >= attempts) && (attempts != 0))
         {
@@ -1985,7 +1985,7 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
               g_message ("open_sock_tcp: %s:%d too many timeouts. "
                          "This port will be set to closed.",
                          host_port_ip_str, port);
-              kb_check_set_int (kb, buffer, 0);
+              kb_item_set_int_with_main_kb_check (kb, buffer, 0);
 
               addr6_to_str (args->ip, host_port_ip_str);
               snprintf (
@@ -1994,7 +1994,8 @@ open_sock_tcp (struct script_infos *args, unsigned int port, int timeout)
                 " was set to closed.",
                 host_port_ip_str,
                 plug_current_vhost () ? plug_current_vhost () : " ", port);
-              kb_check_push_str (args->results, "internal/results", buffer);
+              kb_item_push_str_with_main_kb_check (args->results,
+                                                   "internal/results", buffer);
             }
         }
       g_free (ip_str);

--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -385,6 +385,8 @@ msg_type_to_str (msg_t type)
  *        original scan main kb.
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
@@ -458,12 +460,11 @@ get_main_kb (void)
 
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
- *
- * @param main_kb Current main kb.
- * @param name key name to be used in the kb
  *
  * @return 0 on success, -1 on inconsistency.
  */
@@ -507,18 +508,21 @@ check_kb_inconsistency_log (void)
  *        original scanid, if it matches it kb_item_push_str.
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_push_str (kb_t kb, const char *name, const char *value)
+kb_item_push_str_with_main_kb_check (kb_t kb, const char *name,
+                                     const char *value)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_push_str (kb, name, value) : -1;
@@ -529,18 +533,21 @@ kb_check_push_str (kb_t kb, const char *name, const char *value)
  *        original scanid, if it matches it call kb_item_set_str.
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_set_str (kb_t kb, const char *name, const char *value, size_t len)
+kb_item_set_str_with_main_kb_check (kb_t kb, const char *name,
+                                    const char *value, size_t len)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_set_str (kb, name, value, len) : -1;
@@ -551,19 +558,22 @@ kb_check_set_str (kb_t kb, const char *name, const char *value, size_t len)
  *        original scanid, if it matches it call kb_item_add_str_unique.
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_add_str_unique (kb_t kb, const char *name, const char *value,
-                         size_t len, int pos)
+kb_item_add_str_unique_with_main_kb_check (kb_t kb, const char *name,
+                                           const char *value, size_t len,
+                                           int pos)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_add_str_unique (kb, name, value, len, pos) : -1;
@@ -574,18 +584,20 @@ kb_check_add_str_unique (kb_t kb, const char *name, const char *value,
  *        original scanid, if it matches it call kb_item_set_int.
  * @description Compares the scan id in get_scan_id, set at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_set_int (kb_t kb, const char *name, int value)
+kb_item_set_int_with_main_kb_check (kb_t kb, const char *name, int value)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_set_int (kb, name, value) : -1;
@@ -596,18 +608,20 @@ kb_check_set_int (kb_t kb, const char *name, int value)
  *        original scanid, if it matches it call kb_item_add_int.
  * @description Compares the scan id in get_scan_id, add at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_add_int (kb_t kb, const char *name, int value)
+kb_item_add_int_with_main_kb_check (kb_t kb, const char *name, int value)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_add_int (kb, name, value) : -1;
@@ -618,18 +632,20 @@ kb_check_add_int (kb_t kb, const char *name, int value)
  *        original scanid, if it matches it call kb_item_add_int_unique.
  * @description Compares the scan id in get_scan_id, add at the beginning
  *              of the scan, with the one found in the main kb.
+ *              Therefore it is mandatory that the global main_kb
+ *              variable to be set.
  *              It helps to detect that the kb was not taken by another
  *              task/scan, and that the current plugins does not stores
  *              results in a wrong kb.
  *
- * @param kb Current main kb.
+ * @param kb Kb where to store the item into.
  * @param name key for the given value.
  * @param value to store under key within kb.
  *
  * @return 0 on success, -1 on inconsistency.
  */
 int
-kb_check_add_int_unique (kb_t kb, const char *name, int value)
+kb_item_add_int_unique_with_main_kb_check (kb_t kb, const char *name, int value)
 {
   int result = check_kb_inconsistency_log ();
   return result == 0 ? kb_item_add_int_unique (kb, name, value) : -1;
@@ -694,7 +710,7 @@ proto_post_wrapped (const char *oid, struct script_infos *desc, int port,
     }
 
   kb = plug_get_results_kb (desc);
-  kb_check_push_str (kb, "internal/results", data);
+  kb_item_push_str_with_main_kb_check (kb, "internal/results", data);
   g_free (data);
   g_free (buffer);
   g_string_free (action_str, TRUE);
@@ -1057,7 +1073,7 @@ plug_replace_key_len (struct script_infos *args, char *name, int type,
     return;
 
   if (type == ARG_STRING)
-    kb_check_set_str (kb, name, value, len);
+    kb_item_set_str (kb, name, value, len);
   else if (type == ARG_INT)
     kb_item_set_int (kb, name, GPOINTER_TO_SIZE (value));
   if (global_nasl_debug == 1)

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -153,22 +153,23 @@ kb_t
 get_main_kb (void);
 
 int
-kb_check_push_str (kb_t, const char *, const char *);
+kb_item_push_str_with_main_kb_check (kb_t, const char *, const char *);
 
 int
-kb_check_set_str (kb_t, const char *, const char *, size_t);
+kb_item_set_str_with_main_kb_check (kb_t, const char *, const char *, size_t);
 
 int
-kb_check_add_str_unique (kb_t, const char *, const char *, size_t, int);
+kb_item_add_str_unique_with_main_kb_check (kb_t, const char *, const char *,
+                                           size_t, int);
 
 int
-kb_check_set_int (kb_t, const char *, int);
+kb_item_set_int_with_main_kb_check (kb_t, const char *, int);
 
 int
-kb_check_add_int (kb_t, const char *, int);
+kb_item_add_int_with_main_kb_check (kb_t, const char *, int);
 
 int
-kb_check_add_int_unique (kb_t, const char *, int);
+kb_item_add_int_unique_with_main_kb_check (kb_t, const char *, int);
 
 void
 plug_set_key (struct script_infos *, char *, int, const void *);

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -387,7 +387,7 @@ main (int argc, char **argv)
                                *kb_values_aux);
                       exit (1);
                     }
-                  kb_check_add_str_unique (kb, splits[0], splits[1], 0, pos);
+                  kb_item_add_str_unique (kb, splits[0], splits[1], 0, pos);
                   kb_values_aux++;
                   g_strfreev (splits);
                 }

--- a/nasl/nasl_grammar.y
+++ b/nasl/nasl_grammar.y
@@ -690,7 +690,7 @@ load_checksums (kb_t kb)
       else
         g_snprintf (buffer, sizeof (buffer), "%s:%s/%s", prefix, base,
                     splits[1]);
-      kb_check_set_str (kb, buffer, splits[0], 0);
+      kb_item_set_str (kb, buffer, splits[0], 0);
       g_strfreev (splits);
     }
   fclose (file);
@@ -841,7 +841,7 @@ init_nasl_ctx(naslctxt* pc, const char* name)
       else
         {
           kb_del_items (pc->kb, key_path);
-          kb_check_add_int (pc->kb, key_path, time (NULL));
+          kb_item_add_int (pc->kb, key_path, time (NULL));
         }
 
       g_free (full_name);

--- a/src/attack_tests.c
+++ b/src/attack_tests.c
@@ -96,7 +96,7 @@ Ensure (attack, comm_send_status_sends_correct_text)
   /* Create a dummy kb. */
   kb = &kb_struct;
 
-  /* We can't wrap kb_check_push_str because it is inline, so we have to do
+  /* We can't wrap kb_item_push_str because it is inline, so we have to do
    * a little hacking. */
   kb_ops_struct.kb_push_str = __wrap_redis_push_str;
   kb_ops_struct.kb_lnk_reset = __wrap_redis_lnk_reset;

--- a/src/hosts.c
+++ b/src/hosts.c
@@ -94,7 +94,7 @@ host_set_time (kb_t kb, char *ip, char *type)
             timestr);
   g_free (timestr);
 
-  kb_check_push_str (kb, "internal/results", log_msg);
+  kb_item_push_str_with_main_kb_check (kb, "internal/results", log_msg);
 }
 
 static void

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -266,8 +266,8 @@ overwrite_openvas_prefs_with_prefs_from_client (struct scan_globals *globals)
     }
   kb_del_items (kb, key);
   snprintf (key, sizeof (key), "internal/%s", globals->scan_id);
-  kb_check_set_str (kb, key, "ready", 0);
-  kb_check_set_int (kb, "internal/ovas_pid", getpid ());
+  kb_item_set_str_with_main_kb_check (kb, key, "ready", 0);
+  kb_item_set_int_with_main_kb_check (kb, "internal/ovas_pid", getpid ());
   kb_lnk_reset (kb);
 
   g_debug ("End loading scan preferences.");
@@ -401,11 +401,12 @@ send_message_to_client_and_finish_scan (const char *msg)
   char key[1024];
   kb_t kb;
 
+  // We get the main kb. It is still not set as global at this point.
   snprintf (key, sizeof (key), "internal/%s/scanprefs", get_scan_id ());
   kb = kb_find (prefs_get ("db_address"), key);
-  kb_check_push_str (kb, "internal/results", msg);
+  kb_item_push_str (kb, "internal/results", msg);
   snprintf (key, sizeof (key), "internal/%s", get_scan_id ());
-  kb_check_set_str (kb, key, "finished", 0);
+  kb_item_set_str (kb, key, "finished", 0);
   kb_lnk_reset (kb);
 }
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -154,7 +154,8 @@ update_running_processes (kb_t main_kb, kb_t kb)
                               "ERRMSG|||%s||| |||general/tcp|||%s|||"
                               "NVT timed out after %d seconds.",
                               hostname, oid ? oid : " ", processes[i].timeout);
-                  kb_check_push_str (main_kb, "internal/results", msg);
+                  kb_item_push_str_with_main_kb_check (main_kb,
+                                                       "internal/results", msg);
 
                   /* Check for max VTs timeouts */
                   if (max_nvt_timeouts_reached ())
@@ -168,7 +169,8 @@ update_running_processes (kb_t main_kb, kb_t kb)
                                       "Host has been marked as dead. Too many "
                                       "NVT_TIMEOUTs.",
                                       hostname);
-                          kb_check_push_str (main_kb, "internal/results", msg);
+                          kb_item_push_str_with_main_kb_check (
+                            main_kb, "internal/results", msg);
                         }
                     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,7 +25,7 @@
 
 #include "utils.h"
 
-#include "../misc/plugutils.h"  /* for kb_check_set_int */
+#include "../misc/plugutils.h"  /* for kb_item_set_int_with_main_kb_check */
 #include "../misc/scanneraux.h" /* for struct scan_globals */
 
 #include <errno.h>          /* for errno() */
@@ -274,7 +274,7 @@ check_host_still_alive (kb_t kb, const char *hostname)
       g_message ("%s: Heartbeat check was not successful. The host %s has"
                  " been set as dead.",
                  __func__, hostname);
-      kb_check_set_int (kb, "Host/dead", 1);
+      kb_item_set_int_with_main_kb_check (kb, "Host/dead", 1);
       return 0;
     }
 


### PR DESCRIPTION
**What**:
Don't use the kb_check_* () function when handling nvticache. 
Jira: SC-740

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
kb_check* () requires main_kb, which doesn't exists for nvticache related data handling. This produced the scanner to segfault.
<!-- Why are these changes necessary? -->

**How**:
Run a scan with nasl signature check enabled

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
