### PR TITLE
rs openvas nasl cli verifier

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -428,6 +428,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "feed-verifier"
+version = "0.1.0"
+dependencies = [
+ "redis",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
 name = "feed-verifier"
 version = "0.1.0"
 dependencies = [
+ "configparser",
  "redis",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["nasl-syntax", "nasl-interpreter", "nasl-cli", "sink", "redis-sink" ]
+members = ["nasl-syntax", "nasl-interpreter", "nasl-cli", "sink", "redis-sink", "feed-verifier" ]

--- a/rust/feed-verifier/Cargo.toml
+++ b/rust/feed-verifier/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 redis = "0.22.3"
+configparser = "3"

--- a/rust/feed-verifier/Cargo.toml
+++ b/rust/feed-verifier/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "feed-verifier"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = "0.22.3"

--- a/rust/feed-verifier/README.md
+++ b/rust/feed-verifier/README.md
@@ -9,7 +9,7 @@ openvas -u
 and 
 
 ```
-nasl-cli feed
+nasl-cli feed update
 ```
 
 do have the same output within redis.

--- a/rust/feed-verifier/README.md
+++ b/rust/feed-verifier/README.md
@@ -1,0 +1,17 @@
+# feed-verifier
+
+Is a specialized cli program to verify if 
+
+```
+openvas -u
+```
+
+and 
+
+```
+nasl-cli feed
+```
+
+do have the same output within redis.
+
+This is required to verify if the rust based nasl-cli is downwards compatible to ospd-openvas.

--- a/rust/feed-verifier/src/main.rs
+++ b/rust/feed-verifier/src/main.rs
@@ -1,0 +1,239 @@
+use redis::{Commands, RedisResult};
+
+use std::env;
+use std::process::Command;
+use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    io::{Error, ErrorKind},
+};
+fn get_all(con: &mut redis::Connection) -> RedisResult<HashMap<String, Vec<String>>> {
+    let keys: Vec<String> = con.keys("*")?;
+    Ok(keys
+        .into_iter()
+        .map(|k| {
+            let values: Vec<String> = match con.lrange(&k, 0, -1) {
+                Ok(v) => v,
+                Err(e) => match e.kind() {
+                    // openvas doesn't store as UTF-8 therefore we have to react on type errors
+                    // since the new implementation does use UTF-8 we cannot blindly assume that
+                    // each byte is infact a character therefore we try first the standard parsing
+                    // and again in u8.
+                    redis::ErrorKind::TypeError => {
+                        let values: Vec<Vec<u8>> = match con.lrange(&k, 0, -1) {
+                            Ok(x) => x,
+                            Err(e) => panic!("{e}"),
+                        };
+                        let values: Vec<String> = values
+                            .iter()
+                            .map(|x| x.iter().map(|x| *x as char).collect())
+                            .collect();
+                        values
+                    }
+                    _ => panic!("{e}"),
+                },
+            };
+            (k, values)
+        })
+        .collect())
+}
+
+fn tabula_rasa(con: &mut redis::Connection) -> RedisResult<()> {
+    redis::Cmd::new().arg("FLUSHALL").query(con)
+}
+
+fn get(con: &mut redis::Connection) -> RedisResult<HashMap<String, Vec<String>>> {
+    let (_, max_db) = redis::Cmd::new()
+        .arg("CONFIG")
+        .arg("GET")
+        .arg("databases")
+        .query::<(String, u32)>(con)?;
+    for i in 1..max_db {
+        redis::Cmd::new()
+            .arg("SELECT")
+            .arg(i.to_string())
+            .query(con)?;
+        let result = get_all(con)?;
+        if result.len() > 1 {
+            return Ok(result);
+        }
+    }
+    Err(Error::new(ErrorKind::NotFound, "No values are found").into())
+}
+
+// Although does differentiate between ' and " to handle escaping in
+// openvas c impl the script_parameter does treat it the same.
+// However we are not planing to handle ' " differently based on a built-in function
+// therefore we make those changes to reduce the amount of false positives.
+fn normalize_values(v: &str) -> String {
+    let mut v = v.to_owned();
+
+    v = v.replace(r#"\n"#, "\n");
+    v = v.replace(r#"\\"#, "\\");
+    v = v.replace(r#"\""#, "\"");
+    v = v.replace(r#"\'"#, "'");
+    v = v.replace(r#"\r"#, "\r");
+    v = v.replace(r#"\t"#, "\t");
+    v = v.replace('\\', "");
+    v
+}
+
+trait TagPair {
+    fn as_tag_pair(&self) -> Option<(String, String)>;
+}
+
+impl TagPair for &str {
+    fn as_tag_pair(&self) -> Option<(String, String)> {
+        let v: Vec<&str> = self.splitn(2, '=').collect();
+        if v.len() == 2 {
+            Some((v[0].to_owned(), v[1].to_owned()))
+        } else {
+            eprint!("{self} split len is {}", v.len());
+            None
+        }
+    }
+}
+
+fn run_get(
+    kb: &mut redis::Connection,
+    cmd: &str,
+) -> RedisResult<(Duration, HashMap<String, Vec<String>>)> {
+    tabula_rasa(kb).unwrap();
+    println!("Executing: {cmd}");
+    let mut args: Vec<&str> = cmd.split(' ').collect();
+    args.reverse();
+    let program = args.pop().unwrap_or_default();
+    args.reverse();
+    let start = Instant::now();
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .expect("program should be executable");
+    let elapsed = start.elapsed();
+    println!("{cmd} took {elapsed:?}");
+    if !status.success() {
+        panic!("failed to execute {cmd}: {cmd}")
+    }
+    get(kb).map(|x| (elapsed, x))
+}
+
+fn print_error(t: &str) -> i32 {
+    eprintln!("{t}");
+    1
+}
+
+fn main() {
+    let client = redis::Client::open("unix:///run/redis/redis.sock").unwrap();
+    let mut kb = client.get_connection().unwrap();
+    let (od, openvas) = run_get(&mut kb, "openvas -u").expect("results");
+
+    let nasl_cli = match env::current_exe() {
+        Ok(mut x) => {
+            x.pop();
+            x.push("nasl-cli");
+            x
+        }
+        Err(x) => panic!("This test program is assuming that nasl-cli is in the same dir: {x}"),
+    };
+    let (ncd, nasl_cli) = run_get(
+        &mut kb,
+        &format!("{} feed update", nasl_cli.to_str().unwrap_or_default()),
+    )
+    .expect("results");
+    let mut errors = 0;
+    if ncd > od {
+        errors += print_error(&format!(
+            "openvas ({od:?}) was faster than nasl-cli ({ncd:?})"
+        ));
+    }
+
+    let (left, right) = {
+        println!("nasl-cli: {}", nasl_cli.len());
+        println!("openvas: {}", openvas.len());
+        if nasl_cli.len() > openvas.len() {
+            println!("nasl-cli is left");
+            (nasl_cli, openvas)
+        } else {
+            println!("openvas is left");
+            (openvas, nasl_cli)
+        }
+    };
+    for (key, left_vals) in left {
+        // we don't store filename: since it is an unused function within ospd-openvas
+        // it was used to get the modification time of a nvt plugin and put into the
+        // artificial hash calulation.
+        // However that proved to be error prone and was dismissed without ever removing the functionality
+        // within openvas.
+        if key.starts_with("filename:") {
+            continue;
+        }
+        if key.ends_with(":prefs") {
+            // The ordering doesn't seem to be reliable, most of the times it is reversed id, but sometimes it is not.
+            // Therefore we currently stick with reversed id ordering and just verify if the values are equal.
+            match right.get(&key) {
+                Some(right) => {
+                    for r in right {
+                        if !left_vals.contains(r) {
+                            errors += print_error(&format!("{key} value not found in left"));
+                        }
+                    }
+                }
+                None => {
+                    errors += print_error(&format!("{key} not found in right"));
+                }
+            }
+        } else {
+            match right.get(&key) {
+                Some(vs) => {
+                    if left_vals.len() != vs.len() {
+                        errors +=
+                            print_error(&format!("{key} value length differs in left and right "));
+                    } else {
+                        for (i, v) in vs.iter().enumerate() {
+                            if &left_vals[i] != v {
+                                // those are tags, although the " quotation in NASL means to not interpret escape characters
+                                // in script_tags within openvas it seems that they are partially treated.
+                                // To ignore false positives we need to verify each split value and find a way to normalize this behaviour.
+                                if i == 7 {
+                                    let left: HashMap<String, String> = left_vals[i]
+                                        .split('|')
+                                        .filter_map(|x| x.as_tag_pair())
+                                        .collect();
+                                    let right: HashMap<String, String> =
+                                        v.split('|').filter_map(|x| x.as_tag_pair()).collect();
+                                    for (k, v) in left {
+                                        let v = normalize_values(&v);
+                                        match right.get(&k).cloned() {
+                                            Some(x) => {
+                                                let x = normalize_values(&x);
+                                                if v != x {
+                                                    errors += print_error(&format!(
+                                                        "{key}[{i}]->{k}: {v} \n!=\n {x}"
+                                                    ));
+                                                }
+                                            }
+                                            None => {
+                                                errors += print_error(&format!(
+                                                    "{key}[{i}]->{k} not found in right."
+                                                ));
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    errors += print_error(&format!(
+                                        "{key}[{i}]\n{v}\n!=\n{}",
+                                        &left_vals[i]
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                None => {
+                    errors += print_error(&format!("{key} not found."));
+                }
+            }
+        }
+    }
+    std::process::exit(errors);
+}

--- a/rust/feed-verifier/src/main.rs
+++ b/rust/feed-verifier/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
     for (key, left_vals) in left {
         // we don't store filename: since it is an unused function within ospd-openvas
         // it was used to get the modification time of a nvt plugin and put into the
-        // artificial hash calulation.
+        // artificial hash calculation.
         // However that proved to be error prone and was dismissed without ever removing the functionality
         // within openvas.
         if key.starts_with("filename:") {

--- a/rust/nasl-syntax/src/error.rs
+++ b/rust/nasl-syntax/src/error.rs
@@ -239,13 +239,13 @@ mod tests {
 
     #[test]
     fn missing_semicolon_call() {
-        let code = "calle(me)";
+        let code = "called(me)";
         test_for_missing_semicolon(code);
     }
 
     #[test]
     fn missing_right_paren() {
-        test_for_unclosed_token("calle(me;", TokenCategory::LeftParen);
+        test_for_unclosed_token("called(me;", TokenCategory::LeftParen);
         test_for_unclosed_token("foreach a(x { a = 2;", TokenCategory::LeftParen);
         test_for_unclosed_token("for (i = 0; i < 10; i++ ;", TokenCategory::LeftParen);
         test_for_unclosed_token("while (TRUE ;", TokenCategory::LeftParen);

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -916,8 +916,8 @@ mod tests {
         use Category::*;
         use IdentifierType::*;
         verify_tokens!(
-            "hel_lo",
-            vec![(Identifier(Undefined("hel_lo".to_owned())), 1, 1)]
+            "help_lo",
+            vec![(Identifier(Undefined("help_lo".to_owned())), 1, 1)]
         );
         verify_tokens!(
             "_hello",

--- a/rust/redis-sink/src/connector.rs
+++ b/rust/redis-sink/src/connector.rs
@@ -125,6 +125,7 @@ impl NameSpaceSelector {
                 Ok(*dbi)
             }
             NameSpaceSelector::Free => {
+                Self::select_namespace(kb, 0)?;
                 for dbi in 1..max_db {
                     match kb.hset_nx(DB_INDEX, dbi, 1) {
                         Ok(1) => {


### PR DESCRIPTION
 Add feed-verifier

`feed-verifier` is a specialized program to verify the output of
`openvas -u` with the `nasl-cli` implementation by:
- flushing redis
- executing `openvas -u`
- get the results
- flushing redis
- executing `nasl-cli feed update`
- get the results
- verify results of `openvas -u` with results of `nasl-cli feed updaye`

It does not require any arguments since it assumes that `nasl-cli` is in
the same dir as the own executable and that `openvas` is in `PATH`.

The redis connection parameter as well as plugin path it gets from `openvas -s`.