### PR TITLE
Fix: Stop scan

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -671,9 +671,10 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip,
 
       if (check_kb_inconsistency (get_main_kb ()) != 0)
         {
-          // As long as we don't have a proper communication channel
-          // to our ancestors we just kill our parent and ourselves
-          // (but let our grandparents live).
+          // We send the stop scan signal to the current parent process
+          // group, which is the main scan process and host processes.
+          // This avoid to attack new hosts and force the running host
+          // process to finish and spread the signal to the plugin processes
           // To prevent duplicate results we don't let ACT_END run.
           killpg (parent, SIGUSR1);
         }

--- a/src/nasl_plugins.c
+++ b/src/nasl_plugins.c
@@ -215,7 +215,9 @@ nasl_thread (struct ipc_context *ipcc, struct script_infos *args)
   kb_lnk_reset (get_main_kb ());
   addr6_to_str (args->ip, ip_str);
   // TODO extend sript_infos here
-  setproctitle ("openvas: testing %s (%s)", ip_str, args->name);
+
+  setproctitle ("openvas: testing %s (%s)", ip_str,
+                g_path_get_basename (args->name));
 
   if (prefs_get_bool ("nasl_no_signature_check"))
     nasl_mode |= NASL_ALWAYS_SIGNED;

--- a/src/processes.c
+++ b/src/processes.c
@@ -135,17 +135,6 @@ procs_terminate_childs (void)
     }
 }
 
-/**
- * @brief Init procs, must be called once per process
- *
- * @param max
- */
-void
-procs_init (int cap)
-{
-  ipcc = ipc_contexts_init (cap);
-}
-
 static void
 init_child_signal_handlers (void)
 {

--- a/src/processes.c
+++ b/src/processes.c
@@ -97,8 +97,9 @@ clean_procs (void)
 
 /**
  * @brief Terminates a given process. If termination does not work, the process
- * will get killed. In case init_procs was called, only direct child processes
- * can be terminated
+ * will get killed.
+ * Terminate process can be called with the (-1 * pid) to send the signal to the
+ * process group.
  *
  * @param pid id of the child process
  * @return int 0 on success, NOCHILD if child does not exist, NOINIT if not
@@ -107,29 +108,12 @@ clean_procs (void)
 int
 terminate_process (pid_t pid)
 {
-  if (ipcc != NULL)
-    {
-      for (int i = 0; i < ipcc->len; i++)
-        {
-          if (ipcc->ctxs[i].pid == pid)
-            {
-              kill (pid, SIGTERM);
-              usleep (10000);
-              if (!ipcc->ctxs[i].closed)
-                kill (pid, SIGKILL);
-              return 0;
-            }
-        }
-      return NOCHILD;
-    }
-  else
-    {
-      kill (pid, SIGTERM);
-      usleep (10000);
-      if (waitpid (pid, NULL, WNOHANG))
-        kill (pid, SIGKILL);
-      return 0;
-    }
+  kill (pid, SIGTERM);
+  usleep (10000);
+  if (waitpid (pid, NULL, WNOHANG))
+    kill (pid, SIGKILL);
+
+  return 0;
 }
 
 /**

--- a/src/processes.h
+++ b/src/processes.h
@@ -38,9 +38,6 @@
 typedef void (*process_func_t) (void *);
 
 void
-procs_init (int cap);
-
-void
 procs_terminate_childs (void);
 
 int


### PR DESCRIPTION
**What**:
Fix stop scan
Jira: SC-744

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was leaving orphan plugin processes which still were running and trying to write in the kb.
<!-- Why are these changes necessary? -->

**How**:
Run a FF scan. Stop the scan and check with htop that the process are killed immediately (some seconds are ok, but not minutes until the script times out). 
Check with `lsof  |grep openvas |wc -l ` that the number of open file descriptors (pipe fd) is keept low during the scan, meaning that the fd are being closed during the normal scan run and process termination .

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
