### PR TITLE
rs assign

### DIFF
--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -1,0 +1,179 @@
+use std::ops::Range;
+
+use nasl_syntax::{AssignOrder, Statement, Token, TokenCategory};
+
+use crate::{
+    error::InterpretError, interpreter::InterpretResult, ContextType, Interpreter, NaslValue,
+};
+use Statement::*;
+
+/// Is a trait to handle function assignments within nasl.
+pub(crate) trait AssignExtension {
+    /// Assigns a right value to a left value and returns either previous or new value based on the order
+    fn assign(
+        &mut self,
+        category: TokenCategory,
+        order: AssignOrder,
+        left: Statement,
+        right: Statement,
+    ) -> InterpretResult;
+}
+
+impl<'a> Interpreter<'a> {
+    fn named_value(&self, key: &str) -> Result<NaslValue, InterpretError> {
+        match self
+            .registrat()
+            .named(key)
+            .unwrap_or(&ContextType::Value(NaslValue::Null))
+        {
+            ContextType::Function(_) => Err(InterpretError {
+                reason: format!("{} is not assignable", key),
+            }),
+            ContextType::Value(val) => Ok(val.clone()),
+        }
+    }
+
+    fn store_return(
+        &mut self,
+        key: &str,
+        right: NaslValue,
+        result: impl Fn(NaslValue, NaslValue) -> NaslValue,
+    ) -> InterpretResult {
+        let left = self.named_value(key)?;
+        let result = result(left, right);
+        let register = self.registrat.last_mut();
+        register.add_named(key, ContextType::Value(result.clone()));
+        Ok(result)
+    }
+
+    fn return_store(
+        &mut self,
+        key: &str,
+        right: NaslValue,
+        result: impl Fn(NaslValue, NaslValue) -> NaslValue,
+    ) -> InterpretResult {
+        let left = self.named_value(key)?;
+        let result = result(left.clone(), right);
+        let register = self.registrat.last_mut();
+        register.add_named(key, ContextType::Value(result));
+        println!("in return_store {:?}", left);
+        Ok(left)
+    }
+}
+
+impl<'a> AssignExtension for Interpreter<'a> {
+    fn assign(
+        &mut self,
+        category: TokenCategory,
+        order: AssignOrder,
+        left: Statement,
+        right: Statement,
+    ) -> InterpretResult {
+        let val = self.resolve(right)?;
+        match left {
+            Variable(token) => {
+                let key: &str = &self.code[Range::from(token)];
+                match category {
+                    TokenCategory::Equal => {
+                        let register = self.registrat.last_mut();
+                        register.add_named(key, ContextType::Value(val.clone()));
+                        Ok(val)
+                    }
+                    TokenCategory::PlusEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) + i32::from(right))
+                    }),
+                    TokenCategory::MinusEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) - i32::from(right))
+                    }),
+                    TokenCategory::SlashEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) / i32::from(right))
+                    }),
+                    TokenCategory::StarEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) * i32::from(right))
+                    }),
+                    TokenCategory::GreaterGreaterEqual => {
+                        self.store_return(key, val, |left, right| {
+                            NaslValue::Number(i32::from(left) >> i32::from(right))
+                        })
+                    }
+                    TokenCategory::LessLessEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) << i32::from(right))
+                    }),
+                    TokenCategory::GreaterGreaterGreaterEqual => {
+                        self.store_return(key, val, |left, right| {
+                            // get rid of minus sign
+                            let left = i32::from(left) as u32;
+                            let right = i32::from(right) as u32;
+                            NaslValue::Number((left << right) as i32)
+                        })
+                    }
+                    TokenCategory::PercentEqual => self.store_return(key, val, |left, right| {
+                        NaslValue::Number(i32::from(left) % i32::from(right))
+                    }),
+                    TokenCategory::PlusPlus => {
+                        let assign = |left, _| NaslValue::Number(i32::from(left) + 1);
+                        match order {
+                            AssignOrder::AssignReturn => {
+                                self.store_return(key, NaslValue::Null, assign)
+                            }
+                            AssignOrder::ReturnAssign => {
+                                self.return_store(key, NaslValue::Null, assign)
+                            }
+                        }
+                    }
+                    _ => Err(InterpretError {
+                        reason: format!("{:?} is not supported", category),
+                    }),
+                }
+            }
+            Array(_, _) => todo!("arrays are not yet implemented"),
+            _ => Err(InterpretError {
+                reason: format!("{:?} is not supported", left),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nasl_syntax::parse;
+    use sink::DefaultSink;
+
+    use crate::{error::InterpretError, Interpreter, NaslValue};
+
+    #[test]
+    fn variables() {
+        let code = r###"
+        a = 12;
+        a += 13;
+        a -= 2;
+        a /= 2;
+        a *= 2;
+        a >>= 2;
+        a <<= 2;
+        a >>>= 2;
+        a %= 2;
+        a++;
+        ++a;
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None, code);
+        let mut parser = parse(code).map(|x| match x {
+            Ok(x) => interpreter.resolve(x),
+            Err(x) => Err(InterpretError {
+                reason: x.to_string(),
+            }),
+        });
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(25))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(23))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(11))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(22))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(5))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(20))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(80))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(2))));
+    }
+}

