### PR TITLE
rs refactor nasl cli

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -215,6 +215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "configparser"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5458d9d1a587efaf5091602c59d299696a3877a439c8f6d461a2d3cce11df87a"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -567,7 +573,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi 0.3.0",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -680,7 +686,11 @@ name = "nasl-cli"
 version = "0.1.0"
 dependencies = [
  "clap 4.1.4",
+ "configparser",
+ "nasl-interpreter",
  "nasl-syntax",
+ "redis-sink",
+ "sink",
  "walkdir",
 ]
 
@@ -968,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",

--- a/rust/nasl-cli/Cargo.toml
+++ b/rust/nasl-cli/Cargo.toml
@@ -7,7 +7,15 @@ license = "GPL-2.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# argument parsing
 clap = { version = "~4", features = ["derive"] }
-nasl-syntax = { path = "../nasl-syntax" }
+# read openvas conifuration; until we use own toml file
+configparser = "3"
+# recursively walk through a dir
 walkdir = "2"
+
+nasl-syntax = { path = "../nasl-syntax" }
+nasl-interpreter = { path = "../nasl-interpreter" }
+sink = { path = "../sink" }
+redis-sink = { path = "../redis-sink" }
 

--- a/rust/nasl-cli/README.md
+++ b/rust/nasl-cli/README.md
@@ -1,0 +1,17 @@
+# nasl-cli
+
+Is a program to use the rust nasl impelmentation.
+
+
+Usage: nasl-cli <COMMAND>
+
+Commands:
+- `syntax`  Checks nasl-file or a directory of for syntax errors
+- `feed`    Controls the feed
+  - `update`  Updates feed data into redis
+- `help`    Print this message or the help of the given subcommand(s)
+
+Options:
+- `-h, --help`     Print help information
+-  `-V, --version`  Print version information
+

--- a/rust/nasl-cli/README.md
+++ b/rust/nasl-cli/README.md
@@ -1,6 +1,6 @@
 # nasl-cli
 
-Is a program to use the rust nasl impelmentation.
+Is a program to use the rust nasl implementation.
 
 
 Usage: nasl-cli <COMMAND>

--- a/rust/nasl-cli/src/error.rs
+++ b/rust/nasl-cli/src/error.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+use nasl_interpreter::{InterpretError, LoadError};
+use nasl_syntax::SyntaxError;
+use sink::SinkError;
+
+#[derive(Debug, Clone)]
+pub enum CliErrorKind {
+    WrongAction,
+
+    PluginPathIsNotADir(PathBuf),
+    Openvas {
+        args: Option<String>,
+        err_msg: String,
+    },
+    NoExitCall(String),
+    InterpretError(InterpretError),
+    LoadError(LoadError),
+    SinkError(SinkError),
+    SyntaxError(SyntaxError),
+}
+
+#[derive(Debug, Clone)]
+pub struct CliError {
+    pub filename: String,
+    pub kind: CliErrorKind,
+}
+
+impl From<LoadError> for CliErrorKind {
+    fn from(value: LoadError) -> Self {
+        Self::LoadError(value)
+    }
+}
+
+impl From<InterpretError> for CliErrorKind {
+    fn from(value: InterpretError) -> Self {
+        Self::InterpretError(value)
+    }
+}
+
+impl From<SinkError> for CliErrorKind {
+    fn from(value: SinkError) -> Self {
+        Self::SinkError(value)
+    }
+}
+
+impl From<SyntaxError> for CliErrorKind {
+    fn from(value: SyntaxError) -> Self {
+        Self::SyntaxError(value)
+    }
+}

