### PR TITLE
rs get hostnames

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
 name = "nasl-interpreter"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "nasl-syntax",
  "regex",
  "sink",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -329,6 +329,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +566,7 @@ dependencies = [
 name = "nasl-interpreter"
 version = "0.1.0"
 dependencies = [
- "libc",
+ "dns-lookup",
  "nasl-syntax",
  "regex",
  "sink",
@@ -835,6 +847,16 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 [[package]]
 name = "sink"
 version = "0.1.0"
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/rust/nasl-interpreter/Cargo.toml
+++ b/rust/nasl-interpreter/Cargo.toml
@@ -3,6 +3,8 @@ name = "nasl-interpreter"
 version = "0.1.0"
 edition = "2021"
 
+[target.'cfg(not(windows))'.dependencies]
+libc = "^0.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/rust/nasl-interpreter/Cargo.toml
+++ b/rust/nasl-interpreter/Cargo.toml
@@ -3,12 +3,11 @@ name = "nasl-interpreter"
 version = "0.1.0"
 edition = "2021"
 
-[target.'cfg(not(windows))'.dependencies]
-libc = "^0.2"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 nasl-syntax = {path = "../nasl-syntax"}
 sink = {path = "../sink"}
 # used for !~ =~ string regex operations
 regex = "1"
+# used for get-hostnames; an alternative implementation without dependency can be found in:
+# ee3f7e1ed6da946e5eace08d074b320f80087a3c
+dns-lookup = "1.0.8"

--- a/rust/nasl-interpreter/src/built_in_functions/hostname.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/hostname.rs
@@ -1,0 +1,275 @@
+use std::{
+    ffi::{c_char, CStr},
+    mem::{self, MaybeUninit},
+    net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
+};
+
+use libc::{
+    getnameinfo, in6_addr, in_addr, sa_family_t, sockaddr, sockaddr_in, sockaddr_in6,
+    sockaddr_storage, socklen_t, AF_INET, AF_INET6, NI_NUMERICSERV,
+};
+use sink::Sink;
+use std::str;
+
+use crate::{error::FunctionError, lookup_keys::TARGET, NaslFunction, NaslValue, Register};
+
+/// Is a convenient struct to parse SocketAddr into *const sockaddr.
+///
+/// For DNS requests via libc it is necessary to convert an IP string into an IpAddr
+/// and the IpAddr into an SocketAddr to than transform it into an *const sockaddr to
+/// be useable as a const socket within the libc library.
+///
+/// This struct dos make the conversion from IpV4 as well as IpV6 into sockaddr_storage
+/// so that it useable as:
+///
+/// ```ignore
+/// let addr: IpAddr = "127.0.0.1".to_owned()
+///        .parse()
+///        .expect("127.0.0.1 must be parseable");
+/// let sock: SocketAddr = (addr, 0).into();
+/// let sock: LibCSock = sock.into();
+/// ```
+///
+/// ```ignore
+/// let addr: IpAddr = "::1".to_owned()
+///        .parse()
+///        .expect("::1 must be parseable");
+/// let sock: SocketAddr = (addr, 0).into();
+/// let sock: LibCSock = sock.into();
+/// ```
+struct LibCSock {
+    storage: sockaddr_storage,
+    len: socklen_t,
+}
+
+impl LibCSock {
+    fn storage(&self) -> *const sockaddr {
+        &self.storage as *const _ as *const _
+    }
+}
+
+impl From<SocketAddr> for LibCSock {
+    fn from(addr: SocketAddr) -> Self {
+        match addr {
+            SocketAddr::V4(addr) => addr.into(),
+            SocketAddr::V6(addr) => addr.into(),
+        }
+    }
+}
+
+impl From<SocketAddrV4> for LibCSock {
+    fn from(addr: SocketAddrV4) -> Self {
+        let sockaddr_in = sockaddr_in {
+            sin_family: AF_INET as sa_family_t,
+            sin_port: addr.port().to_be(),
+            sin_addr: in_addr {
+                s_addr: u32::from_ne_bytes(addr.ip().octets()),
+            },
+            sin_zero: Default::default(),
+            #[cfg(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            sin_len: 0,
+        };
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
+        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in).write(sockaddr_in) };
+        Self {
+            storage: unsafe { storage.assume_init() },
+            len: mem::size_of::<sockaddr_in>() as socklen_t,
+        }
+    }
+}
+
+impl From<SocketAddrV6> for LibCSock {
+    fn from(addr: SocketAddrV6) -> Self {
+        let sockaddr_in6 = sockaddr_in6 {
+            sin6_family: AF_INET6 as sa_family_t,
+            sin6_port: addr.port().to_be(),
+            sin6_addr: in6_addr {
+                s6_addr: addr.ip().octets(),
+            },
+            sin6_flowinfo: addr.flowinfo(),
+            sin6_scope_id: addr.scope_id(),
+            #[cfg(any(
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "macos",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            ))]
+            sin6_len: 0,
+        };
+        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
+        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in6).write(sockaddr_in6) };
+        Self {
+            storage: unsafe { storage.assume_init() },
+            len: mem::size_of::<sockaddr_in6>() as socklen_t,
+        }
+    }
+}
+#[inline]
+#[cfg(unix)]
+fn resolve_ip_to_host_and_service(addr: IpAddr) -> Result<(String, String), FunctionError> {
+    use libc::EAI_AGAIN;
+
+    let sock: SocketAddr = (addr, 0).into();
+    let sock: LibCSock = sock.into();
+    let c_sock = sock.storage();
+    let c_sock_len = sock.len;
+    let mut c_host = [0 as c_char; 1024];
+    let mut c_service = [0 as c_char; 32];
+    let mut result = unsafe {
+        getnameinfo(
+            c_sock,
+            c_sock_len,
+            c_host.as_mut_ptr(),
+            c_host.len() as _,
+            c_service.as_mut_ptr(),
+            c_service.len() as _,
+            NI_NUMERICSERV,
+        )
+    };
+    while result == EAI_AGAIN {
+        result = unsafe {
+            getnameinfo(
+                c_sock,
+                c_sock_len,
+                c_host.as_mut_ptr(),
+                c_host.len() as _,
+                c_service.as_mut_ptr(),
+                c_service.len() as _,
+                NI_NUMERICSERV,
+            )
+        };
+    }
+    if result != 0 {
+        return Err(FunctionError::new(format!(
+            "getnameinfo failed for {} -> {}",
+            addr, result
+        )));
+    }
+
+    let host = unsafe { CStr::from_ptr(c_host.as_ptr()) };
+    let service = unsafe { CStr::from_ptr(c_service.as_ptr()) };
+
+    let host = match str::from_utf8(host.to_bytes()) {
+        Ok(name) => name.to_owned(),
+        Err(_) => return Err(FunctionError::new("Host UTF8 parsing failed".to_owned())),
+    };
+
+    let service = match str::from_utf8(service.to_bytes()) {
+        Ok(service) => service.to_owned(),
+        Err(_) => return Err(FunctionError::new("Service UTF8 parsing failed".to_owned())),
+    };
+    Ok((host, service))
+}
+
+#[inline]
+#[cfg(windows)]
+/// Unfortunately there is currently no available rust std implementation available.
+/// For that rason we are using libc and exclude windows machine for now.
+/// If we ever decide to support windows we would need to implement a solution based on
+/// `windows::Win32::System::SystemInformation` and `GetComputerNameExW`.
+fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
+    return Err(FunctionError::new(
+        "resolve_hostname is not supported on Windows.".to_owned(),
+    ));
+}
+
+#[inline]
+#[cfg(unix)]
+/// Resolves IP address of target to hostname
+///
+/// It uses a libc getnameinfo and therefore only works in unix environments.
+/// It does lookup TARGET and when not found falls back to 127.0.0.1 to resolve.
+/// If the TARGET is not a IP address than we assume that it already is a fqdn or a hostname and will return that instead.
+fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
+    let default_ip = "127.0.0.1";
+    // currently we use shadow variables as _FC_ANON_ARGS; the original openvas uses redis for that purpose.
+    let target = register.named(TARGET).map_or_else(
+        || default_ip.to_owned(),
+        |x| match x {
+            crate::ContextType::Value(NaslValue::String(x)) => x.clone(),
+            _ => default_ip.to_owned(),
+        },
+    );
+
+    match target.parse() {
+        Ok(addr) => {
+            match resolve_ip_to_host_and_service(addr).map(|(host, _)| host) {
+                Ok(v) => Ok(v),
+                Err(_) => {
+                    // maybe the resolv.conf needs to be reloaded
+                    // See https://github.com/rust-lang/rust/issues/41570.
+                    unsafe {
+                        libc::res_init();
+                    }
+                    resolve_ip_to_host_and_service(addr).map(|(host, _)| host)
+                }
+            }
+        }
+        // assumes that target is already a hostname
+        Err(_) => Ok(target),
+    }
+}
+
+/// NASL function to get all stored vhosts
+///
+/// As of now (2023-01-20) there is no vhost handling.
+/// Therefore this function does load the registered TARGET and if it is an IP Addres resolves it via DNS instead.
+pub fn get_host_names(
+    _: &str,
+    _: &dyn Sink,
+    register: &Register,
+) -> Result<NaslValue, FunctionError> {
+    resolve_hostname(register).map(|x| NaslValue::Array(vec![NaslValue::String(x)]))
+}
+
+/// NASL function to get the current hostname
+///
+/// As of now (2023-01-20) there is no vhost handling.
+/// Therefore this function does load the registered TARGET and if it is an IP Addres resolves it via DNS instead.
+pub fn get_host_name(
+    _: &str,
+    _: &dyn Sink,
+    register: &Register,
+) -> Result<NaslValue, FunctionError> {
+    resolve_hostname(register).map(NaslValue::String)
+}
+
+/// Returns found function for key or None when not found
+pub fn lookup(key: &str) -> Option<NaslFunction> {
+    match key {
+        "get_host_name" => Some(get_host_name),
+        "get_host_names" => Some(get_host_names),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nasl_syntax::parse;
+    use sink::DefaultSink;
+
+    use crate::{Interpreter, NaslValue, NoOpLoader, Register};
+
+    #[test]
+    fn get_host_name() {
+        let code = r###"
+        get_host_name();
+        get_host_names();
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
+        assert!(matches!(parser.next(), Some(Ok(NaslValue::String(_)))));
+        assert!(matches!(parser.next(), Some(Ok(NaslValue::Array(_)))));
+    }
+}

--- a/rust/nasl-interpreter/src/built_in_functions/hostname.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/hostname.rs
@@ -32,7 +32,7 @@ fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
 /// NASL function to get all stored vhosts
 ///
 /// As of now (2023-01-20) there is no vhost handling.
-/// Therefore this function does load the registered TARGET and if it is an IP Addres resolves it via DNS instead.
+/// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
 pub fn get_host_names(
     _: &str,
     _: &dyn Sink,
@@ -44,7 +44,7 @@ pub fn get_host_names(
 /// NASL function to get the current hostname
 ///
 /// As of now (2023-01-20) there is no vhost handling.
-/// Therefore this function does load the registered TARGET and if it is an IP Addres resolves it via DNS instead.
+/// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
 pub fn get_host_name(
     _: &str,
     _: &dyn Sink,

--- a/rust/nasl-interpreter/src/built_in_functions/hostname.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/hostname.rs
@@ -1,193 +1,15 @@
-use std::{
-    ffi::{c_char, CStr},
-    mem::{self, MaybeUninit},
-    net::{IpAddr, SocketAddr, SocketAddrV4, SocketAddrV6},
-};
-
-use libc::{
-    getnameinfo, in6_addr, in_addr, sa_family_t, sockaddr, sockaddr_in, sockaddr_in6,
-    sockaddr_storage, socklen_t, AF_INET, AF_INET6, NI_NUMERICSERV,
-};
 use sink::Sink;
 use std::str;
 
 use crate::{error::FunctionError, lookup_keys::TARGET, NaslFunction, NaslValue, Register};
 
-/// Is a convenient struct to parse SocketAddr into *const sockaddr.
-///
-/// For DNS requests via libc it is necessary to convert an IP string into an IpAddr
-/// and the IpAddr into an SocketAddr to than transform it into an *const sockaddr to
-/// be useable as a const socket within the libc library.
-///
-/// This struct dos make the conversion from IpV4 as well as IpV6 into sockaddr_storage
-/// so that it useable as:
-///
-/// ```ignore
-/// let addr: IpAddr = "127.0.0.1".to_owned()
-///        .parse()
-///        .expect("127.0.0.1 must be parseable");
-/// let sock: SocketAddr = (addr, 0).into();
-/// let sock: LibCSock = sock.into();
-/// ```
-///
-/// ```ignore
-/// let addr: IpAddr = "::1".to_owned()
-///        .parse()
-///        .expect("::1 must be parseable");
-/// let sock: SocketAddr = (addr, 0).into();
-/// let sock: LibCSock = sock.into();
-/// ```
-struct LibCSock {
-    storage: sockaddr_storage,
-    len: socklen_t,
-}
-
-impl LibCSock {
-    fn storage(&self) -> *const sockaddr {
-        &self.storage as *const _ as *const _
-    }
-}
-
-impl From<SocketAddr> for LibCSock {
-    fn from(addr: SocketAddr) -> Self {
-        match addr {
-            SocketAddr::V4(addr) => addr.into(),
-            SocketAddr::V6(addr) => addr.into(),
-        }
-    }
-}
-
-impl From<SocketAddrV4> for LibCSock {
-    fn from(addr: SocketAddrV4) -> Self {
-        let sockaddr_in = sockaddr_in {
-            sin_family: AF_INET as sa_family_t,
-            sin_port: addr.port().to_be(),
-            sin_addr: in_addr {
-                s_addr: u32::from_ne_bytes(addr.ip().octets()),
-            },
-            sin_zero: Default::default(),
-            #[cfg(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            sin_len: 0,
-        };
-        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
-        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in).write(sockaddr_in) };
-        Self {
-            storage: unsafe { storage.assume_init() },
-            len: mem::size_of::<sockaddr_in>() as socklen_t,
-        }
-    }
-}
-
-impl From<SocketAddrV6> for LibCSock {
-    fn from(addr: SocketAddrV6) -> Self {
-        let sockaddr_in6 = sockaddr_in6 {
-            sin6_family: AF_INET6 as sa_family_t,
-            sin6_port: addr.port().to_be(),
-            sin6_addr: in6_addr {
-                s6_addr: addr.ip().octets(),
-            },
-            sin6_flowinfo: addr.flowinfo(),
-            sin6_scope_id: addr.scope_id(),
-            #[cfg(any(
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "macos",
-                target_os = "netbsd",
-                target_os = "openbsd"
-            ))]
-            sin6_len: 0,
-        };
-        let mut storage = MaybeUninit::<sockaddr_storage>::zeroed();
-        unsafe { (storage.as_mut_ptr() as *mut sockaddr_in6).write(sockaddr_in6) };
-        Self {
-            storage: unsafe { storage.assume_init() },
-            len: mem::size_of::<sockaddr_in6>() as socklen_t,
-        }
-    }
-}
-#[inline]
-#[cfg(unix)]
-fn resolve_ip_to_host_and_service(addr: IpAddr) -> Result<(String, String), FunctionError> {
-    use libc::EAI_AGAIN;
-
-    let sock: SocketAddr = (addr, 0).into();
-    let sock: LibCSock = sock.into();
-    let c_sock = sock.storage();
-    let c_sock_len = sock.len;
-    let mut c_host = [0 as c_char; 1024];
-    let mut c_service = [0 as c_char; 32];
-    let mut result = unsafe {
-        getnameinfo(
-            c_sock,
-            c_sock_len,
-            c_host.as_mut_ptr(),
-            c_host.len() as _,
-            c_service.as_mut_ptr(),
-            c_service.len() as _,
-            NI_NUMERICSERV,
-        )
-    };
-    while result == EAI_AGAIN {
-        result = unsafe {
-            getnameinfo(
-                c_sock,
-                c_sock_len,
-                c_host.as_mut_ptr(),
-                c_host.len() as _,
-                c_service.as_mut_ptr(),
-                c_service.len() as _,
-                NI_NUMERICSERV,
-            )
-        };
-    }
-    if result != 0 {
-        return Err(FunctionError::new(format!(
-            "getnameinfo failed for {} -> {}",
-            addr, result
-        )));
-    }
-
-    let host = unsafe { CStr::from_ptr(c_host.as_ptr()) };
-    let service = unsafe { CStr::from_ptr(c_service.as_ptr()) };
-
-    let host = match str::from_utf8(host.to_bytes()) {
-        Ok(name) => name.to_owned(),
-        Err(_) => return Err(FunctionError::new("Host UTF8 parsing failed".to_owned())),
-    };
-
-    let service = match str::from_utf8(service.to_bytes()) {
-        Ok(service) => service.to_owned(),
-        Err(_) => return Err(FunctionError::new("Service UTF8 parsing failed".to_owned())),
-    };
-    Ok((host, service))
-}
-
-#[inline]
-#[cfg(windows)]
-/// Unfortunately there is currently no available rust std implementation available.
-/// For that rason we are using libc and exclude windows machine for now.
-/// If we ever decide to support windows we would need to implement a solution based on
-/// `windows::Win32::System::SystemInformation` and `GetComputerNameExW`.
-fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
-    return Err(FunctionError::new(
-        "resolve_hostname is not supported on Windows.".to_owned(),
-    ));
-}
-
-#[inline]
-#[cfg(unix)]
 /// Resolves IP address of target to hostname
 ///
