### PR TITLE
rs use col line no

### DIFF
--- a/rust/nasl-interpreter/src/interpreter.rs
+++ b/rust/nasl-interpreter/src/interpreter.rs
@@ -113,6 +113,8 @@ impl TryFrom<&Token> for NaslValue {
             }
             TokenCategory::Number(num) => Ok(NaslValue::Number(*num)),
             TokenCategory::Identifier(IdentifierType::Null) => Ok(NaslValue::Null),
+            TokenCategory::Identifier(IdentifierType::True) => Ok(NaslValue::Boolean(true)),
+            TokenCategory::Identifier(IdentifierType::False) => Ok(NaslValue::Boolean(false)),
             _ => Err(InterpretError {
                 reason: format!("invalid primitive {:?}", token.category()),
             }),
@@ -177,6 +179,7 @@ impl<'a> Interpreter<'a> {
                         })?;
                         Ok(result.clone())
                     }
+                    (Some(_), ContextType::Value(NaslValue::Null)) => Ok(NaslValue::Null),
                     (p, x) => Err(InterpretError {
                         reason: format!("Internal error statement: {:?} -> {:?}.", p, x),
                     }),

--- a/rust/nasl-syntax/src/cursor.rs
+++ b/rust/nasl-syntax/src/cursor.rs
@@ -12,6 +12,8 @@ pub struct Cursor<'a> {
     /// is needed to calculate the length when e.g. tokenizing
     initial_len: usize,
     chars: Chars<'a>,