--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -19,7 +19,23 @@ pub(crate) trait AssignExtension {
     ) -> InterpretResult;
 }
 
+#[inline(always)]
+fn prepare_array(idx: &NaslValue, left: NaslValue) -> (usize, Vec<NaslValue>) {
+    let idx = i32::from(idx) as usize;
+    let mut arr: Vec<NaslValue> = match left {
+        NaslValue::Array(x) => x,
+        _ => {
+            vec![left.clone()]
+        }
+    };
+
+    for _ in arr.len()..idx + 1 {
+        arr.push(NaslValue::Null)
+    }
+    (idx, arr)
+}
 impl<'a> Interpreter<'a> {
+    #[inline(always)]
     fn named_value(&self, key: &str) -> Result<NaslValue, InterpretError> {
         match self
             .registrat()
@@ -33,31 +49,66 @@ impl<'a> Interpreter<'a> {
         }
     }
 
+    #[inline(always)]
     fn store_return(
         &mut self,
         key: &str,
-        right: NaslValue,
-        result: impl Fn(NaslValue, NaslValue) -> NaslValue,
+        lookup: Option<NaslValue>,
+        right: &NaslValue,
+        result: impl Fn(&NaslValue, &NaslValue) -> NaslValue,
     ) -> InterpretResult {
         let left = self.named_value(key)?;
-        let result = result(left, right);
-        let register = self.registrat.last_mut();
-        register.add_named(key, ContextType::Value(result.clone()));
+        let result = match lookup {
+            None => {
+                let result = result(&left, right);
+                let register = self.registrat.last_mut();
+                register.add_named(key, ContextType::Value(result.clone()));
+                result
+            }
+            Some(idx) => {
+                let (idx, mut arr) = prepare_array(&idx, left);
+                let result = result(&arr[idx], right);
+                arr[idx] = result.clone();
+                let register = self.registrat.last_mut();
+                register.add_named(key, ContextType::Value(NaslValue::Array(arr)));
+                result
+            }
+        };
         Ok(result)
     }
 
-    fn return_store(
+    #[inline(always)]
+    fn dynamic_return(
         &mut self,
+        order: &AssignOrder,
         key: &str,
-        right: NaslValue,
-        result: impl Fn(NaslValue, NaslValue) -> NaslValue,
+        lookup: Option<NaslValue>,
+        result: impl Fn(&NaslValue, &NaslValue) -> NaslValue,
     ) -> InterpretResult {
-        let left = self.named_value(key)?;
-        let result = result(left.clone(), right);
-        let register = self.registrat.last_mut();
-        register.add_named(key, ContextType::Value(result));
-        println!("in return_store {:?}", left);
-        Ok(left)
+        match order {
+            AssignOrder::AssignReturn => self.store_return(key, lookup, &NaslValue::Null, result),
+            AssignOrder::ReturnAssign => {
+                let left = self.named_value(key)?;
+                let result = match lookup {
+                    None => {
+                        let result = result(&left, &NaslValue::Null);
+                        let register = self.registrat.last_mut();
+                        register.add_named(key, ContextType::Value(result));
+                        left
+                    }
+                    Some(idx) => {
+                        let (idx, mut arr) = prepare_array(&idx, left);
+                        let orig = arr[idx].clone();
+                        let result = result(&orig, &NaslValue::Null);
+                        arr[idx] = result;
+                        let register = self.registrat.last_mut();
+                        register.add_named(key, ContextType::Value(NaslValue::Array(arr)));
+                        orig
+                    }
+                };
+                Ok(result)
+            }
+        }
     }
 }
 
@@ -69,66 +120,87 @@ impl<'a> AssignExtension for Interpreter<'a> {
         left: Statement,
         right: Statement,
     ) -> InterpretResult {
-        let val = self.resolve(right)?;
-        match left {
-            Variable(token) => {
-                let key: &str = &self.code[Range::from(token)];
-                match category {
-                    TokenCategory::Equal => {
-                        let register = self.registrat.last_mut();
-                        register.add_named(key, ContextType::Value(val.clone()));
-                        Ok(val)
-                    }
-                    TokenCategory::PlusEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) + i32::from(right))
-                    }),
-                    TokenCategory::MinusEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) - i32::from(right))
-                    }),
-                    TokenCategory::SlashEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) / i32::from(right))
-                    }),
-                    TokenCategory::StarEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) * i32::from(right))
-                    }),
-                    TokenCategory::GreaterGreaterEqual => {
-                        self.store_return(key, val, |left, right| {
-                            NaslValue::Number(i32::from(left) >> i32::from(right))
-                        })
-                    }
-                    TokenCategory::LessLessEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) << i32::from(right))
-                    }),
-                    TokenCategory::GreaterGreaterGreaterEqual => {
-                        self.store_return(key, val, |left, right| {
-                            // get rid of minus sign
-                            let left = i32::from(left) as u32;
-                            let right = i32::from(right) as u32;
-                            NaslValue::Number((left << right) as i32)
-                        })
-                    }
-                    TokenCategory::PercentEqual => self.store_return(key, val, |left, right| {
-                        NaslValue::Number(i32::from(left) % i32::from(right))
-                    }),
-                    TokenCategory::PlusPlus => {
-                        let assign = |left, _| NaslValue::Number(i32::from(left) + 1);
-                        match order {
-                            AssignOrder::AssignReturn => {
-                                self.store_return(key, NaslValue::Null, assign)
-                            }
-                            AssignOrder::ReturnAssign => {
-                                self.return_store(key, NaslValue::Null, assign)
-                            }
-                        }
-                    }
-                    _ => Err(InterpretError {
-                        reason: format!("{:?} is not supported", category),
-                    }),
+        let (key, lookup) = {
+            match left {
+                Variable(token) | Array(token, None) => (&self.code[Range::from(token)], None),
+                Array(token, Some(stmt)) => {
+                    (&self.code[Range::from(token)], Some(self.resolve(*stmt)?))
+                }
+                _ => {
+                    return Err(InterpretError {
+                        reason: format!("{:?} is not supported", left),
+                    })
                 }
             }
-            Array(_, _) => todo!("arrays are not yet implemented"),
+        };
+        let val = self.resolve(right)?;
+        match category {
+            TokenCategory::Equal => match lookup {
+                Some(idx) => {
+                    let idx = i32::from(&idx) as usize;
+                    let mut arr: Vec<NaslValue> = match self.registrat().named(key) {
+                        Some(ContextType::Value(NaslValue::Array(x))) => x.clone(),
+                        Some(ContextType::Value(x)) => {
+                            vec![x.clone()]
+                        }
+                        _ => {
+                            vec![]
+                        }
+                    };
+
+                    for _ in arr.len()..idx + 1 {
+                        arr.push(NaslValue::Null)
+                    }
+                    arr[idx] = val.clone();
+                    let register = self.registrat.last_mut();
+                    register.add_named(key, ContextType::Value(NaslValue::Array(arr.clone())));
+                    Ok(val)
+                }
+                None => {
+                    let register = self.registrat.last_mut();
+                    register.add_named(key, ContextType::Value(val.clone()));
+                    Ok(val)
+                }
+            },
+            TokenCategory::PlusEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) + i32::from(right))
+            }),
+            TokenCategory::MinusEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) - i32::from(right))
+            }),
+            TokenCategory::SlashEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) / i32::from(right))
+            }),
+            TokenCategory::StarEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) * i32::from(right))
+            }),
+            TokenCategory::GreaterGreaterEqual => {
+                self.store_return(key, lookup, &val, |left, right| {
+                    NaslValue::Number(i32::from(left) >> i32::from(right))
+                })
+            }
+            TokenCategory::LessLessEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) << i32::from(right))
+            }),
+            TokenCategory::GreaterGreaterGreaterEqual => {
+                self.store_return(key, lookup, &val, |left, right| {
+                    // get rid of minus sign
+                    let left = i32::from(left) as u32;
+                    let right = i32::from(right) as u32;
+                    NaslValue::Number((left << right) as i32)
+                })
+            }
+            TokenCategory::PercentEqual => self.store_return(key, lookup, &val, |left, right| {
+                NaslValue::Number(i32::from(left) % i32::from(right))
+            }),
+            TokenCategory::PlusPlus => self.dynamic_return(&order, key, lookup, |left, _| {
+                NaslValue::Number(i32::from(left) + 1)
+            }),
+            TokenCategory::MinusMinus => self.dynamic_return(&order, key, lookup, |left, _| {
+                NaslValue::Number(i32::from(left) - 1)
+            }),
             _ => Err(InterpretError {
-                reason: format!("{:?} is not supported", left),
+                reason: format!("{:?} is not supported", category),
             }),
         }
     }
