### PR TITLE
rs includes

### DIFF
--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -253,7 +253,7 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{error::InterpretError, Interpreter, NaslValue};
+    use crate::{error::InterpretError, Interpreter, NaslValue, context::Register, loader::NoOpLoader};
 
     #[test]
     fn variables() {
@@ -273,7 +273,9 @@ mod tests {
         --a;
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {
@@ -310,7 +312,9 @@ mod tests {
         ++a[0];
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {
@@ -336,7 +340,9 @@ mod tests {
         a;
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {
@@ -356,7 +362,9 @@ mod tests {
         a;
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {
@@ -377,7 +385,9 @@ mod tests {
         a['hi'];
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {
@@ -394,7 +404,9 @@ mod tests {
         a[] = 12;
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -25,24 +25,24 @@ pub struct Register {
 impl Register {
     /// Creates an empty register
     pub fn new() -> Self {
-        Self { blocks: vec![] }
+        Self {
+            blocks: vec![NaslContext::default()],
+        }
+    }
+
+    pub fn root_initial(initial: Vec<(String, ContextType)>) -> Self {
+        let root = NaslContext{
+            defined: initial.into_iter().collect(),
+            ..Default::default()
+        };
+        Self{
+            blocks: vec![root],
+        }
     }
 
     /// Returns the next index
     pub fn index(&self) -> usize {
         self.blocks.len()
-    }
-
-    /// Creates a root context
-    pub fn create_root(&mut self, initial: Vec<(String, ContextType)>) -> &NaslContext {
-        let initial = initial.into_iter().collect();
-        let result = NaslContext {
-            parent: None,
-            id: 0,
-            defined: initial,
-        };
-        self.blocks.push(result);
-        return self.blocks.last_mut().unwrap();
     }
 
     /// Creates a child context
@@ -124,6 +124,16 @@ pub struct NaslContext {
     id: usize,
     /// The defined values/ functions.
     defined: Named,
+}
+
+impl Default for NaslContext {
+    fn default() -> Self {
+        Self {
+            parent: Default::default(),
+            id: Default::default(),
+            defined: Default::default(),
+        }
+    }
 }
 
 impl NaslContext {

--- a/rust/nasl-interpreter/src/declare.rs
+++ b/rust/nasl-interpreter/src/declare.rs
@@ -47,7 +47,9 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{error::InterpretError, Interpreter, NaslValue};
+    use crate::{
+        context::Register, error::InterpretError, loader::NoOpLoader, Interpreter, NaslValue,
+    };
 
     #[test]
     fn declare_function() {
@@ -58,7 +60,9 @@ mod tests {
         test(a: 1, b: 2);
         "###;
         let storage = DefaultSink::new(false);
-        let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser = parse(code).map(|x| match x {
             Ok(x) => interpreter.resolve(x),
             Err(x) => Err(InterpretError {

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -1,0 +1,89 @@
+use nasl_syntax::{parse, Statement};
+use sink::DefaultSink;
+
+use crate::{
+    error::InterpretError, interpreter::InterpretResult, Interpreter, NaslValue,
+};
+
+/// Is a trait to declare include functionality
+pub(crate) trait IncludeExtension {
+    fn include(&mut self, name: Statement) -> InterpretResult;
+}
+
+impl<'a> IncludeExtension for Interpreter<'a> {
+    fn include(&mut self, name: Statement) -> InterpretResult {
+        match self.resolve(name)? {
+            NaslValue::String(key) => {
+                let code = self.loader.load(&key)?;
+                let storage = DefaultSink::new(false);
+                let mut inter = Interpreter::new(self.key, &storage, self.loader, self.registrat);
+                let result = parse(&code)
+                    .map(|parsed| match parsed {
+                        Ok(stmt) => inter.resolve(stmt),
+                        Err(err) => Err(InterpretError::from(err)),
+                    })
+                    .last()
+                    .ok_or_else(|| InterpretError::new("should not happen".to_owned()))?;
+                result.map(|_| NaslValue::Null)
+            }
+            a => Err(InterpretError::new(format!("invalid: {:?}", a))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use nasl_syntax::parse;
+    use sink::DefaultSink;
+
+    use crate::{
+        context::Register, Interpreter, LoadError, Loader, NaslValue,
+    };
+
+    struct FakeInclude<'a> {
+        plugins: &'a HashMap<String, String>,
+    }
+
+    impl<'a> Loader for FakeInclude<'a> {
+        fn load(&self, key: &str) -> Result<String, LoadError> {
+            self.plugins
+                .get(key)
+                .cloned()
+                .ok_or_else(|| LoadError::NotFound(String::default()))
+        }
+    }
+
+    #[test]
+    fn function_variable() {
+        let example = r#"
+        a = 12;
+        function test() {
+            b['hello'] = 'world';
+            return b;
+        }
+        "#
+        .to_string();
+        let plugins = HashMap::from([("example.inc".to_string(), example)]);
+        let loader = &FakeInclude { plugins: &plugins };
+        let code = r###"
+        include("example.inc");
+        a;
+        test();
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut register = Register::default();
+        let mut interpreter = Interpreter::new("1", &storage, loader, &mut register);
+        let mut interpreter = parse(code).map(|x| interpreter.resolve(x.expect("expected")));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(12))));
+        assert_eq!(
+            interpreter.next(),
+            Some(Ok(NaslValue::Dict(HashMap::from([(
+                "hello".to_owned(),
+                NaslValue::String("world".to_owned())
+            )]))))
+        );
+    }
+}

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -1,9 +1,7 @@
 use nasl_syntax::{parse, Statement};
 use sink::DefaultSink;
 
-use crate::{
-    error::InterpretError, interpreter::InterpretResult, Interpreter, NaslValue,
-};
+use crate::{error::InterpretError, interpreter::InterpretResult, Interpreter, NaslValue};
 
 /// Is a trait to declare include functionality
 pub(crate) trait IncludeExtension {
@@ -22,9 +20,11 @@ impl<'a> IncludeExtension for Interpreter<'a> {
                         Ok(stmt) => inter.resolve(stmt),
                         Err(err) => Err(InterpretError::from(err)),
                     })
-                    .last()
-                    .ok_or_else(|| InterpretError::new("should not happen".to_owned()))?;
-                result.map(|_| NaslValue::Null)
+                    .find(|e| e.is_err());
+                match result {
+                    Some(e) => e,
+                    None => Ok(NaslValue::Null),
+                }
             }
             a => Err(InterpretError::new(format!("invalid: {:?}", a))),
         }
@@ -38,9 +38,7 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{
-        context::Register, Interpreter, LoadError, Loader, NaslValue,
-    };
+    use crate::{context::Register, Interpreter, LoadError, Loader, NaslValue};
 
     struct FakeInclude<'a> {
         plugins: &'a HashMap<String, String>,

--- a/rust/nasl-interpreter/src/loader.rs
+++ b/rust/nasl-interpreter/src/loader.rs
@@ -1,0 +1,78 @@
+//! This crate is used to load NASL code based on a name.
+
+use std::{path::Path, fs};
+
+use crate::error::InterpretError;
+
+/// Defines abstract Loader error cases
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LoadError {
+    /// Informs the caller to retry the call
+    Retry(String),
+    /// The given key was not found
+    NotFound(String),
+    /// Not allowed to read data of key
+    PermissionDenied(String),
+    /// There is a deeper problem with the underlying DataBase
+    Dirty(String),
+}
+
+impl From<LoadError> for InterpretError {
+    fn from(le: LoadError) -> Self {
+        InterpretError { reason: format!("{:?}", le) }
+    }
+}
+
+/// Loader is used to load NASL scripts based on relative paths (e.g. "http_func.inc" )
+pub trait Loader {
+    /// Resolves the given key to nasl code
+    fn load(&self, key: &str) -> Result<String, LoadError>;
+}
+
+#[derive(Default)]
+pub struct NoOpLoader {}
+
+/// Is a no operation loader for test purposes.
+impl Loader for NoOpLoader {
+    fn load(&self, _: &str) -> Result<String, LoadError> {
+        Ok(String::default())
+    }
+}
+
+/// Is a plugin loader based on a root dir.
+///
+/// When load is called with e.g. plugin_feed_info.inc than the FSPluginLoader
+/// expands `plugin_feed_info.inc` with the given root path.
+/// 
+/// So when the root path is `/var/lib/openvas/plugins` than it will be extended to
+/// `/var/lib/openvas/plugins/plugin_feed_info.inc`.
+struct FSPluginLoader<'a> {
+    root: &'a Path,
+}
+
+impl<'a> Loader for FSPluginLoader<'a> {
+    fn load(&self, key: &str) -> Result<String, LoadError> {
+        let path = self.root.join(key);
+        if !path.is_file() {
+            return Err(LoadError::NotFound(format!(
+                "{} does not exist or is not accessable.",
+                path.as_os_str().to_str().unwrap_or_default()
+            )));
+        }
+        // unfortunately NASL is not UTF-8 so we need to map it manually
+        let result= fs::read(path.clone()).map(|bs| bs.iter().map(|&b| b as char).collect());
+        match result {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                let pstr = path.to_str().unwrap_or_default().to_string();
+                match err.kind() {
+                    std::io::ErrorKind::NotFound => Err(LoadError::NotFound(pstr)),
+                    std::io::ErrorKind::PermissionDenied => Err(LoadError::PermissionDenied(pstr)),
+                    std::io::ErrorKind::TimedOut => Err(LoadError::Retry(format!("{} timed out.", pstr))),
+                    std::io::ErrorKind::Interrupted => Err(LoadError::Retry(format!("{} interrupted.", pstr))),
+                    _ => Err(LoadError::Dirty(format!("{}: {:?}", pstr, err))),
+                }
+            }
+        }
+    }
+}

--- a/rust/nasl-interpreter/src/loader.rs
+++ b/rust/nasl-interpreter/src/loader.rs
@@ -55,7 +55,7 @@ impl<'a> Loader for FSPluginLoader<'a> {
         let path = self.root.join(key);
         if !path.is_file() {
             return Err(LoadError::NotFound(format!(
-                "{} does not exist or is not accessable.",
+                "{} does not exist or is not accessible.",
                 path.as_os_str().to_str().unwrap_or_default()
             )));
         }

--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -219,6 +219,7 @@ mod tests {
     use sink::DefaultSink;
 
     use crate::{error::InterpretError, Interpreter, NaslValue};
+    use crate::{NoOpLoader, Register};
 
     macro_rules! create_test {
         ($($name:tt: $code:expr => $result:expr),*) => {
@@ -227,7 +228,9 @@ mod tests {
             #[test]
             fn $name() {
                 let storage = DefaultSink::new(false);
-                let mut interpreter = Interpreter::new(&storage, vec![], Some("1"), None);
+                let mut register = Register::default();
+                let loader = NoOpLoader::default();
+                let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
                 let mut parser = parse($code).map(|x| match x {
                     Ok(x) => interpreter.resolve(x),
                     Err(x) => Err(InterpretError {


### PR DESCRIPTION
 Add includes

Enables includes by using a Loader trait, using a reference of a mutable
register instead of a register ownership within the interpreter.

This trait needs to be implemented in order to load the file content on
an include. For testing purposes there is the NoOpLoader.