--- a/rust/nasl-cli/src/feed_update.rs
+++ b/rust/nasl-cli/src/feed_update.rs
@@ -1,0 +1,192 @@
+use std::{
+    io,
+    path::{Path, PathBuf},
+    time::Instant,
+};
+
+use nasl_interpreter::{
+    ContextType, FSPluginLoader, InterpretError, InterpretErrorKind, Interpreter, LoadError,
+    Loader, NaslValue, Register,
+};
+use nasl_syntax::Statement;
+use sink::{nvt::NVTField, Sink, SinkError};
+use walkdir::WalkDir;
+
+use crate::{CliError, CliErrorKind};
+
+fn retry_dispatch(sink: &dyn Sink, key: &str, dispatch: sink::Dispatch) -> Result<(), SinkError> {
+    match sink.dispatch(key, dispatch.clone()) {
+        Ok(_) => Ok(()),
+        Err(SinkError::Retry(_)) => retry_dispatch(sink, key, dispatch),
+        Err(e) => Err(e),
+    }
+}
+
+fn retry_interpret(
+    interpreter: &mut Interpreter,
+    stmt: &Statement,
+) -> Result<NaslValue, InterpretError> {
+    match interpreter.resolve(stmt) {
+        Ok(x) => Ok(x),
+        Err(e) => match e.kind {
+            InterpretErrorKind::LoadError(LoadError::Retry(_))
+            | InterpretErrorKind::IOError(io::ErrorKind::Interrupted)
+            | InterpretErrorKind::SinkError(SinkError::Retry(_)) => {
+                retry_interpret(interpreter, stmt)
+            }
+            _ => Err(e),
+        },
+    }
+}
+
+fn run_single(
+    verbose: bool,
+    root_dir_len: usize,
+    initial: &[(String, ContextType)],
+    entry: &Path,
+    storage: &dyn Sink,
+    loader: &dyn Loader,
+) -> Result<(), CliErrorKind> {
+    let code = FSPluginLoader::load_non_utf8_path(entry)?;
+    let mut register = Register::root_initial(initial);
+
+    // the key is the filename without the root dir and is used to set the filename
+    // when script_oid is called in the redis sink implementation
+    let key = entry.to_str().unwrap_or_default();
+    let key = &key[root_dir_len..];
+
+    let mut interpreter = Interpreter::new(key, storage, loader, &mut register);
+    if verbose {
+        print!("{key};");
+        let start = Instant::now();
+        let result = execute_description_run(&mut interpreter, storage, &code, key)?;
+        let elapsed = start.elapsed();
+        println!("{result};{elapsed:?}");
+    } else {
+        execute_description_run(&mut interpreter, storage, &code, key)?;
+    }
+    Ok(())
+}
+
+fn load_code(loader: &dyn Loader, key: &str) -> Result<String, CliError> {
+    loader
+        .load(key)
+        .map_err(|e| e.into())
+        .map_err(|kind| CliError {
+            kind,
+            filename: key.to_owned(),
+        })
+}
+
+fn add_feed_version_to_storage(loader: &dyn Loader, storage: &dyn Sink) -> Result<(), CliError> {
+    let code = load_code(loader, "plugin_feed_info.inc")?;
+    let mut register = Register::default();
+    let mut interpreter = Interpreter::new("inc", storage, loader, &mut register);
+    for stmt in nasl_syntax::parse(&code) {
+        match stmt {
+            Ok(stmt) => retry_interpret(&mut interpreter, &stmt)
+                .map_err(|e| e.into())
+                .map_err(|kind| CliError {
+                    kind,
+                    filename: "plugin_feed_info.inc".to_owned(),
+                })?,
+            Err(e) => {
+                return Err(CliError {
+                    kind: e.into(),
+                    filename: "plugin_feed_info.inc".to_owned(),
+                })
+            }
+        };
+    }
+    let feed_version = register
+        .named("PLUGIN_SET")
+        .map(|x| x.to_string())
+        .unwrap_or_else(|| "0".to_owned());
+    retry_dispatch(storage, "generic", NVTField::Version(feed_version).into()).map_err(|e| {
+        CliError {
+            filename: "plugin_feed_info.inc".to_owned(),
+            kind: e.into(),
+        }
+    })
+}
+
+pub fn run(storage: &dyn Sink, path: PathBuf, verbose: bool) -> Result<(), CliError> {
+    if verbose {
+        println!("description run syntax in {path:?}.");
+    }
+    let initial = [
+        ("description".to_owned(), true.into()),
+        ("OPENVAS_VERSION".to_owned(), "1".into()),
+    ];
+    let root_dir = path.clone();
+    let loader: FSPluginLoader =
+        root_dir
+            .as_path()
+            .try_into()
+            .map_err(|e: LoadError| CliError {
+                kind: e.into(),
+                filename: root_dir.to_str().unwrap_or_default().to_owned(),
+            })?;
+    // we use the length of the root_dir to remove it from the used key
+    let root_dir_len = root_dir
+        .to_str()
+        .map(|x| {
+            // if the path does not end with '/' than add +1 to remove it from the relative path
+            if !x.ends_with('/') {
+                x.len() + 1
+            } else {
+                x.len()
+            }
+        })
+        .unwrap_or_default();
+
+    // load feed version
+    add_feed_version_to_storage(&loader, storage)?;
+
+    for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+        let ext = {
+            if let Some(ext) = entry.path().extension() {
+                ext.to_str().unwrap().to_owned()
+            } else {
+                "".to_owned()
+            }
+        };
+        if matches!(ext.as_str(), "nasl") {
+            run_single(
+                verbose,
+                root_dir_len,
+                &initial,
+                entry.path(),
+                storage,
+                &loader,
+            )
+            .map_err(|kind| CliError {
+                filename: entry.path().to_str().unwrap_or_default().to_owned(),
+                kind,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn execute_description_run(
+    interpreter: &mut Interpreter,
+    storage: &dyn Sink,
+    code: &str,
+    key: &str,
+) -> Result<NaslValue, CliErrorKind> {
+    for stmt in nasl_syntax::parse(code) {
+        match retry_interpret(interpreter, &stmt?) {
+            Ok(NaslValue::Exit(i)) => {
+                storage.on_exit()?;
+                return Ok(NaslValue::Exit(i));
+            }
+            Ok(_) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    // each description run must end with exit call.
+    // otherwise the whole nasl plugin will be executed
+    // that's why we escalate on those cases.
+    Err(CliErrorKind::NoExitCall(key.to_owned()))
+}

--- a/rust/nasl-cli/src/main.rs
+++ b/rust/nasl-cli/src/main.rs
@@ -50,14 +50,14 @@ enum FeedAction {
         ///
         /// It must be the complete redis address in either the form of a unix socket or tcp.
         /// For tcp provide the address in the form of: `redis://host:port`.
-        /// For unix sockket provide the path to the socket in the form of: `unix://path/to/redis.sock`.
+        /// For unix socket provide the path to the socket in the form of: `unix://path/to/redis.sock`.
         /// When not provided the DefaultSink will be used instead.
-        /// When it is skipped it will be optained via `openvas -s`
+        /// When it is skipped it will be obtained via `openvas -s`
         #[arg(short, long)]
         redis: Option<String>,
         /// The path to the NASL plugins.
         ///
-        /// When it is skipped it will be optained via `openvas -s`
+        /// When it is skipped it will be obtained via `openvas -s`
         #[arg(short, long)]
         path: Option<PathBuf>,
     },

--- a/rust/nasl-cli/src/main.rs
+++ b/rust/nasl-cli/src/main.rs
@@ -1,15 +1,17 @@
 // Copyright (C) 2023 Greenbone Networks GmbH
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
-
-use std::{
-    fs, io,
-    path::{Path, PathBuf},
-};
+mod error;
+mod feed_update;
+mod syntax_check;
 
 use clap::{Parser, Subcommand};
-use nasl_syntax::{Statement, SyntaxError};
-use walkdir::WalkDir;
+use configparser::ini::Ini;
+pub use error::*;
+
+use redis_sink::connector::RedisCache;
+use sink::SinkError;
+use std::{path::PathBuf, process};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -20,98 +22,164 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Subcommand to print the raw statements of a file.
-    ///
-    /// It is mostly for debug purposes and verification if the nasl-syntax-parser is working as expected.
+    /// Checks nasl-file or a directory of for syntax errors.
     Syntax {
         /// The path for the file or dir to parse
         #[arg(short, long)]
         path: PathBuf,
-        /// prints the parsed statements
+        /// Prints all parsed statements instead of just errors
         #[arg(short, long, default_value_t = false)]
         verbose: bool,
     },
+    /// Controls the feed
+    Feed {
+        /// Prints the interpret filename and elapsed time for each
+        #[arg(short, long, default_value_t = false)]
+        verbose: bool,
+        /// The action to perform on a feed
+        #[command(subcommand)]
+        action: FeedAction,
+    },
 }
 
-fn load_file<P: AsRef<Path>>(path: P) -> Result<String, io::Error> {
-    // unfortunately NASL is not UTF-8 so we need to map it manually
-    fs::read(path).map(|bs| bs.iter().map(|&b| b as char).collect())
+#[derive(clap::Subcommand, Debug, Clone)]
+enum FeedAction {
+    /// Updates feed data into redis.
+    Update {
+        /// Redis address inform of tcp (redis://) or unix socket (unix://).
+        ///
+        /// It must be the complete redis address in either the form of a unix socket or tcp.
+        /// For tcp provide the address in the form of: `redis://host:port`.
+        /// For unix sockket provide the path to the socket in the form of: `unix://path/to/redis.sock`.
+        /// When not provided the DefaultSink will be used instead.
+        /// When it is skipped it will be optained via `openvas -s`
+        #[arg(short, long)]
+        redis: Option<String>,
+        /// The path to the NASL plugins.
+        ///
+        /// When it is skipped it will be optained via `openvas -s`
+        #[arg(short, long)]
+        path: Option<PathBuf>,
+    },
 }
 
-fn read_errors<P: AsRef<Path>>(path: P) -> Result<Vec<SyntaxError>, SyntaxError> {
-    let code = load_file(path)?;
-    Ok(nasl_syntax::parse(&code)
-        .filter_map(|r| match r {
-            Ok(_) => None,
-            Err(err) => Some(err),
-        })
-        .collect())
+trait RunAction<T> {
+    type Error;
+    fn run(&self, verbose: bool) -> Result<T, Self::Error>;
 }
 
-fn read<P: AsRef<Path>>(path: P) -> Result<Vec<Result<Statement, SyntaxError>>, SyntaxError> {
-    let code = load_file(path)?;
-    Ok(nasl_syntax::parse(&code).collect())
-}
-
-fn print_results(path: &Path, verbose: bool) -> usize {
-    let mut errors = 0;
-
-    if verbose {
-        println!("# {:?}", path);
-        let results = read(path).unwrap();
-        for r in results {
-            match r {
-                Ok(stmt) => println!("{:?}", stmt),
-                Err(err) => eprintln!("{}", err),
+impl RunAction<()> for FeedAction {
+    type Error = CliError;
+    fn run(&self, verbose: bool) -> Result<(), Self::Error> {
+        match self {
+            FeedAction::Update { redis: _, path } => {
+                let update_config: FeedUpdateConfiguration =
+                    self.as_config().map_err(|kind| CliError {
+                        filename: String::new(),
+                        kind,
+                    })?;
+                let redis = RedisCache::init(&update_config.redis_url, redis_sink::FEEDUPDATE_SELECTOR)
+                    .map_err(SinkError::from)
+                    .map_err(|e| CliError {
+                        kind: e.into(),
+                        filename: format!("{path:?}"),
+                    })?;
+                redis
+                    .reset()
+                    .map_err(SinkError::from)
+                    .map_err(|e| CliError {
+                        kind: e.into(),
+                        filename: format!("{path:?}"),
+                    })?;
+                feed_update::run(&redis, update_config.plugin_path, verbose)
             }
         }
-    } else {
-        let err = read_errors(&path).unwrap();
-        if !err.is_empty() {
-            eprintln!("# Error in {:?}", path);
-        }
-        errors += err.len();
-        err.iter().for_each(|r| eprintln!("{}", r));
     }
-    errors
 }
 
-fn syntax_check(path: PathBuf, verbose: bool) {
-    let mut parsed: usize = 0;
-    let mut skipped: usize = 0;
-    let mut errors: usize = 0;
-    println!("verifiying NASL syntax in {:?}.", path);
-    if path.as_path().is_dir() {
-        for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
-            print!("\rparsing {}th file", parsed);
-            let ext = {
-                if let Some(ext) = entry.path().extension() {
-                    ext.to_str().unwrap().to_owned()
-                } else {
-                    "".to_owned()
-                }
-            };
-            if !matches!(ext.as_str(), "nasl" | "inc") {
-                skipped += 1;
-            } else {
-                errors += print_results(entry.path(), verbose);
-                parsed += 1;
+impl RunAction<()> for Command {
+    type Error = CliError;
+    fn run(&self, _: bool) -> Result<(), Self::Error> {
+        match self {
+            Command::Syntax { path, verbose } => syntax_check::run(path, *verbose),
+            Command::Feed { verbose, action } => action.run(*verbose),
+        }
+    }
+}
+
+trait AsConfig<T> {
+    fn as_config(&self) -> Result<T, CliErrorKind>;
+}
+
+/// Is the configuration required to run feed related operations.
+struct FeedUpdateConfiguration {
+    /// Plugin path is required for either
+    plugin_path: PathBuf,
+    redis_url: String,
+}
+
+impl AsConfig<FeedUpdateConfiguration> for FeedAction {
+    fn as_config(&self) -> Result<FeedUpdateConfiguration, CliErrorKind> {
+        match self.clone() {
+            FeedAction::Update {
+                redis: Some(redis_url),
+                path: Some(plugin_path),
+            } => Ok(FeedUpdateConfiguration {
+                redis_url,
+                plugin_path,
+            }),
+            FeedAction::Update { redis, path } => {
+                // This is only valid as long as we don't have a proper configuration file and rely on openvas.
+                let oconfig = process::Command::new("openvas")
+                    .arg("-s")
+                    .output()
+                    .map_err(|e| CliErrorKind::Openvas {
+                        args: "-s".to_owned().into(),
+                        err_msg: format!("{e:?}"),
+                    })?;
+
+                let mut config = Ini::new();
+                let oconfig = oconfig.stdout.iter().map(|x| *x as char).collect();
+                config.read(oconfig).map_err(|e| CliErrorKind::Openvas {
+                    args: None,
+                    err_msg: format!("{e:?}"),
+                })?;
+                let redis_url = {
+                    if let Some(rp) = redis {
+                        rp
+                    } else {
+                        let dba = config
+                            .get("default", "db_address")
+                            .expect("openvas -s must contain db_address");
+                        if dba.starts_with("redis://") || dba.starts_with("unix://") {
+                            dba
+                        } else {
+                            format!("unix://{dba}")
+                        }
+                    }
+                };
+
+                let plugin_path = {
+                    if let Some(p) = path {
+                        p
+                    } else {
+                        PathBuf::from(
+                            config
+                                .get("default", "plugins_folder")
+                                .expect("openvas -s must contain plugins_folder"),
+                        )
+                    }
+                };
+                Ok(FeedUpdateConfiguration {
+                    plugin_path,
+                    redis_url,
+                })
             }
         }
-        println!();
-    } else {
-        errors += print_results(path.as_path(), verbose);
-        parsed += 1;
     }
-    println!(
-        "skipped: {} files; parsed: {} files; errors: {}",
-        skipped, parsed, errors
-    );
 }
 
 fn main() {
     let cli = Cli::parse();
-    match cli.command {
-        Command::Syntax { path, verbose } => syntax_check(path, verbose),
-    }
+    cli.command.run(false).unwrap();
 }

--- a/rust/nasl-cli/src/syntax_check.rs
+++ b/rust/nasl-cli/src/syntax_check.rs
@@ -54,7 +54,7 @@ pub fn run(path: &PathBuf, verbose: bool) -> Result<(), CliError> {
     let mut parsed: usize = 0;
     let mut skipped: usize = 0;
     let mut errors: usize = 0;
-    println!("verifiying NASL syntax in {path:?}.");
+    println!("verifying NASL syntax in {path:?}.");
     if path.as_path().is_dir() {
         for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
             print!("\rparsing {parsed}th file");

--- a/rust/nasl-cli/src/syntax_check.rs
+++ b/rust/nasl-cli/src/syntax_check.rs
@@ -1,0 +1,85 @@
+use std::path::{Path, PathBuf};
+
+use nasl_interpreter::FSPluginLoader;
+use nasl_syntax::{Statement, SyntaxError};
+use walkdir::WalkDir;
+
+use crate::{CliError, CliErrorKind};
+
+fn read_errors<P: AsRef<Path>>(path: P) -> Result<Vec<SyntaxError>, CliErrorKind> {
+    let code = FSPluginLoader::load_non_utf8_path(path.as_ref())?;
+    Ok(nasl_syntax::parse(&code)
+        .filter_map(|r| match r {
+            Ok(_) => None,
+            Err(err) => Some(err),
+        })
+        .collect())
+}
+
+fn read<P: AsRef<Path>>(path: P) -> Result<Vec<Result<Statement, SyntaxError>>, CliErrorKind> {
+    let code = FSPluginLoader::load_non_utf8_path(path.as_ref())?;
+    Ok(nasl_syntax::parse(&code).collect())
+}
+
+fn print_results(path: &Path, verbose: bool) -> Result<usize, CliError> {
+    let mut errors = 0;
+
+    if verbose {
+        println!("# {path:?}");
+        let results = read(path).map_err(|kind| CliError {
+            kind,
+            filename: format!("{path:?}"),
+        })?;
+        for r in results {
+            match r {
+                Ok(stmt) => println!("{stmt:?}"),
+                Err(err) => eprintln!("{err}"),
+            }
+        }
+    } else {
+        let err = read_errors(path).map_err(|kind| CliError {
+            kind,
+            filename: format!("{path:?}"),
+        })?;
+        if !err.is_empty() {
+            eprintln!("# Error in {path:?}");
+        }
+        errors += err.len();
+        err.iter().for_each(|r| eprintln!("{r}"));
+    }
+    Ok(errors)
+}
+
+pub fn run(path: &PathBuf, verbose: bool) -> Result<(), CliError> {
+    let mut parsed: usize = 0;
+    let mut skipped: usize = 0;
+    let mut errors: usize = 0;
+    println!("verifiying NASL syntax in {path:?}.");
+    if path.as_path().is_dir() {
+        for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+            print!("\rparsing {parsed}th file");
+            let ext = {
+                if let Some(ext) = entry.path().extension() {
+                    ext.to_str().unwrap().to_owned()
+                } else {
+                    "".to_owned()
+                }
+            };
+            if !matches!(ext.as_str(), "nasl" | "inc") {
+                skipped += 1;
+            } else {
+                errors += print_results(entry.path(), verbose)?;
+                parsed += 1;
+            }
+        }
+        println!();
+    } else {
+        errors += print_results(path.as_path(), verbose)?;
+        parsed += 1;
+    }
+    println!("skipped: {skipped} files; parsed: {parsed} files; errors: {errors}");
+    if errors > 0 {
+        std::process::exit(errors as i32);
+    }
+    Ok(())
+}

--- a/rust/redis-sink/src/lib.rs
+++ b/rust/redis-sink/src/lib.rs
@@ -9,3 +9,5 @@ pub mod dberror;
 /// Module to handle Nvt metadata. The Nvt structure is defined here as well
 /// as the methods to set and get the struct members.
 pub mod nvt;
+/// Default selector for feed update
+pub use connector::FEEDUPDATE_SELECTOR;


### PR DESCRIPTION
 Refactor nasl-cli

Implements `nasl-cli feed update` to update redis with the feed data
from a plugin dir.

If either no plugin dir or no redis url is given it calls `openvas -s`
to get the default from there.