-/// It uses a libc getnameinfo and therefore only works in unix environments.
 /// It does lookup TARGET and when not found falls back to 127.0.0.1 to resolve.
 /// If the TARGET is not a IP address than we assume that it already is a fqdn or a hostname and will return that instead.
 fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
+    use dns_lookup::lookup_addr;
+
     let default_ip = "127.0.0.1";
     // currently we use shadow variables as _FC_ANON_ARGS; the original openvas uses redis for that purpose.
     let target = register.named(TARGET).map_or_else(
@@ -199,19 +21,9 @@ fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
     );
 
     match target.parse() {
-        Ok(addr) => {
-            match resolve_ip_to_host_and_service(addr).map(|(host, _)| host) {
-                Ok(v) => Ok(v),
-                Err(_) => {
-                    // maybe the resolv.conf needs to be reloaded
-                    // See https://github.com/rust-lang/rust/issues/41570.
-                    unsafe {
-                        libc::res_init();
-                    }
-                    resolve_ip_to_host_and_service(addr).map(|(host, _)| host)
-                }
-            }
-        }
+        Ok(addr) => lookup_addr(&addr).map_err(|x| FunctionError {
+            reason: format!("Error while lookup {}: {}", addr, x),
+        }),
         // assumes that target is already a hostname
         Err(_) => Ok(target),
     }

