### PR TITLE
rs rand

### DIFF
--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -1,3 +1,4 @@
 pub mod description;
 pub mod hostname;
+pub mod rand;
 

--- a/rust/nasl-interpreter/src/built_in_functions/rand.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/rand.rs
@@ -1,0 +1,68 @@
+//! Defines NASL functions that deal with random and helpers
+
+use std::{
+    fs::File,
+    io::{self, Read},
+};
+
+use sink::Sink;
+
+use crate::{error::FunctionError, NaslFunction, NaslValue, Register};
+
+impl From<io::Error> for FunctionError {
+    fn from(e: io::Error) -> Self {
+        Self {
+            reason: format!("Internal error on rand {}", e),
+        }
+    }
+}
+
+#[inline]
+#[cfg(unix)]
+/// Reads 8 bytes from /dev/urandom and parses it to an i64
+fn random_impl() -> Result<i64, FunctionError> {
+    let mut rng = File::open("/dev/urandom")?;
+    let mut buffer = [0u8; 8];
+    rng.read_exact(&mut buffer)?;
+    Ok(i64::from_be_bytes(buffer))
+}
+
+/// NASL function to get random number
+pub fn rand(_: &str, _: &dyn Sink, _: &Register) -> Result<NaslValue, FunctionError> {
+    random_impl().map(NaslValue::Number)
+}
+
+/// Returns found function for key or None when not found
+pub fn lookup(key: &str) -> Option<NaslFunction> {
+    match key {
+        "rand" => Some(rand),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nasl_syntax::parse;
+    use sink::DefaultSink;
+
+    use crate::{Interpreter, NaslValue, NoOpLoader, Register};
+
+    #[test]
+    fn rand() {
+        let code = r###"
+        rand();
+        rand();
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
+        let first = parser.next();
+        let second = parser.next();
+        assert!(matches!(first, Some(Ok(NaslValue::Number(_)))));
+        assert!(matches!(second, Some(Ok(NaslValue::Number(_)))));
+        assert_ne!(first, second);
+    }
+}

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -3,9 +3,9 @@
 use built_in_functions::description;
 mod error;
 use built_in_functions::hostname;
+use built_in_functions::rand;
 use error::FunctionError;
 
-mod lookup_keys;
 mod assign;
 mod built_in_functions;
 mod call;
@@ -14,6 +14,7 @@ mod declare;
 mod include;
 mod interpreter;
 mod loader;
+mod lookup_keys;
 mod loop_extension;
 mod operator;
 
@@ -27,7 +28,9 @@ use sink::{Sink, SinkError};
 // Is a type definition for built-in functions
 pub(crate) type NaslFunction = fn(&str, &dyn Sink, &Register) -> Result<NaslValue, FunctionError>;
 pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
-    description::lookup(function_name).or_else(|| hostname::lookup(function_name))
+    description::lookup(function_name)
+        .or_else(|| hostname::lookup(function_name))
+        .or_else(|| rand::lookup(function_name))
 }
 
 impl From<SinkError> for InterpretError {


### PR DESCRIPTION
Implements the NASL rand function. Currently it is only available in
unix and reads 8 bytes of `/dev/urandom` to gather a random i64 number.