### PR TITLE
Add: Implement NASL `chomp` function for Rust implementation

### DIFF
--- a/rust/nasl-interpreter/src/built_in_functions/string.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/string.rs
@@ -235,6 +235,19 @@ fn crap(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, Functio
     }
 }
 
+/// NASL function to remove trailing whitespaces from a string
+///
+/// Takes one required positional argument of string type.
+fn chomp(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
+    let positional = resolve_positional_arguments(register);
+    match positional.get(0) {
+        Some(NaslValue::String(x)) => Ok(NaslValue::String(x.trim_end().to_owned())),
+        _ => Err(FunctionError::new(
+            "expected positional argument of string type".to_owned(),
+        )),
+    }
+}
+
 /// Returns found function for key or None when not found
 pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
@@ -246,6 +259,7 @@ pub fn lookup(key: &str) -> Option<NaslFunction> {
         "string" => Some(string),
         "substr" => Some(substr),
         "crap" => Some(crap),
+        "chomp" => Some(chomp),
         _ => None,
     }
 }
@@ -394,5 +408,25 @@ mod tests {
         assert_eq!(parser.next(), Some(Ok("XXXXX".into())));
         assert_eq!(parser.next(), Some(Ok("XXXXX".into())));
         assert_eq!(parser.next(), Some(Ok("ababababab".into())));
+    }
+
+    #[test]
+    fn chomp() {
+        let code = r###"
+        chomp("abc");
+        chomp("abc\n");
+        chomp("abc  ");
+        chomp("abc\n\t\r ");
+        "###;
+        let storage = DefaultSink::new(false);
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
+        assert_eq!(parser.next(), Some(Ok("abc".into())));
+        assert_eq!(parser.next(), Some(Ok("abc".into())));
+        assert_eq!(parser.next(), Some(Ok("abc".into())));
+        assert_eq!(parser.next(), Some(Ok("abc".into())));
     }
 }


### PR DESCRIPTION
**What**:

Implement NASL `chomp` function for Rust implementation.

**Why**:

It is a built-in NASL function.

**How**:

Small unit test.

**Checklist**:

- [x] Tests
- [ ] PR merge commit message adjusted