+    line: usize,
+    col: usize,
 }
 
 impl<'a> Cursor<'a> {
@@ -20,6 +22,8 @@ impl<'a> Cursor<'a> {
         Cursor {
             initial_len: input.len(),
             chars: input.chars(),
+            line: 1,
+            col: 1,
         }
     }
 
@@ -34,7 +38,19 @@ impl<'a> Cursor<'a> {
 
     /// Returns the next char or None if at the end
     pub fn advance(&mut self) -> Option<char> {
-        self.chars.next()
+        match self.chars.next() {
+            Some('\n') => {
+                self.line += 1;
+                self.col = 1;
+                Some('\n')
+            }
+            Some(c) => {
+                self.col += 1;
+                Some(c)
+            }
+            None => None
+
+        }
     }
 
     /// Returns true when the Cursor is at the end of the initial input
@@ -52,6 +68,11 @@ impl<'a> Cursor<'a> {
     /// Returns amount of already consumed symbols.
     pub fn len_consumed(&self) -> usize {
         self.initial_len - self.chars.as_str().len()
+    }
+
+    /// Returns the line and the colum in line of the current position
+    pub fn line_colum(&self) -> (usize, usize) {
+        (self.line, self.col)
     }
 }
 

--- a/rust/nasl-syntax/src/grouping_extension.rs
+++ b/rust/nasl-syntax/src/grouping_extension.rs
@@ -110,18 +110,18 @@ mod test {
                     AssignOrder::AssignReturn,
                     Box::new(Variable(Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (31, 32)
+                        position: (3, 17)
                     })),
                     Box::new(Operator(
                         Plus,
                         vec![
                             Variable(Token {
                                 category: Identifier(Undefined("b".to_owned())),
-                                position: (35, 36)
+                                position: (3, 21)
                             }),
                             Primitive(Token {
                                 category: Number(1),
-                                position: (39, 40)
+                                position: (3, 25)
                             })
                         ]
                     ))
@@ -131,21 +131,21 @@ mod test {
                     AssignOrder::AssignReturn,
                     Box::new(Variable(Token {
                         category: Identifier(Undefined("b".to_owned())),
-                        position: (58, 59)
+                        position: (4, 17)
                     },)),
                     Box::new(Operator(
                         Minus,
                         vec![
                             Variable(Token {
                                 category: Identifier(Undefined("a".to_owned())),
-                                position: (62, 63)
+                                position: (4, 21)
                             }),
                             Assign(
                                 MinusMinus,
                                 AssignOrder::AssignReturn,
                                 Box::new(Variable(Token {
                                     category: Identifier(Undefined("c".to_owned())),
-                                    position: (68, 69)
+                                    position: (4, 27)
                                 },)),
                                 Box::new(NoOp(None))
                             )
@@ -157,11 +157,11 @@ mod test {
                     AssignOrder::AssignReturn,
                     Box::new(Variable(Token {
                         category: Identifier(Undefined("d".to_owned())),
-                        position: (108, 109)
+                        position: (6, 20)
                     },)),
                     Box::new(Primitive(Token {
                         category: Number(23),
-                        position: (112, 114)
+                        position: (6, 24)
                     }))
                 )])
             ])

--- a/rust/nasl-syntax/src/infix_extension.rs
+++ b/rust/nasl-syntax/src/infix_extension.rs
@@ -156,8 +156,6 @@ fn first_element_as_named_parameter(
 #[cfg(test)]
 mod test {
 
-    use std::ops::Range;
-
     use super::*;
     
     
@@ -180,7 +178,7 @@ mod test {
             };
         match s {
             Primitive(token) => match token.category() {
-                Number(_) => code[Range::from(&token)].parse().unwrap(),
+                Number(num) => *num,
                 String(_) => todo!(),
                 _ => todo!(),
             },
@@ -276,8 +274,8 @@ mod test {
             Assign(
                 category,
                 AssignOrder::AssignReturn,
-                Box::new(Variable(token(Identifier(Undefined("a".to_owned())), 0, 1))),
-                Box::new(Primitive(token(Number(1), 5 + shift, 6 + shift))),
+                Box::new(Variable(token(Identifier(Undefined("a".to_owned())), 1, 1))),
+                Box::new(Primitive(token(Number(1), 1, 6 + shift))),
             )
         }
         assert_eq!(result("a += 1;"), expected(PlusEqual, 0));
@@ -300,11 +298,11 @@ mod test {
                 vec![
                     Variable(Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (0, 1),
+                        position: (1, 1),
                     }),
                     Primitive(Token {
                         category: String("1".to_owned()),
-                        position: ((6 + shift) as usize, (7 + shift) as usize),
+                        position: (1, (6 + shift) as usize),
                     }),
                 ],
             )
@@ -329,11 +327,11 @@ mod test {
                 vec![
                     Variable(Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (0, 1),
+                        position: (1, 1),
                     }),
                     Primitive(Token {
                         category: Number(1),
-                        position: (5 + shift, 6 + shift),
+                        position: (1, 6 + shift),
                     }),
                 ],
             )
@@ -349,10 +347,10 @@ mod test {
             Assign(
                 Category::Equal,
                 AssignOrder::AssignReturn,
-                Box::new(Variable(token(Identifier(Undefined("a".to_owned())), 0, 1))),
+                Box::new(Variable(token(Identifier(Undefined("a".to_owned())), 1, 1))),
                 Box::new(Primitive(Token {
                     category: Number(1),
-                    position: (4, 5)
+                    position: (1, 5)
                 }))
             )
         );
@@ -364,7 +362,7 @@ mod test {
                 Box::new(Variable(token(Identifier(Undefined("a".to_owned())), 1, 2))),
                 Box::new(Primitive(Token {
                     category: Number(1),
-                    position: (5, 6)
+                    position: (1, 6)
                 }))
             )
         );
@@ -380,13 +378,13 @@ mod test {
                     Call(
                         Token {
                             category: Identifier(Undefined("x".to_owned())),
-                            position: (0, 1)
+                            position: (1, 1)
                         },
                         Box::new(Parameter(vec![]))
                     ),
                     Primitive(Token {
                         category: Number(2),
-                        position: (6, 7)
+                        position: (1, 7)
                     })
                 ]
             )

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -354,26 +354,26 @@ mod test {
             If(
                 Box::new(Variable(Token {
                     category: Identifier(Undefined("description".to_owned())),
-                    position: (4, 15)
+                    position: (1, 5)
                 })),
                 Box::new(Call(
                     Token {
                         category: Identifier(Undefined("script_oid".to_owned())),
-                        position: (17, 27)
+                        position: (1, 18)
                     },
                     Box::new(Parameter(vec![Primitive(Token {
                         category: String("1".to_owned()),
-                        position: (29, 30)
+                        position: (1, 29)
                     })]))
                 )),
                 Some(Box::new(Call(
                     Token {
                         category: Identifier(Undefined("display".to_owned())),
-                        position: (39, 46)
+                        position: (1, 40)
                     },
                     Box::new(Parameter(vec![Primitive(Token {
                         category: String("hi".to_owned()),
-                        position: (48, 50)
+                        position: (1, 48)
                     })]))
                 )))
             )
@@ -392,7 +392,7 @@ mod test {
             If(
                 Box::new(Variable(Token {
                     category: Identifier(Undefined("description".to_owned())),
-                    position: (4, 15)
+                    position: (1, 5)
                 })),
                 Box::new(Block(vec![])),
                 None
@@ -408,15 +408,15 @@ mod test {
                 vec![
                     Variable(Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (10 + offset, 11 + offset),
+                        position: (1, 11 + offset),
                     }),
                     Variable(Token {
                         category: Identifier(Undefined("b".to_owned())),
-                        position: (13 + offset, 14 + offset),
+                        position: (1, 14 + offset),
                     }),
                     Variable(Token {
                         category: Identifier(Undefined("c".to_owned())),
-                        position: (16 + offset, 17 + offset),
+                        position: (1, 17 + offset),
                     }),
                 ],
             )
@@ -438,7 +438,7 @@ mod test {
             parse("NULL;").next().unwrap().unwrap(),
             Primitive(Token {
                 category: Identifier(IdentifierType::Null),
-                position: (0, 4)
+                position: (1, 1)
             })
         );
     }
@@ -449,14 +449,14 @@ mod test {
             parse("TRUE;").next().unwrap().unwrap(),
             Primitive(Token {
                 category: Identifier(IdentifierType::True),
-                position: (0, 4)
+                position: (1, 1)
             })
         );
         assert_eq!(
             parse("FALSE;").next().unwrap().unwrap(),
             Primitive(Token {
                 category: Identifier(IdentifierType::False),
-                position: (0, 5)
+                position: (1, 1)
             })
         );
     }
@@ -559,15 +559,15 @@ mod test {
             FunctionDeclaration(
                 Token {
                     category: Identifier(Undefined("register_packages".to_owned())),
-                    position: (9, 26)
+                    position: (1, 10)
                 },
                 vec![Variable(Token {
                     category: Identifier(Undefined("buf".to_owned())),
-                    position: (28, 31)
+                    position: (1, 29)
                 })],
                 Box::new(Block(vec![Return(Box::new(Primitive(Token {
                     category: Number(1),
-                    position: (43, 44)
+                    position: (1, 44)
                 })))]))
             )
         );
@@ -579,12 +579,12 @@ mod test {
             FunctionDeclaration(
                 Token {
                     category: Identifier(Undefined("register_packages".to_owned())),
-                    position: (9, 26)
+                    position: (1, 10)
                 },
                 vec![],
                 Box::new(Block(vec![Return(Box::new(Primitive(Token {
                     category: Number(1),
-                    position: (39, 40)
+                    position: (1, 40)
                 })))]))
             )
         );
@@ -599,16 +599,16 @@ mod test {
                 AssignOrder::AssignReturn,
                 Box::new(Variable(Token {
                     category: Category::Identifier(Undefined("arg1".to_owned())),
-                    position: (0, 4)
+                    position: (1, 1)
                 },)),
                 Box::new(Array(
                     Token {
                         category: Category::Identifier(IdentifierType::FCTAnonArgs),
-                        position: (7, 21),
+                        position: (1, 8),
                     },
                     Some(Box::new(Primitive(Token {
                         category: Category::Number(0),
-                        position: (22, 23)
+                        position: (1, 23)
                     })))
                 ))
             ))