--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -1,2 +1,3 @@
 pub mod description;
+pub mod hostname;
 

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -2,7 +2,7 @@ use nasl_syntax::{Statement, Statement::*, Token};
 
 use crate::{
     error::InterpretError, interpreter::InterpretResult, lookup, ContextType, Interpreter,
-    NaslValue,
+    NaslValue, lookup_keys::FC_ANON_ARGS,
 };
 use std::collections::HashMap;
 
@@ -41,7 +41,7 @@ impl<'a> CallExtension for Interpreter<'a> {
             }
         };
         named.insert(
-            "_FCT_ANON_ARGS".to_owned(),
+            FC_ANON_ARGS.to_owned(),
             ContextType::Value(NaslValue::Array(position)),
         );
         self.registrat.create_root_child(named);

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -1,6 +1,6 @@
 use nasl_syntax::Statement;
 
-use crate::{error::InterpretError, interpreter::NaslValue};
+use crate::{error::InterpretError, interpreter::NaslValue, lookup_keys::FC_ANON_ARGS};
 
 /// Contexts are responsible to locate, add and delete everything that is declared within a NASL plugin
 
@@ -127,7 +127,7 @@ impl Register {
 
     /// Retrieves all positional definitions
     pub fn positional(&self) -> &[NaslValue] {
-        match self.named("_FCT_ANON_ARGS") {
+        match self.named(FC_ANON_ARGS) {
             Some(ContextType::Value(NaslValue::Array(arr))) => arr,
             _ => &[],
         }

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -2,8 +2,10 @@
 #![warn(missing_docs)]
 use built_in_functions::description;
 mod error;
+use built_in_functions::hostname;
 use error::FunctionError;
 
+mod lookup_keys;
 mod assign;
 mod built_in_functions;
 mod call;
@@ -12,8 +14,8 @@ mod declare;
 mod include;
 mod interpreter;
 mod loader;
-mod operator;
 mod loop_extension;
+mod operator;
 
 pub use context::ContextType;
 pub use context::Register;
@@ -25,7 +27,7 @@ use sink::{Sink, SinkError};
 // Is a type definition for built-in functions
 pub(crate) type NaslFunction = fn(&str, &dyn Sink, &Register) -> Result<NaslValue, FunctionError>;
 pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
-    description::lookup(function_name)
+    description::lookup(function_name).or_else(|| hostname::lookup(function_name))
 }
 
 impl From<SinkError> for InterpretError {

--- a/rust/nasl-interpreter/src/lookup_keys.rs
+++ b/rust/nasl-interpreter/src/lookup_keys.rs
@@ -1,0 +1,14 @@
+
+//! This crate has definitions of internally used lookup keys
+//!
+//! A lookup key is used to gather script internal information that are not shared
+//! between different runs and may be set before running as initial data.
+
+/// _FCT_ANON_ARGS is used to gather unnamed parameter within a function call
+pub const FC_ANON_ARGS: &str = "_FCT_ANON_ARGS";
+/// _OPENVAS_TARGET is set as the target of the current script run
+///
+/// In the current version of openvas this information is stored into redis.
+/// In the current state of the rust implementation (2023-01-23) we don't have the interface to store data between different script runs.
+// Therefore it is currently stored within the register with this key. 
+pub const TARGET: &str = "_OPENVAS_TARGET";

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -169,17 +169,6 @@ mod tests {
     use sink::DefaultSink;
 
     use crate::{Interpreter, NaslValue, Register, NoOpLoader};
-    macro_rules! no_op_interpreter {
-        ($code:expr) => {
-            {
-                let storage = DefaultSink::new(false);
-                let mut register = Register::default();
-                let loader = NoOpLoader::default();
-                let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-                parse($code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")))
-            }
-        };
-    }
 
 
     #[test]


### PR DESCRIPTION
Implements get_host_name and get_host_names as NASL function.

Unfortunately there is no wrapper std wrapper for libc
- getnameinfo
- gethostname

therefore this Implements wrapper methods for that. Unfortunately those
are unix only, for windows it would require to use the windows specific
API instead.

