### PR TITLE
rs fix for loop

### DIFF
--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -189,6 +189,25 @@ mod tests {
     }
 
     #[test]
+    fn for_loop_without_update() {
+        let code = r###"
+        a = 0;
+        for ( a = 1; a < 5; ) {
+            a += 1;
+        }
+        a;
+        "###;
+        let storage = DefaultSink::default();
+        let mut register = Register::default();
+        let loader = NoOpLoader::default();
+        let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
+        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        assert_eq!(interpreter.next(), Some(Ok(0.into())));
+        assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
+        assert_eq!(interpreter.next(), Some(Ok(5.into())));
+    }
+
+    #[test]
     fn for_each_loop_test() {
         let code = r###"
         arr[0] = 3;

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -192,7 +192,7 @@ mod tests {
     fn for_loop_without_update() {
         let code = r###"
         a = 0;
-        for ( a = 1; a < 5; ) {
+        for (; a < 5; ) {
             a += 1;
         }
         a;

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -211,7 +211,7 @@ impl<'a> Lexer<'a> {
     fn parse_for(&mut self) -> Result<(End, Statement), SyntaxError> {
         self.jump_to_left_parenthesis()?;
         let (end, assignment) = self.statement(0, &|c| c == &Category::Semicolon)?;
-        if !matches!(assignment, Statement::Assign(_, _, _, _)) {
+        if !matches!(assignment, Statement::Assign(_, _, _, _) | Statement::NoOp(_)) {
             return Err(unexpected_statement!(assignment));
         }
         if end == End::Continue {


### PR DESCRIPTION
In nasl a for loop is allowed to skip the update statement.

This commit allows

```
for(i = 0; i < 4;) i += 1;
```