### PR TITLE
Loop extension

### DIFF
--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -1,4 +1,4 @@
-//! Is a crate to use Statements from nasl-syntax and execute them.
+//! Is a crate to use Stataments from nasl-syntax and execute them.
 #![warn(missing_docs)]
 use built_in_functions::description;
 mod error;
@@ -32,4 +32,3 @@ impl From<SinkError> for InterpretError {
         InterpretError::new(format!("An error occurred while using a sink: {}", se))
     }
 }
-

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -32,3 +32,4 @@ impl From<SinkError> for InterpretError {
         InterpretError::new(format!("An error occurred while using a sink: {}", se))
     }
 }
+

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -1,4 +1,4 @@
-//! Is a crate to use Stataments from nasl-syntax and execute them.
+//! Is a crate to use Statements from nasl-syntax and execute them.
 #![warn(missing_docs)]
 use built_in_functions::description;
 mod error;
@@ -13,6 +13,7 @@ mod include;
 mod interpreter;
 mod loader;
 mod operator;
+mod loop_extension;
 
 pub use context::ContextType;
 pub use context::Register;

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -1,0 +1,309 @@
+use nasl_syntax::{IdentifierType, Statement, Token, TokenCategory};
+
+use crate::{interpreter::InterpretResult, InterpretError, Interpreter, NaslValue, ContextType};
+
+/// Extension to handle the interpretation of NASL loops
+pub(crate) trait LoopExtension {
+    /// Interpreting a NASL for loop. A NASL for loop is built up with the
+    /// following:
+    ///
+    /// for (assignment; condition; update) {body}
+    ///
+    /// It first resolves the assignment and runs until the condition resolves
+    /// into a `FALSE` NaslValue. The update statement is resolved after each
+    /// iteration.
+    fn for_loop(
+        &mut self,
+        assignment: &Statement,
+        condition: &Statement,
+        update: &Statement,
+        body: &Statement,
+    ) -> InterpretResult;
+
+    /// Interpreting a NASL foreach loop. A NASL foreach loop is built up with
+    /// the following:
+    ///
+    /// foreach variable(iterable) {body}
+    ///
+    /// The iterable is first transformed into an Array, then we iterate through
+    /// it and resolve the body for every value in the array.
+    fn while_loop(&mut self, condition: &Statement, body: &Statement) -> InterpretResult;
+
+    /// Interpreting a NASL while loop. A NASL while loop is built up with the
+    /// following:
+    ///
+    /// while (condition) {body}
+    ///
+    /// The condition is first checked, then the body resolved, as long as the
+    /// condition resolves into a `TRUE` NaslValue.
+    fn repeat_loop(&mut self, body: &Statement, condition: &Statement) -> InterpretResult;
+
+    /// Interpreting a NASL repeat until loop. A NASL repeat until loop is built
+    /// up with the following:
+    ///
+    /// repeat {body} until (condition);
+    ///
+    /// It first resolves the body at least once. It keeps resolving the body,
+    /// until the condition statement resolves into a `TRUE` NaslValue.
+    fn for_each_loop(
+        &mut self,
+        variable: &Token,
+        iterable: &Statement,
+        body: &Statement,
+    ) -> InterpretResult;
+}
+
+/// Implementation for the Loop extension. Note that for all loops, we do not
+/// change the context, as the current NASL also does not change it too.
+impl<'a> LoopExtension for Interpreter<'a> {
+    fn for_loop(
+        &mut self,
+        assignment: &Statement,
+        condition: &Statement,
+        update: &Statement,
+        body: &Statement,
+    ) -> InterpretResult {
+        // Resolve assignment
+        self.resolve(assignment)?;
+
+        loop {
+            // Check condition statement
+            if !bool::from(self.resolve(condition)?) {
+                break;
+            }
+
+            // Execute loop body
+            let ret = self.resolve(body)?;
+            // Catch special values
+            match ret {
+                NaslValue::Break => break,
+                NaslValue::Exit(code) => return Ok(NaslValue::Exit(code)),
+                NaslValue::Return(val) => return Ok(NaslValue::Return(val)),
+                _ => (),
+            };
+
+            // Execute update Statement
+            self.resolve(update)?;
+        }
+
+       Ok(NaslValue::Null)
+    }
+
+    fn for_each_loop(
+        &mut self,
+        variable: &Token,
+        iterable: &Statement,
+        body: &Statement,
+    ) -> InterpretResult {
+        // Get name of the iteration variable
+        let iter_name = match variable.category() {
+            TokenCategory::Identifier(IdentifierType::Undefined(name)) => name,
+            _ => {
+                return Err(InterpretError::new(format!(
+                    "Unexpected variable category: {}",
+                    variable.category()
+                )))
+            }
+        };
+        // Iterate through the iterable Statement
+        for val in Vec::<NaslValue>::from(self.resolve(iterable)?) {
+            // Change the value of the iteration variable after each iteration
+            self.registrat
+                .add_local(iter_name, ContextType::Value(val));
+
+            // Execute loop body
+            let ret = self.resolve(body)?;
+            // Catch special values
+            match ret {
+                NaslValue::Break => break,
+                NaslValue::Exit(code) => return Ok(NaslValue::Exit(code)),
+                NaslValue::Return(val) => return Ok(NaslValue::Return(val)),
+                _ => (),
+            };
+        }
+
+        Ok(NaslValue::Null)
+    }
+
+    fn while_loop(&mut self, condition: &Statement, body: &Statement) -> InterpretResult {
+        while bool::from(self.resolve(condition)?) {
+            // Execute loop body
+            let ret = self.resolve(body)?;
+            // Catch special values
+            match ret {
+                NaslValue::Break => break,
+                NaslValue::Exit(code) => return Ok(NaslValue::Exit(code)),
+                NaslValue::Return(val) => return Ok(NaslValue::Return(val)),
+                _ => (),
+            };
+        }
+
+        Ok(NaslValue::Null)
+    }
+
+    fn repeat_loop(&mut self, body: &Statement, condition: &Statement) -> InterpretResult {
+        loop {
+            // Execute loop body
+            let ret = self.resolve(body)?;
+            // Catch special values
+            match ret {
+                NaslValue::Break => break,
+                NaslValue::Exit(code) => return Ok(NaslValue::Exit(code)),
+                NaslValue::Return(val) => return Ok(NaslValue::Return(val)),
+                _ => (),
+            };
+
+            // Check condition statement
+            if bool::from(self.resolve(condition)?) {
+                break;
+            }
+        }
+
+        Ok(NaslValue::Null)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nasl_syntax::parse;
+    use sink::DefaultSink;
+
+    use crate::{Interpreter, NaslValue, Register, NoOpLoader};
+    macro_rules! no_op_interpreter {
+        ($code:expr) => {
+            {
+                let storage = DefaultSink::new(false);
+                let mut register = Register::default();
+                let loader = NoOpLoader::default();
+                let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+                parse($code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")))
+            }
+        };
+    }
+
+
+    #[test]
+    fn for_loop_test() {
+        let code = r###"
+        a = 0;
+        for ( i = 1; i < 5; i++) {
+            a += i;
+        }
+        a;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(10))));
+    }
+
+    #[test]
+    fn for_each_loop_test() {
+        let code = r###"
+        arr[0] = 3;
+        arr[1] = 5;
+        a = 0;
+        foreach i (arr) {
+            a += i;
+        }
+        a;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(3))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(5))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(8))));
+    }
+
+    #[test]
+    fn while_loop_test() {
+        let code = r###"
+        i = 4;
+        a = 0;
+        i > 0;
+        while(i > 0) {
+            a += i;
+            i--;
+        }
+        a;
+        i;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(4))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Boolean(true))));
+
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(10))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+    }
+
+    #[test]
+    fn repeat_loop_test() {
+        let code = r###"
+        i = 10;
+        a = 0;
+        repeat {
+            a += i;
+            i--;
+        } until (i > 0);
+        a;
+        i;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(10))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(10))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(9))));
+    }
+
+    #[test]
+    fn control_flow() {
+        let code = r###"
+        a = 0;
+        i = 5;
+        while(i > 0) {
+            if(i == 4) {
+                i--;
+                continue;
+            }
+            if (i == 1) {
+                break;
+            }
+            a += i;
+            i--;
+        }
+        a;
+        i;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(0))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(5))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(10))));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(1))));
+    }
+}
+

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -169,6 +169,30 @@ impl<'a> Lexer<'a> {
             Err(unexpected_end!("exit"))
         }
     }