@@ -620,12 +620,12 @@ mod test {
                 AssignOrder::AssignReturn,
                 Box::new(Variable(Token {
                     category: Category::Identifier(Undefined("arg1".to_owned())),
-                    position: (0, 4)
+                    position: (1, 1)
                 },)),
                 Box::new(Array(
                     Token {
                         category: Category::Identifier(IdentifierType::FCTAnonArgs),
-                        position: (7, 21),
+                        position: (1, 8),
                     },
                     None
                 ))

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -64,23 +64,23 @@ mod tests {
             vec![
                 Token {
                     category: Category::Identifier(IdentifierType::LocalVar),
-                    position: (0, 9)
+                    position: (1, 1)
                 },
                 Token {
                     category: Category::Identifier(IdentifierType::Undefined("hello".to_owned())),
-                    position: (10, 15)
+                    position: (1, 11)
                 },
                 Token {
                     category: Category::Equal,
-                    position: (16, 17)
+                    position: (1, 17)
                 },
                 Token {
                     category: Category::String("World!".to_owned()),
-                    position: (19, 25)
+                    position: (1, 19)
                 },
                 Token {
                     category: Category::Semicolon,
-                    position: (26, 27)
+                    position: (1, 27)
                 }
             ]
         );
@@ -100,11 +100,11 @@ mod tests {
                     AssignOrder::AssignReturn,
                     Box::new(Variable(Token {
                         category: Identifier(IdentifierType::Undefined("a".to_owned())),
-                        position: (0, 1)
+                        position: (1, 1)
                     },)),
                     Box::new(Primitive(Token {
                         category: Number(23),
-                        position: (4, 6)
+                        position: (1, 5)
                     }))
                 )),
                 Ok(Assign(
@@ -112,11 +112,11 @@ mod tests {
                     AssignOrder::AssignReturn,
                     Box::new(Variable(Token {
                         category: Identifier(IdentifierType::Undefined("b".to_owned())),
-                        position: (7, 8)
+                        position: (1, 8)
                     },)),
                     Box::new(Primitive(Token {
                         category: Number(1),
-                        position: (11, 12)
+                        position: (1, 12)
                     }))
                 ))
             ]