@@ -155,6 +227,45 @@ mod tests {
         a %= 2;
         a++;
         ++a;
+        a--;
+        --a;
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None, code);
+        let mut parser = parse(code).map(|x| match x {
+            Ok(x) => interpreter.resolve(x),
+            Err(x) => Err(InterpretError {
+                reason: x.to_string(),
+            }),
+        });
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(25))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(23))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(11))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(22))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(5))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(20))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(80))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(2))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(2))));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Number(0))));
+    }
+    #[test]
+    fn arrays() {
+        let code = r###"
+        a[0] = 12;
+        a[0] += 13;
+        a[0] -= 2;
+        a[0] /= 2;
+        a[0] *= 2;
+        a[0] >>= 2;
+        a[0] <<= 2;
+        a[0] >>>= 2;
+        a[0] %= 2;
+        a[0]++;
+        ++a[0];
         "###;
         let storage = DefaultSink::new(false);
         let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None, code);

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -1,0 +1,66 @@
+use nasl_syntax::{
+    Statement, Statement::*, Token,
+};
+use std::ops::Range;
+
+
+use crate::{interpreter::InterpretResult, Interpreter, context::CtxType, lookup, ContextType, error::InterpretError};
+
+/// Is a trait to handle function calls within nasl.
+pub(crate) trait CallExtension {
+    /// Is the actual handling of postfix. The caller must ensure that needs_postfix is called previously.
+    fn call(&mut self, name: Token, arguments: Box<Statement>) -> InterpretResult;
+}
+
+impl<'a> CallExtension for Interpreter<'a> {
+    #[inline(always)]
+    fn call(&mut self, name: Token, arguments: Box<Statement>) -> InterpretResult {
+        let name = &self.code[Range::from(name)];
+        // get the context
+        let mut named = vec![];
+        let mut position = vec![];
+        match *arguments{
+            Parameter(params) => {
+                for p in params {
+                    match p {
+                        NamedParameter(token, val) => {
+                            let val = self.resolve(*val)?;
+                            let name = self.code[Range::from(token)].to_owned();
+                            named.push((name, ContextType::Value(val)))
+                        }
+                        val => {
+                            let val = self.resolve(val)?;
+                            position.push(ContextType::Value(val));
+                        }
+                    }
+                }
+            }
+            _ => {
+                return Err(InterpretError::new(
+                    "invalid statement type for function parameters".to_string(),
+                ))
+            }
+        };
+
+        self.registrat
+            .create_root_child(CtxType::Function(named, position));
+        // TODO change to use root context to lookup both
+        let result = match lookup(name) {
+            // Built-In Function
+            Some(function) => match function(self.resolve_key(), self.storage, &self.registrat) {
+                Ok(value) => Ok(value),
+                Err(x) => Err(InterpretError::new(format!(
+                    "unable to call function {}: {:?}",
+                    name, x
+                ))),
+            },
+            // Check for user defined function
+            None => todo!(
+                "{} not a built-in function and user function are not yet implemented",
+                name.to_string()
+            ),
+        };
+        self.registrat.drop_last();
+        result
+    }
+}