+    fn parse_continue(&mut self) -> Result<(End, Statement), SyntaxError> {
+        let token = self.peek();
+        if let Some(token) = token {
+            if matches!(token.category(), Category::Semicolon) {
+                self.token();
+                return Ok((End::Done(Category::Semicolon), Statement::Continue));
+            } else {
+                return Err(unexpected_token!(token));
+            }
+        }
+        Err(unexpected_end!("exit"))
+    }
+    fn parse_break(&mut self) -> Result<(End, Statement), SyntaxError> {
+        let token = self.peek();
+        if let Some(token) = token {
+            if matches!(token.category(), Category::Semicolon) {
+                self.token();
+                return Ok((End::Done(Category::Semicolon), Statement::Break));
+            } else {
+                return Err(unexpected_token!(token));
+            }
+        }
+        Err(unexpected_end!("exit"))
+    }
     fn parse_for(&mut self) -> Result<(End, Statement), SyntaxError> {
         self.jump_to_left_parenthesis()?;
         let (end, assignment) = self.statement(0, &|c| c == &Category::Semicolon)?;
@@ -326,6 +350,8 @@ impl<'a> Keywords for Lexer<'a> {
                 Ok((End::Continue, Statement::AttackCategory(category)))
             }
             IdentifierType::Undefined(_) => Err(unexpected_token!(token)),
+            IdentifierType::Continue => self.parse_continue(),
+            IdentifierType::Break => self.parse_break(),
         }
     }
 }

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -21,7 +21,8 @@ pub use token::StringCategory;
 pub use token::Base as NumberBase;
 pub use token::IdentifierType;
 pub use sink::nvt::ACT as ACT;
