### PR TITLE
rs use reference statement

### DIFF
--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -12,10 +12,10 @@ pub(crate) trait AssignExtension {
     /// Assigns a right value to a left value and returns either previous or new value based on the order
     fn assign(
         &mut self,
-        category: TokenCategory,
-        order: AssignOrder,
-        left: Statement,
-        right: Statement,
+        category: &TokenCategory,
+        order: &AssignOrder,
+        left: &Statement,
+        right: &Statement,
     ) -> InterpretResult;
 }
 
@@ -191,18 +191,18 @@ impl<'a> Interpreter<'a> {
 impl<'a> AssignExtension for Interpreter<'a> {
     fn assign(
         &mut self,
-        category: TokenCategory,
-        order: AssignOrder,
-        left: Statement,
-        right: Statement,
+        category: &TokenCategory,
+        order: &AssignOrder,
+        left: &Statement,
+        right: &Statement,
     ) -> InterpretResult {
         let (key, lookup) = {
             match left {
                 Variable(ref token) => (Self::identifier(token)?, None),
                 Array(ref token, Some(stmt)) => {
-                    (Self::identifier(token)?, Some(self.resolve(*stmt)?))
+                    (Self::identifier(token)?, Some(self.resolve(stmt)?))
                 }
-                _ => return Err(InterpretError::unsupported(&left, "assign left")),
+                _ => return Err(InterpretError::unsupported(left, "assign left")),
             }
         };
         let val = self.resolve(right)?;
@@ -239,10 +239,10 @@ impl<'a> AssignExtension for Interpreter<'a> {
             TokenCategory::PercentEqual => self.store_return(&key, lookup, &val, |left, right| {
                 NaslValue::Number(i64::from(left) % i64::from(right))
             }),
-            TokenCategory::PlusPlus => self.without_right(&order, &key, lookup, |left, _| {
+            TokenCategory::PlusPlus => self.without_right(order, &key, lookup, |left, _| {
                 NaslValue::Number(i64::from(left) + 1)
             }),
-            TokenCategory::MinusMinus => self.without_right(&order, &key, lookup, |left, _| {
+            TokenCategory::MinusMinus => self.without_right(order, &key, lookup, |left, _| {
                 NaslValue::Number(i64::from(left) - 1)
             }),
 
@@ -285,7 +285,7 @@ mod tests {
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
-            parse(code).map(|x| interpreter.resolve(x.expect("no parse error expected")));
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(25))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(23))));
@@ -320,7 +320,7 @@ mod tests {
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
-            parse(code).map(|x| interpreter.resolve(x.expect("no parse error expected")));
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(25))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(23))));
@@ -344,7 +344,7 @@ mod tests {
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
-            parse(code).map(|x| interpreter.resolve(x.expect("no parse error expected")));
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(
             parser.next(),
@@ -369,7 +369,7 @@ mod tests {
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
-            parse(code).map(|x| interpreter.resolve(x.expect("no parse error expected")));
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
@@ -395,7 +395,7 @@ mod tests {
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
-            parse(code).map(|x| interpreter.resolve(x.expect("no parse error expected")));
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(
             parser.next(),

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -8,23 +8,23 @@ use std::collections::HashMap;
 
 /// Is a trait to handle function calls within nasl.
 pub(crate) trait CallExtension {
-    fn call(&mut self, name: Token, arguments: Box<Statement>) -> InterpretResult;
+    fn call(&mut self, name: &Token, arguments: &Statement) -> InterpretResult;
 }
 
 impl<'a> CallExtension for Interpreter<'a> {
     #[inline(always)]
-    fn call(&mut self, name: Token, arguments: Box<Statement>) -> InterpretResult {
-        let name = &Self::identifier(&name)?;
+    fn call(&mut self, name: &Token, arguments: &Statement) -> InterpretResult {
+        let name = &Self::identifier(name)?;
         // get the context
         let mut named = HashMap::new();
         let mut position = vec![];
-        match *arguments {
+        match arguments {
             Parameter(params) => {
                 for p in params {
                     match p {
                         NamedParameter(token, val) => {
-                            let val = self.resolve(*val)?;
-                            let name = Self::identifier(&token)?;
+                            let val = self.resolve(val)?;
+                            let name = Self::identifier(token)?;
                             named.insert(name, ContextType::Value(val));
                         }
                         val => {
@@ -74,7 +74,7 @@ impl<'a> CallExtension for Interpreter<'a> {
                                 Some(_) => {}
                             }
                         }
-                        match self.resolve(stmt)? {
+                        match self.resolve(&stmt)? {
                             NaslValue::Return(x) => Ok(*x),
                             a => Ok(a),
                         }
@@ -111,7 +111,7 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut parser = parse(code).map(|x| interpreter.resolve(x.expect("unexpected parse error")));
+        let mut parser = parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(3))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(1))));

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -30,6 +30,7 @@ impl Register {
         }
     }
 
+    /// Creates a root Register based on the given initial values
     pub fn root_initial(initial: Vec<(String, ContextType)>) -> Self {
         let root = NaslContext {
             defined: initial.into_iter().collect(),

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -32,7 +32,7 @@ impl InterpretError {
 
     pub fn from_statement(stmt: &Statement, reason: String) -> Self {
         let (line, col) = stmt.as_token().map(|x| x.position).unwrap_or_default();
-        return InterpretError { reason, line, col };
+        InterpretError { reason, line, col }
     }
 
     pub fn internal_error(stmt: &Statement, dspl: &dyn Display) -> Self {

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -2,7 +2,6 @@ use std::fmt::Display;
 
 use nasl_syntax::{Statement, SyntaxError};
 
-// TODO refactor error handling
 #[derive(Debug)]
 pub struct FunctionError {
     pub reason: String,
@@ -15,13 +14,26 @@ impl FunctionError {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+/// Is used to represent an error while interpreting
 pub struct InterpretError {
+    /// Represents a human readable reason
     pub reason: String,
+    /// The line number within the script when that error occured
+    ///
+    /// It starts 1.
     pub line: usize,
+    /// The colum number within the script when that error occured
+    ///
+    /// It starts 1.
     pub col: usize,
 }
 
 impl InterpretError {
+    /// Creates a new Error with line and col set to 0
+    ///
+    /// Use this only when there is no statement available.
+    /// If thre line as well as col is null Interpreter::resolve will replace it 
+    /// with the line and col number based on the root statement.
     pub fn new(reason: String) -> Self {
         Self {
             reason,
@@ -30,20 +42,28 @@ impl InterpretError {
         }
     }
 
+    /// Creates a new Error based on a given statement and reason
     pub fn from_statement(stmt: &Statement, reason: String) -> Self {
         let (line, col) = stmt.as_token().map(|x| x.position).unwrap_or_default();
         InterpretError { reason, line, col }
     }
 
+    /// Creates a new internal Error based on a given statement and dspl
+    ///
+    /// It produces the reason Internal error: statement {statement} -> {dspl}
     pub fn internal_error(stmt: &Statement, dspl: &dyn Display) -> Self {
-        Self::from_statement(stmt, format!("Internal error: statement {} -> {}", stmt, dspl))
+        Self::from_statement(
+            stmt,
+            format!("Internal error: statement {} -> {}", stmt, dspl),
+        )
     }
 
     /// Creates a InterpreterError for an unsupported statement
+    ///
+    /// It produces the reason {root}: {statement} is not supported
     pub fn unsupported(stmt: &Statement, root: &str) -> Self {
         Self::from_statement(stmt, format!("{}: {} is not supported", root, stmt))
     }
-
 }
 
 impl From<SyntaxError> for InterpretError {

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -18,11 +18,11 @@ impl FunctionError {
 pub struct InterpretError {
     /// Represents a human readable reason
     pub reason: String,
-    /// The line number within the script when that error occured
+    /// The line number within the script when that error occurred
     ///
     /// It starts 1.
     pub line: usize,
-    /// The colum number within the script when that error occured
+    /// The colum number within the script when that error occurred
     ///
     /// It starts 1.
     pub col: usize,
@@ -32,7 +32,7 @@ impl InterpretError {
     /// Creates a new Error with line and col set to 0
     ///
     /// Use this only when there is no statement available.
-    /// If thre line as well as col is null Interpreter::resolve will replace it 
+    /// If the line as well as col is null Interpreter::resolve will replace it 
     /// with the line and col number based on the root statement.
     pub fn new(reason: String) -> Self {
         Self {

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -5,11 +5,11 @@ use crate::{error::InterpretError, interpreter::InterpretResult, Interpreter, Na
 
 /// Is a trait to declare include functionality
 pub(crate) trait IncludeExtension {
-    fn include(&mut self, name: Statement) -> InterpretResult;
+    fn include(&mut self, name: &Statement) -> InterpretResult;
 }
 
 impl<'a> IncludeExtension for Interpreter<'a> {
-    fn include(&mut self, name: Statement) -> InterpretResult {
+    fn include(&mut self, name: &Statement) -> InterpretResult {
         match self.resolve(name)? {
             NaslValue::String(key) => {
                 let code = self.loader.load(&key)?;
@@ -17,7 +17,7 @@ impl<'a> IncludeExtension for Interpreter<'a> {
                 let mut inter = Interpreter::new(self.key, &storage, self.loader, self.registrat);
                 let result = parse(&code)
                     .map(|parsed| match parsed {
-                        Ok(stmt) => inter.resolve(stmt),
+                        Ok(stmt) => inter.resolve(&stmt),
                         Err(err) => Err(InterpretError::from(err)),
                     })
                     .find(|e| e.is_err());
@@ -73,7 +73,7 @@ mod tests {
         let storage = DefaultSink::new(false);
         let mut register = Register::default();
         let mut interpreter = Interpreter::new("1", &storage, loader, &mut register);
-        let mut interpreter = parse(code).map(|x| interpreter.resolve(x.expect("expected")));
+        let mut interpreter = parse(code).map(|x| interpreter.resolve(&x.expect("expected")));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Number(12))));
         assert_eq!(

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -64,7 +64,7 @@ pub fn interpret<'a>(
     let mut interpreter = Interpreter::new(key, storage, &loader, &mut register);
     let result = parse(code)
         .map(|stmt| match stmt {
-            Ok(stmt) => interpreter.resolve(stmt),
+            Ok(stmt) => interpreter.resolve(&stmt),
             Err(r) => Err(InterpretError::from(r)),
         })
         .last()

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -1,81 +1,34 @@
+//! Is a crate to use Stataments from nasl-syntax and execute them.
+#![warn(missing_docs)]
 use built_in_functions::description;
-pub use context::Register;
-use error::{FunctionError, InterpretError};
+mod error;
+use error::FunctionError;
 
 mod assign;
 mod built_in_functions;
 mod call;
 mod context;
 mod declare;
-pub mod error;
 mod include;
 mod interpreter;
 mod loader;
 mod operator;
 
 pub use context::ContextType;
+pub use context::Register;
+pub use error::InterpretError;
 pub use interpreter::{Interpreter, NaslValue};
 pub use loader::*;
-use loader::NoOpLoader;
-use nasl_syntax::parse;
 use sink::{Sink, SinkError};
 
-pub type NaslFunction = fn(&str, &dyn Sink, &Register) -> Result<NaslValue, FunctionError>;
-pub fn lookup(function_name: &str) -> Option<NaslFunction> {
+// Is a type definition for inbuild functions
+pub(crate) type NaslFunction = fn(&str, &dyn Sink, &Register) -> Result<NaslValue, FunctionError>;
+pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
     description::lookup(function_name)
-}
-
-/// Defines the mode of the run
-pub enum Mode<'a> {
-    /// Runs without any kind of prerequisites; requires the OID of the script.
-    Normal(&'a str),
-    /// A Description run will set description to 1 and stores the key as NVTFileName; requires the filename of the script.
-    Description(&'a str),
 }
 
 impl From<SinkError> for InterpretError {
     fn from(se: SinkError) -> Self {
         InterpretError::new(format!("An error occurred while using a sink: {}", se))
-    }
-}
-
-pub fn interpret<'a>(
-    storage: &dyn Sink,
-    mode: Mode,
-    code: &'a str,
-) -> Result<NaslValue, InterpretError> {
-    let (key, mut register) = match mode {
-        Mode::Normal(key) => (key, Register::default()),
-        Mode::Description(key) => {
-            let initial = vec![(
-                "description".to_owned(),
-                ContextType::Value(NaslValue::Number(1)),
-            )];
-            if let Err(err) = storage.dispatch(
-                key,
-                sink::Dispatch::NVT(sink::nvt::NVTField::FileName(key.to_owned())),
-            ) {
-                return Err(InterpretError::from(err));
-            }
-            (key, Register::root_initial(initial))
-        }
-    };
-    let loader = NoOpLoader::default();
-    let mut interpreter = Interpreter::new(key, storage, &loader, &mut register);
-    let result = parse(code)
-        .map(|stmt| match stmt {
-            Ok(stmt) => interpreter.resolve(&stmt),
-            Err(r) => Err(InterpretError::from(r)),
-        })
-        .last()
-        // for the case of NaslValue that returns nothing
-        .unwrap_or(Ok(NaslValue::Exit(0)));
-    let result = result.map(|x| match x {
-        NaslValue::Exit(rc) => NaslValue::Exit(rc),
-        _ => NaslValue::Exit(0),
-    });
-    match storage.on_exit() {
-        Ok(_) => result,
-        Err(err) => Err(InterpretError::from(err)),
     }
 }

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -1,4 +1,4 @@
-//! Is a crate to use Stataments from nasl-syntax and execute them.
+//! Is a crate to use Statements from nasl-syntax and execute them.
 #![warn(missing_docs)]
 use built_in_functions::description;
 mod error;
@@ -21,7 +21,7 @@ pub use interpreter::{Interpreter, NaslValue};
 pub use loader::*;
 use sink::{Sink, SinkError};
 
-// Is a type definition for inbuild functions
+// Is a type definition for built-in functions
 pub(crate) type NaslFunction = fn(&str, &dyn Sink, &Register) -> Result<NaslValue, FunctionError>;
 pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
     description::lookup(function_name)

--- a/rust/nasl-interpreter/src/loader.rs
+++ b/rust/nasl-interpreter/src/loader.rs
@@ -42,7 +42,7 @@ pub trait Loader {
 }
 
 #[derive(Default)]
-pub struct NoOpLoader {}
+pub(crate) struct NoOpLoader {}
 
 /// Is a no operation loader for test purposes.
 impl Loader for NoOpLoader {
@@ -63,6 +63,7 @@ pub struct FSPluginLoader<'a> {
 }
 
 impl<'a> FSPluginLoader<'a> {
+    /// Creates a new file system plugin loader based on the given root path
     pub fn new(root: &'a Path) -> Self {
         Self { root }
     }


### PR DESCRIPTION
 Change use reference in interpreter::resolve

Since the statement within resolve of interpreter does not mutate the
statement but reads it to generate Values it is changed to a reference
instead.

This makes it clear that Interpreter does not own the Statement and that
it is reading it making it easier to handle and clearer in the future.