--- a/rust/nasl-interpreter/src/interpreter.rs
+++ b/rust/nasl-interpreter/src/interpreter.rs
@@ -103,16 +103,17 @@ impl From<NaslValue> for bool {
     }
 }
 
-impl From<NaslValue> for i32 {
-    fn from(value: NaslValue) -> Self {
+
+impl From<&NaslValue> for i32 {
+    fn from(value: &NaslValue) -> Self {
         match value {
             NaslValue::String(_) => 1,
-            NaslValue::Number(x) => x,
+            &NaslValue::Number(x) => x,
             NaslValue::Array(_) => 1,
-            NaslValue::Boolean(x) => x as i32,
-            NaslValue::AttackCategory(x) => x as i32,
+            &NaslValue::Boolean(x) => x as i32,
+            &NaslValue::AttackCategory(x) => x as i32,
             NaslValue::Null => 0,
-            NaslValue::Exit(x) => x,
+            &NaslValue::Exit(x) => x,
         }
     }
 }

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -4,6 +4,7 @@ use error::{FunctionError, InterpretError};
 
 mod built_in_functions;
 mod call;
+mod assign;
 mod context;
 pub mod error;
 mod interpreter;

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -15,6 +15,7 @@ mod tests {
     #[test]
     fn description() {
         let code = r###"
+rc = 23;
 if(description)
 {
   script_oid("0.0.0.0.0.0.0.0.0.1");
@@ -34,12 +35,12 @@ if(description)
   script_require_keys("WMI/Apache/RootPath");
   script_add_preference(name:"Enable Password", type:"password", value:"", id:2);
   script_add_preference(name:"Without ID", type:"password", value:"");
-  exit(0);
+  exit(rc);
 }
         "###;
         let storage = DefaultSink::new(true);
         let results = interpret(&storage, Mode::Description("test.nasl"), code);
-        assert_eq!(results, vec![Ok(NaslValue::Exit(0))]);
+        assert_eq!(results, Ok(NaslValue::Exit(23)));
         assert_eq!(
             &storage.retrieve("test.nasl", sink::Retrieve::NVT(None)).unwrap(),
             &vec![


### PR DESCRIPTION
Add the possibility to handle:
```
a = 12;
a += 13;
a -= 2;
a /= 2;
a *= 2;
a >>= 2;
a <<= 2;
a >>>= 2;
a %= 2;
a++;
++a;
```

Creates an extension for assign statements.