-
+pub use lexer::Lexer as Lexer;
+pub use token::Tokenizer;
 
 /// Parses given code and returns found Statements and Errors
 ///
@@ -34,8 +35,6 @@ pub use sink::nvt::ACT as ACT;
 ///     nasl_syntax::parse("a = 23;b = 1;").collect::<Vec<Result<Statement, SyntaxError>>>();
 /// ````
 pub fn parse(code: &str) -> impl Iterator<Item = Result<Statement, SyntaxError>> + '_ {
-    use lexer::Lexer;
-    use token::Tokenizer;
     let tokenizer = Tokenizer::new(code);
     Lexer::new(tokenizer)
 }

--- a/rust/nasl-syntax/src/statement.rs
+++ b/rust/nasl-syntax/src/statement.rs
@@ -39,6 +39,10 @@ pub enum Statement {
     Exit(Box<Statement>),
     /// Special Return statement
     Return(Box<Statement>),
+    /// Special Break statement
+    Break,
+    /// Special Continue statement
+    Continue,
     /// Special include call
     Include(Box<Statement>),
     /// Declares a new variable in either global or local scope
@@ -148,6 +152,8 @@ impl Statement {
             Statement::NoOp(token) => token.as_ref(),
             Statement::EoF => None,
             Statement::AttackCategory(_) => None,
+            Statement::Continue => None,
+            Statement::Break => None,
         }
     }
 }
@@ -177,6 +183,8 @@ impl fmt::Display for Statement {
             Statement::FunctionDeclaration(_, _, _) => write!(f, "FunctionDeclaration"),
             Statement::NoOp(_) => write!(f, "NoOp"),
             Statement::EoF => write!(f, "EoF"),
+            Statement::Break => write!(f, "Break"),
+            Statement::Continue => write!(f, "Continue"),
         }
     }
 }

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -145,6 +145,10 @@ pub enum IdentifierType {
     Null,
     /// return
     Return,
+    /// continue
+    Continue,
+    /// break
+    Break,
     /// include
     Include,
     /// Scanning phases; can be set by category in the description block
@@ -183,7 +187,9 @@ make_keyword_matcher! {
     ACT_KILL_HOST: IdentifierType::ACT(ACT::KillHost),
     ACT_MIXED_ATTACK: IdentifierType::ACT(ACT::MixedAttack),
     ACT_SCANNER: IdentifierType::ACT(ACT::Scanner),
-    ACT_SETTINGS: IdentifierType::ACT(ACT::Settings)
+    ACT_SETTINGS: IdentifierType::ACT(ACT::Settings),
+    continue: IdentifierType::Continue,
+    break: IdentifierType::Break
 }
 
 /// Is used to identify a Token
@@ -582,7 +588,7 @@ impl<'a> Tokenizer<'a> {
 
     // checks if a number is binary, octal, base10 or hex
     #[inline(always)]
-    pub fn tokenize_number(&mut self, mut start: usize, current: char) -> Category {
+    fn tokenize_number(&mut self, mut start: usize, current: char) -> Category {
         use Base::*;
         let may_base = {
             if current == '0' {
@@ -945,6 +951,8 @@ mod tests {
         verify_tokens!("return", vec![(Identifier(Return), 1, 1)]);
         verify_tokens!("include", vec![(Identifier(Include), 1, 1)]);
         verify_tokens!("exit", vec![(Identifier(Exit), 1, 1)]);
+        verify_tokens!("break", vec![(Identifier(Break), 1, 1)]);
+        verify_tokens!("continue", vec![(Identifier(Continue), 1, 1)]);
     }
 
     #[test]


### PR DESCRIPTION
**What**:

Add support for loops in the NASL Rust implementation
    
This PR introduces a new module which adds support to interprete loop structures in the rust implementation of NASL.
In order to support the loop control flow keywords `continue` and `break` the nasl-syntax was adjusted to parse them.
To be able to actually work with these controll flow keywords, new `NaslValue`s are introduced.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