--- a/rust/nasl-syntax/src/operation.rs
+++ b/rust/nasl-syntax/src/operation.rs
@@ -69,7 +69,7 @@ impl Operation {
             | Category::DoublePoint
             | Category::PercentEqual
             | Category::MinusMinus => Some(Operation::Assign(token.category().clone())),
-            Category::String(_) | Category::Number(_) | Category::IPv4Address => Some(Operation::Primitive),
+            Category::String(_) | Category::Number(_) | Category::IPv4Address(_) => Some(Operation::Primitive),
             Category::LeftParen
             | Category::LeftBrace
             | Category::LeftCurlyBracket

--- a/rust/nasl-syntax/src/postfix_extension.rs
+++ b/rust/nasl-syntax/src/postfix_extension.rs
@@ -97,14 +97,14 @@ mod test {
     }
 
     #[test]
-    fn postfix_variable_assignment_operator() {
+    fn variable_assignment_operator() {
         let expected = |assign_operator: Category| {
             Operator(
                 Plus,
                 vec![
                     Primitive(Token {
                         category: Number(1),
-                        position: (0, 1),
+                        position: (1, 1),
                     }),
                     Operator(
                         Star,
@@ -114,13 +114,13 @@ mod test {
                                 AssignOrder::ReturnAssign,
                                 Box::new(Variable(Token {
                                     category: Identifier(Undefined("a".to_owned())),
-                                    position: (4, 5),
+                                    position: (1, 5),
                                 })),
                                 Box::new(NoOp(None)),
                             ),
                             Primitive(Token {
                                 category: Number(1),
-                                position: (10, 11),
+                                position: (1, 11),
                             }),
                         ],
                     ),
@@ -132,7 +132,7 @@ mod test {
     }
 
     #[test]
-    fn postfix_array_assignment_operator() {
+    fn array_assignment_operator() {
         use AssignOrder::*;
         let expected = |assign_operator: Category| {
             Assign(
@@ -141,11 +141,11 @@ mod test {
                 Box::new(Array(
                     Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (0, 1),
+                        position: (1, 1),
                     },
                     Some(Box::new(Primitive(Token {
                         category: Number(1),
-                        position: (2, 3),
+                        position: (1, 3),
                     }))),
                 )),
                 Box::new(NoOp(None)),

--- a/rust/nasl-syntax/src/prefix_extension.rs
+++ b/rust/nasl-syntax/src/prefix_extension.rs
@@ -3,12 +3,12 @@ use crate::{
     error::SyntaxError,
     grouping_extension::Grouping,
     keyword_extension::Keywords,
-    lexer::{Lexer, End},
-    {AssignOrder, Statement},
+    lexer::{End, Lexer},
     operation::Operation,
     token::{Category, Token},
     unexpected_end, unexpected_token,
     variable_extension::Variables,
+    {AssignOrder, Statement},
 };
 pub(crate) trait Prefix {
     /// Handles statements before operation statements get handled.
@@ -28,7 +28,6 @@ fn prefix_binding_power(token: Token) -> Result<u8, SyntaxError> {
         _ => Err(unexpected_token!(token)),
     }
 }
-
 
 impl<'a> Lexer<'a> {
     /// Parses Operations that have an prefix (e.g. -1)
@@ -92,15 +91,14 @@ impl<'a> Prefix for Lexer<'a> {
 mod test {
 
     use crate::{
-        AssignOrder,
-        Statement,
         parse,
         token::{Category, Token},
+        AssignOrder, Statement,
     };
 
+    use crate::IdentifierType::Undefined;
     use Category::*;
     use Statement::*;
-    use crate::IdentifierType::Undefined;
 
     fn result(code: &str) -> Statement {
         parse(code).next().unwrap().unwrap()
@@ -115,10 +113,7 @@ mod test {
     #[test]
     fn operations() {
         fn expected(category: Category) -> Statement {
-            Statement::Operator(
-                category,
-                vec![Statement::Primitive(token(Number(1), 1, 2))],
-            )
+            Statement::Operator(category, vec![Statement::Primitive(token(Number(1), 1, 2))])
         }
 
         assert_eq!(result("-1;"), expected(Category::Minus));
@@ -129,10 +124,10 @@ mod test {
 
     #[test]
     fn single_statement() {
-        assert_eq!(result("1;"), Primitive(token(Number(1), 0, 1)));
+        assert_eq!(result("1;"), Primitive(token(Number(1), 1, 1)));
         assert_eq!(
             result("'a';"),
-            Primitive(token(String("a".to_owned()), 1, 2))
+            Primitive(token(String("a".to_owned()), 1, 1))
         );
     }
 
@@ -144,7 +139,7 @@ mod test {
                 vec![
                     Primitive(Token {
                         category: Number(1),
-                        position: (0, 1),
+                        position: (1, 1),
                     }),
                     Operator(
                         Star,
@@ -154,13 +149,13 @@ mod test {
                                 AssignOrder::AssignReturn,
                                 Box::new(Variable(Token {
                                     category: Identifier(Undefined("a".to_owned())),
-                                    position: (6, 7),
+                                    position: (1, 7),
                                 })),
                                 Box::new(NoOp(None)),
                             ),
                             Primitive(Token {
                                 category: Number(1),
-                                position: (10, 11),
+                                position: (1, 11),
                             }),
                         ],
                     ),
@@ -180,11 +175,11 @@ mod test {
                 Box::new(Array(
                     Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (2, 3),
+                        position: (1, 3),
                     },
                     Some(Box::new(Primitive(Token {
                         category: Number(0),
-                        position: (4, 5),
+                        position: (1, 5),
                     }))),
                 )),
                 Box::new(NoOp(None)),

--- a/rust/nasl-syntax/src/variable_extension.rs
+++ b/rust/nasl-syntax/src/variable_extension.rs
@@ -113,7 +113,7 @@ mod test {
 
     #[test]
     fn variables() {
-        assert_eq!(result("a;"), Variable(token(Identifier(Undefined("a".to_owned())), 0, 1)));
+        assert_eq!(result("a;"), Variable(token(Identifier(Undefined("a".to_owned())), 1, 1)));
     }
 
     #[test]
@@ -121,8 +121,8 @@ mod test {
         assert_eq!(
             result("a[0];"),
             Array(
-                token(Identifier(Undefined("a".to_owned())), 0, 1),
-                Some(Box::new(Primitive(token(Number(0), 2, 3))))
+                token(Identifier(Undefined("a".to_owned())), 1, 1),
+                Some(Box::new(Primitive(token(Number(0), 1, 3))))
             )
         );
 
@@ -134,22 +134,22 @@ mod test {
                 Box::new(Array(
                     Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (0, 1)
+                        position: (1, 1)
                     },
                     None
                 )),
                 Box::new(Parameter(vec![
                     Primitive(Token {
                         category: Number(1),
-                        position: (5, 6)
+                        position: (1, 6)
                     }),
                     Primitive(Token {
                         category: Number(2),
-                        position: (8, 9)
+                        position: (1, 9)
                     }),
                     Primitive(Token {
                         category: Number(3),
-                        position: (11, 12)
+                        position: (1, 12)
                     })
                 ]))
             )
@@ -163,25 +163,25 @@ mod test {
                 Box::new(Array(
                     Token {
                         category: Identifier(Undefined("a".to_owned())),
-                        position: (0, 1)
+                        position: (1, 1)
                     },
                     Some(Box::new(Primitive(Token {
                         category: Number(0),
-                        position: (2, 3)
+                        position: (1, 3)
                     })))
                 )),
                 Box::new(Parameter(vec![
                     Primitive(Token {
                         category: Number(1),
-                        position: (8, 9)
+                        position: (1, 9)
                     }),
                     Primitive(Token {
                         category: Number(2),
-                        position: (11, 12)
+                        position: (1, 12)
                     }),
                     Primitive(Token {
                         category: Number(4),
-                        position: (14, 15)
+                        position: (1, 15)
                     })
                 ]))
             )
@@ -190,11 +190,11 @@ mod test {
 
     #[test]
     fn anon_function_call() {
-        let fn_name = token(Identifier(Undefined("a".to_owned())), 0, 1);
+        let fn_name = token(Identifier(Undefined("a".to_owned())), 1, 1);
         let args = Box::new(Parameter(vec![
-            Primitive(token(Number(1), 2, 3)),
-            Primitive(token(Number(2), 5, 6)),
-            Primitive(token(Number(3), 8, 9)),
+            Primitive(token(Number(1), 1, 3)),
+            Primitive(token(Number(2), 1, 6)),
+            Primitive(token(Number(3), 1, 9)),
         ]));
 
         assert_eq!(result("a(1, 2, 3);"), Call(fn_name, args));
@@ -208,41 +208,41 @@ mod test {
             Call(
                 Token {
                     category: Identifier(Undefined("script_tag".to_owned())),
-                    position: (0, 10)
+                    position: (1, 1)
                 },
                 Box::new(Parameter(vec![
                     NamedParameter(
                         Token {
                             category: Identifier(Undefined("name".to_owned())),
-                            position: (11, 15)
+                            position: (1, 12)
                         },
                         Box::new(Primitive(Token {
                             category: String("cvss_base".to_owned()),
-                            position: (17, 26)
+                            position: (1, 17)
                         }))
                     ),
                     NamedParameter(
                         Token {
                             category: Identifier(Undefined("value".to_owned())),
-                            position: (29, 34)
+                            position: (1, 30)
                         },
                         Box::new(Operator(
                             Plus,
                             vec![
                                 Primitive(Token {
                                     category: Number(1),
-                                    position: (35, 36)
+                                    position: (1, 36)
                                 }),
                                 Operator(
                                     Percent,
                                     vec![
                                         Primitive(Token {
                                             category: Number(1),
-                                            position: (39, 40)
+                                            position: (1, 40)
                                         }),
                                         Primitive(Token {
                                             category: Number(2),
-                                            position: (43, 44)
+                                            position: (1, 44)
                                         })
                                     ]
                                 )
@@ -258,16 +258,16 @@ mod test {
             Call(
                 Token {
                     category: Identifier(Undefined("script_tag".to_owned())),
-                    position: (0, 10)
+                    position: (1, 1)
                 },
                 Box::new(Parameter(vec![NamedParameter(
                     Token {
                         category: Identifier(Undefined("name".to_owned())),
-                        position: (11, 15)
+                        position: (1, 12)
                     },
                     Box::new(Primitive(Token {
                         category: Number(2),
-                        position: (17, 18)
+                        position: (1, 18)
                     }))
                 )]))
             )


### PR DESCRIPTION
 Change use col and line number instead of byte location

To make error handling easier and because the tokens the byte range for
an token is not needed anymore. To be able to handle independently from
the source code the tokens are changed to contain the line number as
well as the column number instead.