### PR TITLE
Change mandatory_keys handling, adjust cves, simplify redis-sink

### DIFF
--- a/rust/nasl-interpreter/src/built_in_functions/string.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/string.rs
@@ -289,7 +289,6 @@ fn stridx(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, Funct
 fn display(buf: &str, sink: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
     register
         .logger()
-        .as_ref()
         .print(string(buf, sink, register)?.to_string());
     Ok(NaslValue::Null)
 }
@@ -497,12 +496,12 @@ mod tests {
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
         let mut parser =
             parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
-        assert_eq!(parser.next(), Some(Ok((-1 as i64).into())));
-        assert_eq!(parser.next(), Some(Ok((1 as i64).into())));
-        assert_eq!(parser.next(), Some(Ok((0 as i64).into())));
-        assert_eq!(parser.next(), Some(Ok((0 as i64).into())));
-        assert_eq!(parser.next(), Some(Ok((1 as i64).into())));
-        assert_eq!(parser.next(), Some(Ok((-1 as i64).into())));
+        assert_eq!(parser.next(), Some(Ok((-1_i64).into())));
+        assert_eq!(parser.next(), Some(Ok(1_i64.into())));
+        assert_eq!(parser.next(), Some(Ok(0_i64.into())));
+        assert_eq!(parser.next(), Some(Ok(0_i64.into())));
+        assert_eq!(parser.next(), Some(Ok(1_i64.into())));
+        assert_eq!(parser.next(), Some(Ok((-1_i64).into())));
     }
 
     #[test]

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -22,6 +22,68 @@ pub enum ContextType {
     Value(NaslValue),
 }
 
+impl ToString for ContextType {
+    fn to_string(&self) -> String {
+        match self {
+            ContextType::Function(_, _) => "".to_owned(),
+            ContextType::Value(v) => v.to_string(),
+        }
+    }
+}
+
+impl From<NaslValue> for ContextType {
+    fn from(value: NaslValue) -> Self {
+        Self::Value(value)
+    }
+}
+
+impl From<Vec<u8>> for ContextType {
+    fn from(s: Vec<u8>) -> Self {
+        Self::Value(s.into())
+    }
+}
+
+impl From<bool> for ContextType {
+    fn from(b: bool) -> Self {
+        Self::Value(b.into())
+    }
+}
+
+impl From<&str> for ContextType {
+    fn from(s: &str) -> Self {
+        Self::Value(s.into())
+    }
+}
+
+impl From<String> for ContextType {
+    fn from(s: String) -> Self {
+        Self::Value(s.into())
+    }
+}
+
+impl From<i32> for ContextType {
+    fn from(n: i32) -> Self {
+        Self::Value(n.into())
+    }
+}
+
+impl From<i64> for ContextType {
+    fn from(n: i64) -> Self {
+        Self::Value(n.into())
+    }
+}
+
+impl From<usize> for ContextType {
+    fn from(n: usize) -> Self {
+        Self::Value(n.into())
+    }
+}
+
+impl From<HashMap<String, NaslValue>> for ContextType {
+    fn from(x: HashMap<String, NaslValue>) -> Self {
+        Self::Value(x.into())
+    }
+}
 /// Registers all NaslContext
 ///
 /// When creating a new context call a corresponding create method.
@@ -42,20 +104,25 @@ impl Register {
     }
 
     /// Creates a root Register based on the given initial values
-    pub fn root_initial(initial: Vec<(String, ContextType)>) -> Self {
+    pub fn root_initial(initial: &[(String, ContextType)]) -> Self {
+        let mut defined = HashMap::with_capacity(initial.len());
+        for (k, v) in initial {
+            defined.insert(k.to_owned(), v.to_owned());
+
+        }
         let root = NaslContext {
-            defined: initial.into_iter().collect(),
+            defined,
             ..Default::default()
         };
         Self {
             blocks: vec![root],
-            logger: Box::new(DefaultLogger::new()),
+            logger: Box::<DefaultLogger>::default(),
         }
     }
 
     /// Get the logger to print messages
-    pub fn logger(&self) -> &Box<dyn NaslLogger> {
-        &self.logger
+    pub fn logger(&self) -> &dyn NaslLogger {
+        &*self.logger
     }
 
     /// Set a new logger

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -9,7 +9,7 @@ use sink::SinkError;
 
 use crate::{ContextType, LoadError, NaslValue};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionErrorKind {
     MissingPositionalArguments { expected: usize, got: usize },
     MissingArguments(Vec<String>),
@@ -93,7 +93,7 @@ impl From<io::ErrorKind> for FunctionErrorKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionError {
     pub function: String,
     pub kind: FunctionErrorKind,
@@ -114,7 +114,7 @@ impl From<SinkError> for FunctionError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Is used to represent an error while interpreting
 pub struct InterpretError {
     /// Defined the type of error that occurred.
@@ -123,7 +123,8 @@ pub struct InterpretError {
     pub origin: Option<Statement>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Is used to give hints to the user how to react on an error while interpreting
 pub enum InterpretErrorKind {
     /// When returned context is a function when a value is required.
     FunctioExpectedValue,
@@ -136,7 +137,12 @@ pub enum InterpretErrorKind {
     /// Regex parsing went wrong.
     InvalidRegex(String),
     /// An SyntaxError while including another script
-    IncludeSyntaxError { filename: String, err: SyntaxError },
+    IncludeSyntaxError { 
+        /// The name of the file trying to include
+        filename: String, 
+        /// The syntactical error that occurred
+        err: SyntaxError 
+    },
     /// SyntaxError
     SyntaxError(SyntaxError),
     /// When the given key was not found in the context

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -32,6 +32,7 @@ mod operator;
 pub use context::ContextType;
 pub use context::Register;
 pub use error::InterpretError;
+pub use error::InterpretErrorKind;
 pub use interpreter::Interpreter;
 pub use loader::*;
 pub use logger::{DefaultLogger, Mode, NaslLogger};

--- a/rust/nasl-interpreter/src/logger.rs
+++ b/rust/nasl-interpreter/src/logger.rs
@@ -1,9 +1,11 @@
 /// Modes that are used by the default logger
 #[derive(PartialEq, PartialOrd)]
+#[derive(Default)]
 pub enum Mode {
     /// Debug Mode, enables all logging
     Debug = 0,
     /// Info Mode, enables Info, Warning and Error Messages
+    #[default]
     Info,
     /// Warning Mde, enables Warning and Error Messages
     Warning,
@@ -30,6 +32,7 @@ pub trait NaslLogger {
 /// basic mode system and color scheme for printing. The mode order is
 /// debug > info > warning > error > nothing. Printing normal messages is meant
 /// to be used by the display function therefore it cannot be disabled
+#[derive(Default)]
 pub struct DefaultLogger {
     mode: Mode,
 }

--- a/rust/nasl-interpreter/src/naslvalue.rs
+++ b/rust/nasl-interpreter/src/naslvalue.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use nasl_syntax::{IdentifierType, Token, TokenCategory, ACT};
 
@@ -31,6 +31,43 @@ pub enum NaslValue {
     Break,
     /// Exit value of the script
     Exit(i64),
+}
+
+impl Display for NaslValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NaslValue::String(x) => write!(f, "{x}"),
+            NaslValue::Number(x) => write!(f, "{x}"),
+            NaslValue::Array(x) => write!(
+                f,
+                "{}",
+                x.iter()
+                    .enumerate()
+                    .map(|(i, v)| format!("{}: {}", i, v))
+                    .collect::<Vec<String>>()
+                    .join(",")
+            ),
+            NaslValue::Data(x) => write!(f, "{}", x.iter().map(|x| *x as char).collect::<String>()),
+            NaslValue::Dict(x) => write!(
+                f,
+                "{}",
+                x.iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<String>>()
+                    .join(",")
+            ),
+            NaslValue::Boolean(true) => write!(f, "1"),
+            NaslValue::Boolean(false) => write!(f, "0"),
+            NaslValue::Null => write!(f, "\0"),
+            NaslValue::Exit(rc) => write!(f, "exit({})", rc),
+            NaslValue::AttackCategory(category) => {
+                write!(f, "{}", IdentifierType::ACT(*category).to_string())
+            }
+            NaslValue::Return(rc) => write!(f, "return({:?})", *rc),
+            NaslValue::Continue => write!(f, "continue"),
+            NaslValue::Break => write!(f, "break"),
+        }
+    }
 }
 
 impl From<Vec<u8>> for NaslValue {
@@ -78,34 +115,6 @@ impl From<usize> for NaslValue {
 impl From<HashMap<String, NaslValue>> for NaslValue {
     fn from(x: HashMap<String, NaslValue>) -> Self {
         NaslValue::Dict(x)
-    }
-}
-
-impl ToString for NaslValue {
-    fn to_string(&self) -> String {
-        match self {
-            NaslValue::String(x) => x.to_owned(),
-            NaslValue::Number(x) => x.to_string(),
-            NaslValue::Array(x) => x
-                .iter()
-                .enumerate()
-                .map(|(i, v)| format!("{}: {}", i, v.to_string()))
-                .collect::<Vec<String>>()
-                .join(","),
-            NaslValue::Data(x) => x.iter().map(|x| *x as char).collect(),
-            NaslValue::Dict(x) => x
-                .iter()
-                .map(|(k, v)| format!("{}: {}", k, v.to_string()))
-                .collect::<Vec<String>>()
-                .join(","),
-            NaslValue::Boolean(x) => x.to_string(),
-            NaslValue::Null => "\0".to_owned(),
-            NaslValue::Exit(rc) => format!("exit({})", rc),
-            NaslValue::AttackCategory(category) => IdentifierType::ACT(*category).to_string(),
-            NaslValue::Return(rc) => format!("return({:?})", *rc),
-            NaslValue::Continue => "".to_string(),
-            NaslValue::Break => "".to_string(),
-        }
     }
 }
 

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -60,7 +60,7 @@ if(description)
         let storage = DefaultSink::new(true);
         let loader = NoOpLoader::default();
         let key = "test.nasl";
-        let initial = vec![(
+        let initial = [(
             "description".to_owned(),
             ContextType::Value(NaslValue::Number(1)),
         )];
@@ -70,7 +70,7 @@ if(description)
                 sink::Dispatch::NVT(sink::nvt::NVTField::FileName(key.to_owned())),
             )
             .expect("storage should work");
-        let mut register = Register::root_initial(initial);
+        let mut register = Register::root_initial(&initial);
         let mut interpreter = Interpreter::new(key, &storage, &loader, &mut register);
         let results = parse(code)
             .map(|stmt| match stmt {
@@ -106,11 +106,11 @@ if(description)
                     "22".to_owned()
                 ])),
                 NVT(MandatoryKeys(vec!["ssh/blubb/detected".to_owned()])),
-                NVT(Reference(NvtRef {
+                NVT(Reference(vec![NvtRef {
                     class: "http://freshmeat.sourceforge.net/projects/eventh/".to_owned(),
                     id: "URL".to_owned(),
                     text: None
-                })),
+                }])),
                 NVT(ExcludedKeys(vec![
                     "Settings/disable_cgi_scanning".to_owned(),
                     "bla/bla".to_owned()
@@ -119,11 +119,11 @@ if(description)
                     "Services/udp/unknown".to_owned(),
                     "17".to_owned()
                 ])),
-                NVT(Reference(NvtRef {
+                NVT(Reference(vec![NvtRef {
                     class: "cve".to_owned(),
                     id: "CVE-1999-0524".to_owned(),
                     text: None
-                })),
+                }])),
                 NVT(RequiredKeys(vec!["WMI/Apache/RootPath".to_owned()])),
                 NVT(Preference(NvtPreference {
                     id: Some(2),

--- a/rust/nasl-syntax/src/error.rs
+++ b/rust/nasl-syntax/src/error.rs
@@ -169,13 +169,13 @@ impl fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             // TODO fix statement print
-            ErrorKind::UnexpectedToken(token) => write!(f, "unexpected token: {:?}", token),
-            ErrorKind::UnclosedToken(token) => write!(f, "unclosed token: {:?}", token),
-            ErrorKind::UnexpectedStatement(stmt) => write!(f, "unexpected statement: {:?}", stmt),
-            ErrorKind::UnclosedStatement(stmt) => write!(f, "unclosed statement: {:?}", stmt),
-            ErrorKind::MissingSemicolon(stmt) => write!(f, "missing semicolon: {:?}", stmt),
+            ErrorKind::UnexpectedToken(token) => write!(f, "unexpected token: {token:?}"),
+            ErrorKind::UnclosedToken(token) => write!(f, "unclosed token: {token:?}"),
+            ErrorKind::UnexpectedStatement(stmt) => write!(f, "unexpected statement: {stmt:?}"),
+            ErrorKind::UnclosedStatement(stmt) => write!(f, "unclosed statement: {stmt:?}"),
+            ErrorKind::MissingSemicolon(stmt) => write!(f, "missing semicolon: {stmt:?}"),
             ErrorKind::EoF => write!(f, "end of file."),
-            ErrorKind::IOError(kind) => write!(f, "IOError: {}", kind),
+            ErrorKind::IOError(kind) => write!(f, "IOError: {kind}"),
         }
     }
 }
@@ -214,7 +214,7 @@ mod tests {
             Ok(_) => panic!("expected test to return Err"),
             Err(e) => match e.kind {
                 ErrorKind::MissingSemicolon(_) => {}
-                _ => panic!("Expected MissingSemicolon but got: {:?}", e),
+                _ => panic!("Expected MissingSemicolon but got: {e:?}"),
             },
         }
     }
@@ -227,7 +227,7 @@ mod tests {
                 ErrorKind::UnclosedToken(token) => {
                     assert_eq!(token.category(), &category);
                 }
-                _ => panic!("Expected UnclosedToken but got: {:?} for {}", e, code),
+                _ => panic!("Expected UnclosedToken but got: {e:?} for {code}"),
             },
         }
     }

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -524,7 +524,7 @@ mod test {
         for call in test_cases {
             assert!(
                 matches!(
-                    parse(&format!("{};", call)).next().unwrap().unwrap(),
+                    parse(&format!("{call};")).next().unwrap().unwrap(),
                     Exit(_),
                 ),
                 "{}",
@@ -545,7 +545,7 @@ mod test {
         for call in test_cases {
             assert!(
                 matches!(
-                    parse(&format!("{};", call)).next().unwrap().unwrap(),
+                    parse(&format!("{call};")).next().unwrap().unwrap(),
                     Return(_),
                 ),
                 "{}",
@@ -584,7 +584,7 @@ mod test {
         for call in test_cases {
             assert!(
                 matches!(
-                    parse(&format!("{};", call)).next().unwrap().unwrap(),
+                    parse(&format!("{call};")).next().unwrap().unwrap(),
                     ForEach(_, _, _),
                 ),
                 "{}",

--- a/rust/redis-sink/src/dberror.rs
+++ b/rust/redis-sink/src/dberror.rs
@@ -26,13 +26,13 @@ pub enum DbError {
     /// Redis is currently not able to handle request and the caller needs to retry it
     Retry(String),
     /// Cannot find a DB to use; redis must be cleaned up to free available slots.
-    NoAvailDbErr(String),
+    NoAvailDbErr,
 }
 
 impl fmt::Display for DbError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DbError::NoAvailDbErr(e) => write!(f, "No DB available: {}", e),
+            DbError::NoAvailDbErr => write!(f, "No DB available"),
             DbError::ConfigurationError(e) => {
                 write!(f, "Unable to use redis due to wrong configuration: {}", e)
             }
@@ -77,7 +77,7 @@ impl From<DbError> for SinkError {
             DbError::Unknown(_)
             | DbError::ConfigurationError(_)
             | DbError::SystemError(_)
-            | DbError::NoAvailDbErr(_) => SinkError::Dirty(err.to_string()),
+            | DbError::NoAvailDbErr => SinkError::Dirty(err.to_string()),
             DbError::ConnectionLost(_) => SinkError::ConnectionLost(err.to_string()),
             DbError::Retry(_) => SinkError::Retry(err.to_string()),
             DbError::LibraryError(_) => SinkError::UnexpectedData(err.to_string()),

--- a/rust/redis-sink/src/nvt.rs
+++ b/rust/redis-sink/src/nvt.rs
@@ -39,25 +39,6 @@ pub fn parse_nvt_timestamp(str_time: &str) -> TimeT {
     ret
 }
 
-/// Structure to store NVT Severities
-// Severities are stored in redis under the Tag item
-// Currently not used
-#[derive(Clone, Debug)]
-#[allow(dead_code)]
-pub struct NvtSeverity {
-    /// Severity type ("cvss_base_v2", ...)
-    severity_type: String,
-    /// Optional: Where does the severity come from
-    /// ("CVE-2018-1234", "Greenbone Research")
-    origin: String,
-    /// Timestamp in seconds since epoch, defaults to VT creation date.
-    date: i32,
-    /// The score derived from the value in range [0.0-10.0]
-    score: f32,
-    /// The value which corresponds to the type.
-    value: String,
-}
-
 #[derive(Clone, Debug)]
 /// Structure to hold a NVT
 pub struct Nvt {
@@ -65,20 +46,6 @@ pub struct Nvt {
     name: String,
     filename: String,
     tag: Vec<(String, String)>,
-    cvss_base: String,            //Stored in redis under Tag item. Not in use.
-    summary: String,              //Stored in redis under Tag item. Not in use.
-    insight: String,              //Stored in redis under Tag item. Not in use.
-    affected: String,             //Stored in redis under Tag item. Not in use.
-    impact: String,               //Stored in redis under Tag item. Not in use.
-    creation_time: TimeT,         //Stored in redis under Tag item. Not in use.
-    modification_time: TimeT,     //Stored in redis under Tag item. Not in use.
-    solution: String,             //Stored in redis under Tag item. Not in use.
-    solution_type: String,        //Stored in redis under Tag item. Not in use.
-    solution_method: String,      //Stored in redis under Tag item. Not in use.
-    detection: String,            //Stored in redis under Tag item. Not in use.
-    qod_type: String,             //Stored in redis under Tag item. Not in use.
-    qod: String,                  //Stored in redis under Tag item. Not in use.
-    severities: Vec<NvtSeverity>, //Stored in redis under Tag item. Not in use.
     dependencies: Vec<String>,
     required_keys: Vec<String>,
     mandatory_keys: Vec<String>,
@@ -97,28 +64,14 @@ impl Default for Nvt {
             oid: String::new(),
             name: String::new(),
             filename: String::new(),
-            summary: String::new(),
-            insight: String::new(),
-            affected: String::new(),
-            impact: String::new(),
-            creation_time: 0,
-            modification_time: 0,
-            solution: String::new(),
-            solution_type: String::new(),
-            solution_method: String::new(),
             tag: vec![],
-            cvss_base: String::new(),
             dependencies: vec![],
             required_keys: vec![],
             mandatory_keys: vec![],
             excluded_keys: vec![],
             required_ports: vec![],
             required_udp_ports: vec![],
-            detection: String::new(),
-            qod_type: String::new(),
-            qod: String::new(),
             refs: vec![],
-            severities: vec![],
             prefs: vec![],
             category: ACT::End,
             family: String::new(),
@@ -142,68 +95,9 @@ impl Nvt {
         self.name = name;
     }
 
-    /// Set the NVT summary
-    // Not used during plugin upload.
-    pub fn set_summary(&mut self, summary: String) {
-        self.summary = summary;
-    }
-
-    /// Set the NVT insight
-    // Not used during plugin upload.
-    pub fn set_insight(&mut self, insight: String) {
-        self.insight = insight;
-    }
-
-    /// Set the NVT affected
-    // Not used during plugin upload.
-    pub fn set_affected(&mut self, affected: String) {
-        self.affected = affected;
-    }
-
-    /// Set the NVT impact
-    // Not used during plugin upload.
-    pub fn set_impact(&mut self, impact: String) {
-        self.impact = impact;
-    }
-
-    /// Set the NVT creation_time
-    // Not used during plugin upload.
-    pub fn set_creation_time(&mut self, creation_time: TimeT) {
-        self.creation_time = creation_time;
-    }
-
-    /// Set the NVT modification_time
-    // Not used during plugin upload.
-    pub fn set_modification_time(&mut self, modification_time: TimeT) {
-        self.modification_time = modification_time;
-    }
-    /// Set the NVT solution
-    // Not used during plugin upload.
-    pub fn set_solution(&mut self, solution: String) {
-        self.solution = solution;
-    }
-
-    /// Set the NVT solution_type
-    // Not used during plugin upload.
-    pub fn set_solution_type(&mut self, solution_type: String) {
-        self.solution_type = solution_type;
-    }
-
-    /// Set the NVT solution method
-    // Not used during plugin upload.
-    pub fn set_solution_method(&mut self, solution_method: String) {
-        self.solution_method = solution_method;
-    }
-
     /// Set the NVT tag
     pub fn set_tag(&mut self, tag: Vec<(String, String)>) {
         self.tag = tag;
-    }
-
-    /// Set the NVT CVSS base
-    // Not used during plugin upload.
-    pub fn set_cvss_base(&mut self, cvss_base: String) {
-        self.cvss_base = cvss_base;
     }
 
     /// Set the NVT dependencies
@@ -234,24 +128,6 @@ impl Nvt {
     /// Set the NVT required udp ports
     pub fn set_required_udp_ports(&mut self, required_udp_ports: Vec<String>) {
         self.required_udp_ports = required_udp_ports;
-    }
-
-    /// Set the NVT detection
-    // Not used during plugin upload.
-    pub fn set_detection(&mut self, detection: String) {
-        self.detection = detection;
-    }
-
-    /// Set the NVT QoD Type
-    // Not used during plugin upload.
-    pub fn set_qod_type(&mut self, qod_type: String) {
-        self.qod_type = qod_type;
-    }
-
-    /// Set the NVT QoD (Quality of Detection)
-    // Not used during plugin upload.
-    pub fn set_qod(&mut self, qod: String) {
-        self.qod = qod;
     }
 
     /// Set the NVT category. Check that category is a valid Category
@@ -302,14 +178,6 @@ impl Nvt {
         self.refs.push(nvtref);
     }
 
-    /// Function to add a new severity to the Nvt
-    // Not used during plugin upload.
-    pub fn add_severity(&mut self, severity: NvtSeverity) {
-        self.severities.push(severity);
-    }
-
-    //   GET FUNCTIONS
-
     /// Get the NVT OID
     pub fn oid(&self) -> &str {
         &self.oid
@@ -320,69 +188,10 @@ impl Nvt {
         &self.name
     }
 
-    /// Get the NVT summary
-    // Not used during plugin upload.
-    pub fn summary(&self) -> &str {
-        &self.summary
-    }
-
-    /// Get the NVT insight
-    // Not used during plugin upload.
-    pub fn insight(&self) -> &str {
-        &self.insight
-    }
-
-    /// Get the NVT affected
-    // Not used during plugin upload.
-    pub fn affected(&self) -> &str {
-        &self.affected
-    }
-
-    /// Get the NVT impact
-    // Not used during plugin upload.
-    pub fn impact(&self) -> &str {
-        &self.impact
-    }
-
-    /// Get the NVT creation_time
-    // Not used during plugin upload.
-    pub fn creation_time(&mut self) -> RedisSinkResult<TimeT> {
-        Ok(self.creation_time)
-    }
-
-    /// Get the NVT modification_time
-    // Not used during plugin upload.
-    pub fn modification_time(&mut self) -> RedisSinkResult<TimeT> {
-        Ok(self.modification_time)
-    }
-    /// Get the NVT solution
-    // Not used during plugin upload.
-    pub fn solution(&self) -> &str {
-        &self.solution
-    }
-
-    /// Get the NVT solution_type
-    // Not used during plugin upload.
-    pub fn solution_type(&self) -> &str {
-        &self.solution_type
-    }
-
-    /// Get the NVT solution method
-    // Not used during plugin upload.
-    pub fn solution_method(&self) -> &str {
-        &self.solution_method
-    }
-
-    /// Get the NVT tag
-    pub fn tag(&self) -> &Vec<(String, String)> {
+    pub fn tag(&self) -> &[(String, String)] {
         &self.tag
     }
 
-    /// Get the NVT CVSS base
-    // Not used during plugin upload.
-    pub fn cvss_base(&self) -> &str {
-        &self.cvss_base
-    }
     /// Get the NVT dependencies
     pub fn dependencies(&self) -> &Vec<String> {
         &self.dependencies
@@ -411,24 +220,6 @@ impl Nvt {
     /// Get the NVT required udp ports
     pub fn required_udp_ports(&self) -> &Vec<String> {
         &self.required_udp_ports
-    }
-
-    /// Get the NVT detection
-    // Not used during plugin upload.
-    pub fn detection(&self) -> &str {
-        &self.detection
-    }
-
-    /// Get the NVT QoD Type
-    // Not used during plugin upload.
-    pub fn qod_type(&self) -> &str {
-        &self.qod_type
-    }
-
-    /// Get the NVT QoD (Quality of Detection)
-    // Not used during plugin upload.
-    pub fn qod(&self) -> &str {
-        &self.qod
     }
 
     /// Get the NVT category.
@@ -467,7 +258,7 @@ impl Nvt {
                         }
                         _ => {
                             let mut new_xref: Vec<String> = xrefs;
-                            new_xref.push(format!("{}:{}", b.class(), b.id()));
+                            new_xref.push(format!("{}:{}", b.id(), b.class()));
                             (bids, cves, new_xref)
                         }
                     }
@@ -476,6 +267,7 @@ impl Nvt {
         // Some references include a comma. Therefore the refs separator is ", ".
         // The string ", " is not accepted as reference value, since it will misunderstood
         // as ref separator.
+
         return (
             cves.iter().as_ref().join(", "),
             bids.iter().as_ref().join(", "),
@@ -485,18 +277,21 @@ impl Nvt {
 
     /// Transforms prefs to string representation {id}:{name}:{id}:{default} so that it can be stored into redis
     pub fn prefs(&self) -> Vec<String> {
-        self.prefs
+        let mut prefs = self.prefs.clone();
+        prefs.sort_by(|a, b| b.id.unwrap_or_default().cmp(&a.id.unwrap_or_default()));
+        let results: Vec<String> = prefs
             .iter()
             .map(|pref| {
                 format!(
-                    "{}:{}:{}:{}",
+                    "{}|||{}|||{}|||{}",
                     pref.id().unwrap_or_default(),
                     pref.name(),
                     pref.class().as_ref(),
                     pref.default()
                 )
             })
-            .collect()
+            .collect();
+        results
     }
 
     pub fn set_filename(&mut self, filename: String) {

--- a/rust/redis-sink/tests/nvt_tests.rs
+++ b/rust/redis-sink/tests/nvt_tests.rs
@@ -38,17 +38,17 @@ mod test {
     #[test]
     fn test_timestamp_converter() {
         let t = "2011-08-09 08:20:34 +0200 (Tue, 09 Aug 2011)";
-        assert_eq!(parse_nvt_timestamp(&t), 1312870834);
+        assert_eq!(parse_nvt_timestamp(t), 1312870834);
 
         let t = "$Date: 2012-02-17 16:05:26 +0100 (Fr, 17. Feb 2012) $";
-        assert_eq!(parse_nvt_timestamp(&t), 1329491126);
+        assert_eq!(parse_nvt_timestamp(t), 1329491126);
 
         let t = "$Date: Fri, 11 Nov 2011 14:42:28 +0100 $";
-        assert_eq!(parse_nvt_timestamp(&t), 1321018948);
+        assert_eq!(parse_nvt_timestamp(t), 1321018948);
 
         //Space left at the end. Fails and 0
         let t = "$Date: Fri, 11 Nov 2011 14:42:28 +0100 ";
-        assert_eq!(parse_nvt_timestamp(&t), 0);
+        assert_eq!(parse_nvt_timestamp(t), 0);
     }
 
     #[test]
@@ -113,7 +113,7 @@ mod test {
         nvt.add_ref(xrefs2);
         let xrefs;
         (_, _, xrefs) = nvt.refs();
-        assert_eq!(xrefs, "URL:http://greenbone.net, URL:http://openvas.net");
+        assert_eq!(xrefs, "http://greenbone.net:URL, http://openvas.net:URL");
 
         Ok(())
     }

--- a/rust/sink/src/lib.rs
+++ b/rust/sink/src/lib.rs
@@ -22,6 +22,12 @@ pub enum Dispatch {
     NVT(NVTField),
 }
 
+impl From<NVTField> for Dispatch {
+    fn from(value: NVTField) -> Self {
+        Self::NVT(value)
+    }
+}
+
 /// Retrieve command for a given Field
 ///
 /// Defines what kind of information needs to be gathered.
@@ -53,10 +59,10 @@ pub enum SinkError {
 impl Display for SinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SinkError::Retry(p) => write!(f, "There was a temporary issue while reading {}.", p),
-            SinkError::ConnectionLost(p) => write!(f, "Connection lost {}.", p),
-            SinkError::UnexpectedData(p) => write!(f, "Unexpected data {}", p),
-            SinkError::Dirty(p) => write!(f, "Unexpected issue {}", p),
+            SinkError::Retry(p) => write!(f, "There was a temporary issue while reading {p}."),
+            SinkError::ConnectionLost(p) => write!(f, "Connection lost {p}."),
+            SinkError::UnexpectedData(p) => write!(f, "Unexpected data {p}"),
+            SinkError::Dirty(p) => write!(f, "Unexpected issue {p}"),
         }
     }
 }

--- a/rust/sink/src/nvt.rs
+++ b/rust/sink/src/nvt.rs
@@ -222,7 +222,7 @@ Those ports must be found and open. Otherwise it will be skipped."### =>
     r###"Preferences that can be set by a User"### =>
     Preference(NvtPreference),
     r###"Reference either cve, bid, ..."### =>
-    Reference(NvtRef),
+    Reference(Vec<NvtRef>),
     r###"Category of a plugin
 
 Category will be used to identify the type of the NASL plugin."### =>
@@ -257,6 +257,27 @@ pub struct NvtRef {
     pub text: Option<String>,
 }
 
+impl From<(&str, &str)> for NvtRef {
+    fn from(value: (&str, &str)) -> Self {
+        let (class, id) = value;
+        Self {
+            class: class.to_owned(),
+            id: id.to_owned(),
+            text: None,
+        }
+    }
+}
+
+impl From<(&str, String)> for NvtRef {
+    fn from(value: (&str, String)) -> Self {
+        let (class, id) = value;
+        Self {
+            class: class.to_owned(),
+            id,
+            text: None,
+        }
+    }
+}
 impl NvtRef {
     pub fn new(class: String, id: String, text: Option<String>) -> Self {
         Self { class, id, text }


### PR DESCRIPTION
Adjust CVES to store all CVEs instead of just the first, changing
mandatory keys to not contain double fields that are matched by the re:
field.

Add a Redis Namespace selector

Since the tag handling is already handled we remove the functional split
methods of nvt inside redis-sink.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
