### PR TITLE
Introduce Data type

### DIFF
--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -167,6 +167,10 @@ impl<'a> Interpreter<'a> {
                 NaslValue::String(idx) => {
                     self.handle_dict(ridx, key, idx, left, right, order, result)
                 }
+                NaslValue::Data(idx) => {
+                    let idx = idx.into_iter().map(|x| x as char).collect();
+                    self.handle_dict(ridx, key, idx, left, right, order, result)
+                }
                 _ => match left {
                     NaslValue::Dict(_) => {
                         self.handle_dict(ridx, key, idx.to_string(), left, right, order, result)

--- a/rust/nasl-interpreter/src/built_in_functions/array.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/array.rs
@@ -11,10 +11,9 @@ use std::collections::HashMap;
 
 use sink::Sink;
 
-use crate::{Register, NaslValue, error::FunctionError, NaslFunction};
+use crate::{error::FunctionError, NaslFunction, NaslValue, Register};
 
 use super::resolve_positional_arguments;
-
 
 /// NASL function to create a dictionary out of an even number of arguments
 ///
@@ -26,7 +25,7 @@ pub fn make_array(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValu
     let mut values = HashMap::new();
     for (idx, val) in positional.iter().enumerate() {
         if idx % 2 == 1 {
-            values.insert(positional[idx -1].to_string(), val.clone());
+            values.insert(positional[idx - 1].to_string(), val.clone());
         }
     }
     Ok(values.into())
@@ -47,7 +46,7 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{Register, NoOpLoader, Interpreter, NaslValue};
+    use crate::{Interpreter, NaslValue, NoOpLoader, Register};
 
     macro_rules! make_dict {
         ($($key:expr => $val:expr),*) => {

--- a/rust/nasl-interpreter/src/built_in_functions/description.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/description.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 
 use crate::{
     context::{ContextType, Register},
-    NaslFunction, NaslValue,
-    FunctionError, error::FunctionErrorKind
+    error::FunctionErrorKind,
+    FunctionError, NaslFunction, NaslValue,
 };
 
 use sink::nvt::{NVTField, NvtPreference, NvtRef, PreferenceType, TagKey};

--- a/rust/nasl-interpreter/src/built_in_functions/function.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/function.rs
@@ -4,7 +4,6 @@
 
 //! Defines various built-in functions for NASL functions.
 
-
 use sink::Sink;
 
 use crate::{error::FunctionError, ContextType, NaslFunction, NaslValue, Register};

--- a/rust/nasl-interpreter/src/built_in_functions/hostname.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/hostname.rs
@@ -25,9 +25,7 @@ fn resolve_hostname(function: &str, register: &Register) -> Result<String, Funct
     );
 
     match target.parse() {
-        Ok(addr) => {
-            lookup_addr(&addr).map_err(|x| FunctionError::new(function, x.kind().into()))
-        }
+        Ok(addr) => lookup_addr(&addr).map_err(|x| FunctionError::new(function, x.kind().into())),
         // assumes that target is already a hostname
         Err(_) => Ok(target),
     }

--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use crate::{Register, NaslValue, ContextType, lookup_keys::FC_ANON_ARGS};
+use crate::{lookup_keys::FC_ANON_ARGS, ContextType, NaslValue, Register};
 
+pub mod array;
+pub mod cryptography;
 pub mod description;
+pub mod function;
 pub mod hostname;
 pub mod misc;
 pub mod string;
-pub mod array;
-pub mod function;
-pub mod cryptography;
 
 pub(crate) fn resolve_positional_arguments(register: &Register) -> Vec<NaslValue> {
     match register.named(FC_ANON_ARGS).cloned() {
@@ -18,5 +18,3 @@ pub(crate) fn resolve_positional_arguments(register: &Register) -> Vec<NaslValue
         _ => vec![],
     }
 }
-
-

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -4,7 +4,12 @@
 
 use nasl_syntax::Statement;
 
-use crate::{error::InterpretError, lookup_keys::FC_ANON_ARGS, NaslValue, logger::{NaslLogger, DefaultLogger}};
+use crate::{
+    error::InterpretError,
+    logger::{DefaultLogger, NaslLogger},
+    lookup_keys::FC_ANON_ARGS,
+    NaslValue,
+};
 
 /// Contexts are responsible to locate, add and delete everything that is declared within a NASL plugin
 
@@ -32,7 +37,7 @@ impl Register {
     pub fn new() -> Self {
         Self {
             blocks: vec![NaslContext::default()],
-            logger: Box::new(DefaultLogger::new())
+            logger: Box::new(DefaultLogger::new()),
         }
     }
 
@@ -42,8 +47,9 @@ impl Register {
             defined: initial.into_iter().collect(),
             ..Default::default()
         };
-        Self { blocks: vec![root],
-               logger: Box::new(DefaultLogger::new())
+        Self {
+            blocks: vec![root],
+            logger: Box::new(DefaultLogger::new()),
         }
     }
 

--- a/rust/nasl-interpreter/src/declare.rs
+++ b/rust/nasl-interpreter/src/declare.rs
@@ -33,9 +33,7 @@ impl<'a> DeclareFunctionExtension for Interpreter<'a> {
                     let param_name = &Self::identifier(token)?;
                     names.push(param_name.to_owned());
                 }
-                _ => {
-                    return Err(InterpretError::unsupported(a, "variable"))
-                }
+                _ => return Err(InterpretError::unsupported(a, "variable")),
             }
         }
         self.registrat
@@ -74,9 +72,7 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{
-        context::Register, loader::NoOpLoader, Interpreter, NaslValue,
-    };
+    use crate::{context::Register, loader::NoOpLoader, Interpreter, NaslValue};
 
     #[test]
     fn declare_local() {
@@ -93,9 +89,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut parser = parse(code).map(|x| 
-            interpreter.resolve(&x.expect("unexpected parse error"))
-        );
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(3.into())));
         assert!(matches!(parser.next(), Some(Ok(NaslValue::Null)))); // not found
@@ -113,7 +108,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut parser = parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(3.into())));
     }

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -7,7 +7,7 @@ use std::io;
 use nasl_syntax::{Statement, SyntaxError, TokenCategory};
 use sink::SinkError;
 
-use crate::{NaslValue, LoadError, ContextType};
+use crate::{ContextType, LoadError, NaslValue};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum FunctionErrorKind {
@@ -32,7 +32,6 @@ impl From<&str> for FunctionErrorKind {
     }
 }
 
-
 impl From<(&str, &str)> for FunctionErrorKind {
     fn from(value: (&str, &str)) -> Self {
         let (expected, got) = value;
@@ -48,7 +47,6 @@ impl From<(&str, &str, &NaslValue)> for FunctionErrorKind {
     }
 }
 
-
 impl From<(&str, &str, Option<&NaslValue>)> for FunctionErrorKind {
     fn from(value: (&str, &str, Option<&NaslValue>)) -> Self {
         match value {
@@ -62,12 +60,14 @@ impl From<(&str, &str, Option<&ContextType>)> for FunctionErrorKind {
     fn from(value: (&str, &str, Option<&ContextType>)) -> Self {
         match value {
             (key, expected, Some(ContextType::Value(x))) => (key, expected, x).into(),
-            (key, expected, Some(ContextType::Function(_, _))) => (key, expected, "function").into(),
+            (key, expected, Some(ContextType::Function(_, _))) => {
+                (key, expected, "function").into()
+            }
             (key, expected, None) => (key, expected, "NULL").into(),
         }
     }
 }
-impl From<(&str,  &NaslValue)> for FunctionErrorKind {
+impl From<(&str, &NaslValue)> for FunctionErrorKind {
     fn from(value: (&str, &NaslValue)) -> Self {
         let (expected, got) = value;
         let got: &str = &got.to_string();
@@ -101,7 +101,10 @@ pub struct FunctionError {
 
 impl FunctionError {
     pub fn new(function: &str, kind: FunctionErrorKind) -> Self {
-        Self { function: function.to_owned(), kind }
+        Self {
+            function: function.to_owned(),
+            kind,
+        }
     }
 }
 

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -84,7 +84,7 @@ mod tests {
             interpreter.next(),
             Some(Ok(NaslValue::Dict(HashMap::from([(
                 "hello".to_owned(),
-                NaslValue::String("world".to_owned())
+                NaslValue::Data("world".as_bytes().into())
             )]))))
         );
     }

--- a/rust/nasl-interpreter/src/interpreter.rs
+++ b/rust/nasl-interpreter/src/interpreter.rs
@@ -14,7 +14,7 @@ use crate::{
     loader::Loader,
     loop_extension::LoopExtension,
     operator::OperatorExtension,
-    NaslValue, InterpretError,
+    InterpretError, NaslValue,
 };
 
 /// Used to interpret a Statement

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -4,16 +4,16 @@
 
 //! Is a crate to use Statements from nasl-syntax and execute them.
 #![warn(missing_docs)]
-mod naslvalue;
 mod built_in_functions;
+mod naslvalue;
 use built_in_functions::array;
 use built_in_functions::description;
 mod error;
+use built_in_functions::cryptography;
 use built_in_functions::function;
 use built_in_functions::hostname;
 use built_in_functions::misc;
 use built_in_functions::string;
-use built_in_functions::cryptography;
 
 use error::FunctionError;
 
@@ -34,8 +34,8 @@ pub use context::Register;
 pub use error::InterpretError;
 pub use interpreter::Interpreter;
 pub use loader::*;
+pub use logger::{DefaultLogger, Mode, NaslLogger};
 pub use naslvalue::NaslValue;
-pub use logger::{Mode, NaslLogger, DefaultLogger};
 use sink::Sink;
 
 // Is a type definition for built-in functions
@@ -49,4 +49,3 @@ pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
         .or_else(|| function::lookup(function_name))
         .or_else(|| cryptography::lookup(function_name))
 }
-

--- a/rust/nasl-interpreter/src/loader.rs
+++ b/rust/nasl-interpreter/src/loader.rs
@@ -6,7 +6,6 @@
 
 use std::{fmt::Display, fs, path::Path};
 
-
 /// Defines abstract Loader error cases
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LoadError {
@@ -30,7 +29,6 @@ impl Display for LoadError {
         }
     }
 }
-
 
 /// Loader is used to load NASL scripts based on relative paths (e.g. "http_func.inc" )
 pub trait Loader {

--- a/rust/nasl-interpreter/src/logger.rs
+++ b/rust/nasl-interpreter/src/logger.rs
@@ -10,7 +10,7 @@ pub enum Mode {
     /// Error Mode, enables only Error Messages
     Error,
     /// Disabled, no Messages are logged
-    Nothing
+    Nothing,
 }
 /// A interface for a logger for the NASL interpreter
 pub trait NaslLogger {
@@ -53,30 +53,29 @@ impl NaslLogger for DefaultLogger {
         }
         println!("\x1b[38;5;8mDEBUG: \x1b[0m{}", msg);
     }
-    
+
     fn info(&self, msg: String) {
         if self.mode > Mode::Info {
             return;
         }
         println!("\x1b[38;5;2mINFO : \x1b[0m{}", msg);
     }
-    
+
     fn warning(&self, msg: String) {
         if self.mode > Mode::Warning {
             return;
         }
         println!("\x1b[38;5;3mWARN : \x1b[0m{}", msg);
     }
-    
+
     fn error(&self, msg: String) {
         if self.mode > Mode::Error {
             return;
         }
         println!("\x1b[38;5;1mERROR: \x1b[0m{}", msg);
     }
-    
+
     fn print(&self, msg: String) {
         println!("{}", msg);
     }
-    
 }

--- a/rust/nasl-interpreter/src/lookup_keys.rs
+++ b/rust/nasl-interpreter/src/lookup_keys.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-
 //! This crate has definitions of internally used lookup keys
 //!
 //! A lookup key is used to gather script internal information that are not shared
@@ -14,5 +13,5 @@ pub const FC_ANON_ARGS: &str = "_FCT_ANON_ARGS";
 ///
 /// In the current version of openvas this information is stored into redis.
 /// In the current state of the rust implementation (2023-01-23) we don't have the interface to store data between different script runs.
-// Therefore it is currently stored within the register with this key. 
+// Therefore it is currently stored within the register with this key.
 pub const TARGET: &str = "_OPENVAS_TARGET";

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -4,7 +4,7 @@
 
 use nasl_syntax::{IdentifierType, Statement, Token, TokenCategory};
 
-use crate::{interpreter::InterpretResult, InterpretError, Interpreter, NaslValue, ContextType};
+use crate::{interpreter::InterpretResult, ContextType, InterpretError, Interpreter, NaslValue};
 
 /// Extension to handle the interpretation of NASL loops
 pub(crate) trait LoopExtension {
@@ -90,7 +90,7 @@ impl<'a> LoopExtension for Interpreter<'a> {
             self.resolve(update)?;
         }
 
-       Ok(NaslValue::Null)
+        Ok(NaslValue::Null)
     }
 
     fn for_each_loop(
@@ -102,15 +102,12 @@ impl<'a> LoopExtension for Interpreter<'a> {
         // Get name of the iteration variable
         let iter_name = match variable.category() {
             TokenCategory::Identifier(IdentifierType::Undefined(name)) => name,
-            o => {
-                return Err(InterpretError::wrong_category(o))
-            }
+            o => return Err(InterpretError::wrong_category(o)),
         };
         // Iterate through the iterable Statement
         for val in Vec::<NaslValue>::from(self.resolve(iterable)?) {
             // Change the value of the iteration variable after each iteration
-            self.registrat
-                .add_local(iter_name, ContextType::Value(val));
+            self.registrat.add_local(iter_name, ContextType::Value(val));
 
             // Execute loop body
             let ret = self.resolve(body)?;
@@ -169,8 +166,7 @@ mod tests {
     use nasl_syntax::parse;
     use sink::DefaultSink;
 
-    use crate::{Interpreter, NaslValue, Register, NoOpLoader};
-
+    use crate::{Interpreter, NaslValue, NoOpLoader, Register};
 
     #[test]
     fn for_loop_test() {
@@ -185,7 +181,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(interpreter.next(), Some(Ok(10.into())));
@@ -206,7 +203,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(3.into())));
         assert_eq!(interpreter.next(), Some(Ok(5.into())));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
@@ -231,7 +229,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(4.into())));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Boolean(true))));
@@ -257,7 +256,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(10.into())));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
@@ -288,7 +288,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
         assert_eq!(interpreter.next(), Some(Ok(5.into())));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
@@ -296,4 +297,3 @@ mod tests {
         assert_eq!(interpreter.next(), Some(Ok(1.into())));
     }
 }
-

--- a/rust/nasl-interpreter/src/naslvalue.rs
+++ b/rust/nasl-interpreter/src/naslvalue.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
 use nasl_syntax::{IdentifierType, Token, TokenCategory, ACT};
 
@@ -172,6 +172,7 @@ impl TryFrom<&Token> for NaslValue {
             TokenCategory::String(category) | TokenCategory::IPv4Address(category) => {
                 Ok(NaslValue::String(category.clone()))
             }
+            TokenCategory::Data(data) => Ok(NaslValue::Data(data.clone())),
             TokenCategory::Identifier(IdentifierType::Undefined(id)) => {
                 Ok(NaslValue::String(id.clone()))
             }
@@ -184,13 +185,14 @@ impl TryFrom<&Token> for NaslValue {
     }
 }
 
+// is used for loops, maybe refactor
 impl From<NaslValue> for Vec<NaslValue> {
     fn from(value: NaslValue) -> Self {
         match value {
             NaslValue::Array(ret) => ret,
             NaslValue::Dict(ret) => ret.values().cloned().collect(),
-            NaslValue::Boolean(_) => vec![value],
-            NaslValue::Number(_) => vec![value],
+            NaslValue::Boolean(_) | NaslValue::Number(_) => vec![value],
+            NaslValue::Data(ret) => ret.into_iter().map(|x| NaslValue::Data(vec![x])).collect(),
             NaslValue::String(ret) => ret
                 .chars()
                 .map(|x| NaslValue::String(x.to_string()))

--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -85,7 +85,12 @@ impl<'a> OperatorExtension for Interpreter<'a> {
             TokenCategory::Plus => self.execute(stmts, |a, b| match a {
                 NaslValue::String(x) => {
                     let right = b.map(|x| x.to_string()).unwrap_or_default();
-                    Ok(NaslValue::String(format!("{}{}", x, right)))
+                    Ok(NaslValue::String(format!("{x}{right}")))
+                }
+                NaslValue::Data(x) => {
+                    let right: String = b.map(|x| x.to_string()).unwrap_or_default();
+                    let x: String = x.into_iter().map(|b| b as char).collect();
+                    Ok(NaslValue::String(format!("{x}{right}")))
                 }
                 left => {
                     let right = b.map(|x| i64::from(&x)).unwrap_or_default();
@@ -95,6 +100,11 @@ impl<'a> OperatorExtension for Interpreter<'a> {
             TokenCategory::Minus => self.execute(stmts, |a, b| match a {
                 NaslValue::String(x) => {
                     let right: String = b.map(|x| x.to_string()).unwrap_or_default();
+                    Ok(NaslValue::String(x.replacen(&right, "", 1)))
+                }
+                NaslValue::Data(x) => {
+                    let right: String = b.map(|x| x.to_string()).unwrap_or_default();
+                    let x: String = x.into_iter().map(|b| b as char).collect();
                     Ok(NaslValue::String(x.replacen(&right, "", 1)))
                 }
                 left => {
@@ -227,9 +237,11 @@ mod tests {
     }
     create_test! {
         numeric_plus: "1+2;" => 3.into(),
-        string_plus: "'hello ' + 'world!';" => "hello world!".into(),
+        string_plus: "\"hello \" + \"world!\";" => "hello world!".into(),
+        string_minus : "\"hello \" - 'o ';" => "hell".into(),
+        data_plus: "'hello ' + 'world!';" => "hello world!".into(),
+        data_minus: "'hello ' - 'o ';" => "hell".into(),
         numeric_minus : "1 - 2;" => NaslValue::Number(-1),
-        string_minus : "'hello ' - 'o ';" => "hell".into(),
         multiplication: "1*2;" => 2.into(),
         division: "512/2;" => 256.into(),
         modulo: "512%2;" => 0.into(),

--- a/rust/nasl-syntax/src/cursor.rs
+++ b/rust/nasl-syntax/src/cursor.rs
@@ -52,8 +52,7 @@ impl<'a> Cursor<'a> {
                 self.col += 1;
                 Some(c)
             }
-            None => None
-
+            None => None,
         }
     }
 

--- a/rust/nasl-syntax/src/grouping_extension.rs
+++ b/rust/nasl-syntax/src/grouping_extension.rs
@@ -4,9 +4,11 @@
 
 use crate::{
     error::SyntaxError,
-    lexer::{Lexer, End},
+    lexer::{End, Lexer},
     token::{Category, Token},
-    unclosed_token, unexpected_token, variable_extension::CommaGroup, Statement, AssignOrder,
+    unclosed_token, unexpected_token,
+    variable_extension::CommaGroup,
+    AssignOrder, Statement,
 };
 
 pub(crate) trait Grouping {
@@ -64,9 +66,7 @@ impl<'a> Grouping for Lexer<'a> {
 
     fn parse_grouping(&mut self, token: Token) -> Result<(End, Statement), SyntaxError> {
         match token.category() {
-            Category::LeftParen => self
-                .parse_paren(token)
-                .map(|stmt| (End::Continue, stmt)),
+            Category::LeftParen => self.parse_paren(token).map(|stmt| (End::Continue, stmt)),
             Category::LeftCurlyBracket => self
                 .parse_block(token)
                 .map(|stmt| (End::Done(Category::LeftCurlyBracket), stmt)),
@@ -81,14 +81,14 @@ impl<'a> Grouping for Lexer<'a> {
 #[cfg(test)]
 mod test {
     use crate::{
-        {AssignOrder, Statement},
         parse,
         token::{Category, Token},
+        {AssignOrder, Statement},
     };
 
+    use crate::IdentifierType::Undefined;
     use Category::*;
     use Statement::*;
-    use crate::IdentifierType::Undefined;
 
     fn result(code: &str) -> Statement {
         parse(code).next().unwrap().unwrap()

--- a/rust/nasl-syntax/src/infix_extension.rs
+++ b/rust/nasl-syntax/src/infix_extension.rs
@@ -161,12 +161,11 @@ fn first_element_as_named_parameter(
 mod test {
 
     use super::*;
-    
-    
+
     use crate::token::Category::*;
     use crate::token::Token;
-    use Statement::*;
     use crate::IdentifierType::Undefined;
+    use Statement::*;
 
     // simplified resolve method to verify a calculate with a given statement
     fn resolve(code: &str, s: Statement) -> i64 {
@@ -305,7 +304,7 @@ mod test {
                         position: (1, 1),
                     }),
                     Primitive(Token {
-                        category: String("1".to_owned()),
+                        category: Data(vec![49]),
                         position: (1, (6 + shift) as usize),
                     }),
                 ],

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -414,7 +414,7 @@ mod test {
                         position: (1, 18)
                     },
                     vec![Primitive(Token {
-                        category: String("1".to_owned()),
+                        category: Data(vec![49]),
                         position: (1, 29)
                     })]
                 )),
@@ -424,7 +424,7 @@ mod test {
                         position: (1, 40)
                     },
                     vec![Primitive(Token {
-                        category: String("hi".to_owned()),
+                        category: Data(vec![104, 105]),
                         position: (1, 48)
                     })]
                 )))

--- a/rust/nasl-syntax/src/lexer.rs
+++ b/rust/nasl-syntax/src/lexer.rs
@@ -15,7 +15,6 @@ use crate::{
     unexpected_statement, unexpected_token, Statement,
 };
 
-
 /// Is used to parse Token to Statement
 pub struct Lexer<'a> {
     tokenizer: Tokenizer<'a>,
@@ -63,7 +62,7 @@ impl<'a> Lexer<'a> {
 
     /// Returns peeks token of tokenizer
     pub(crate) fn peek(&mut self) -> Option<Token> {
-        for token in self.tokenizer.clone(){
+        for token in self.tokenizer.clone() {
             if token.category() == &Category::Comment {
                 continue;
             }
@@ -107,13 +106,14 @@ impl<'a> Lexer<'a> {
         }
 
         let mut end_statement = End::Continue;
-        while let Some(token) = self.peek(){
+        while let Some(token) = self.peek() {
             if abort(token.category()) {
                 self.token();
                 end_statement = End::Done(token.category().clone());
                 break;
             }
-            let op = Operation::new(token.clone()).ok_or_else(|| unexpected_token!(token.clone()))?;
+            let op =
+                Operation::new(token.clone()).ok_or_else(|| unexpected_token!(token.clone()))?;
 
             if self.needs_postfix(op.clone()) {
                 let (end, stmt) = self

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -13,19 +13,18 @@ mod lexer;
 mod operation;
 mod postfix_extension;
 mod prefix_extension;
+mod statement;
 mod token;
 mod variable_extension;
-mod statement;
 
-pub use error::{SyntaxError, ErrorKind};
+pub use error::{ErrorKind, SyntaxError};
+pub use lexer::Lexer;
+pub use sink::nvt::ACT;
 pub use statement::*;
-pub use token::Category as TokenCategory;
-pub use token::Token;
-pub use token::StringCategory;
 pub use token::Base as NumberBase;
+pub use token::Category as TokenCategory;
 pub use token::IdentifierType;
-pub use sink::nvt::ACT as ACT;
-pub use lexer::Lexer as Lexer;
+pub use token::Token;
 pub use token::Tokenizer;
 
 /// Parses given code and returns found Statements and Errors
@@ -48,7 +47,7 @@ mod tests {
     use crate::{
         cursor::Cursor,
         token::{Category, IdentifierType, Token, Tokenizer},
-        Statement, SyntaxError, AssignOrder,
+        AssignOrder, Statement, SyntaxError,
     };
 
     #[test]
@@ -78,7 +77,7 @@ mod tests {
                     position: (1, 17)
                 },
                 Token {
-                    category: Category::String("World!".to_owned()),
+                    category: Category::Data("World!".as_bytes().to_vec()),
                     position: (1, 19)
                 },
                 Token {

--- a/rust/nasl-syntax/src/operation.rs
+++ b/rust/nasl-syntax/src/operation.rs
@@ -73,7 +73,10 @@ impl Operation {
             | Category::DoublePoint
             | Category::PercentEqual
             | Category::MinusMinus => Some(Operation::Assign(token.category().clone())),
-            Category::String(_) | Category::Number(_) | Category::IPv4Address(_) => Some(Operation::Primitive),
+            Category::String(_)
+            | Category::Data(_)
+            | Category::Number(_)
+            | Category::IPv4Address(_) => Some(Operation::Primitive),
             Category::LeftParen
             | Category::LeftBrace
             | Category::LeftCurlyBracket

--- a/rust/nasl-syntax/src/postfix_extension.rs
+++ b/rust/nasl-syntax/src/postfix_extension.rs
@@ -8,7 +8,7 @@ use crate::{
     lexer::{End, Lexer},
     operation::Operation,
     token::{Category, Token},
-    unexpected_token, Statement, AssignOrder,
+    unexpected_token, AssignOrder, Statement,
 };
 
 /// Is a trait to handle postfix statements.
@@ -88,13 +88,13 @@ impl<'a> Postfix for Lexer<'a> {
 mod test {
     use crate::{
         parse,
-        token::{Category, Token}, Statement, AssignOrder,
+        token::{Category, Token},
+        AssignOrder, Statement,
     };
 
-    
-    use Category::*;
-    use crate::Statement::*;
     use crate::IdentifierType::Undefined;
+    use crate::Statement::*;
+    use Category::*;
 
     fn result(code: &str) -> Statement {
         parse(code).next().unwrap().unwrap()

--- a/rust/nasl-syntax/src/prefix_extension.rs
+++ b/rust/nasl-syntax/src/prefix_extension.rs
@@ -129,10 +129,7 @@ mod test {
     #[test]
     fn single_statement() {
         assert_eq!(result("1;"), Primitive(token(Number(1), 1, 1)));
-        assert_eq!(
-            result("'a';"),
-            Primitive(token(String("a".to_owned()), 1, 1))
-        );
+        assert_eq!(result("'a';"), Primitive(token(Data(vec![97]), 1, 1)));
     }
 
     #[test]

--- a/rust/nasl-syntax/src/variable_extension.rs
+++ b/rust/nasl-syntax/src/variable_extension.rs
@@ -35,7 +35,8 @@ impl<'a> CommaGroup for Lexer<'a> {
                 end = End::Done(category);
                 break;
             }
-            let (stmtend, param) = self.statement(0, &|c| c == &category || c == &Category::Comma)?;
+            let (stmtend, param) =
+                self.statement(0, &|c| c == &category || c == &Category::Comma)?;
             match param {
                 Statement::Parameter(nparams) => params.extend_from_slice(&nparams),
                 param => params.push(param),
@@ -56,7 +57,10 @@ impl<'a> CommaGroup for Lexer<'a> {
 
 impl<'a> Variables for Lexer<'a> {
     fn parse_variable(&mut self, token: Token) -> Result<(End, Statement), SyntaxError> {
-        if !matches!(token.category(), Category::Identifier(crate::IdentifierType::Undefined(_))) {
+        if !matches!(
+            token.category(),
+            Category::Identifier(crate::IdentifierType::Undefined(_))
+        ) {
             return Err(unexpected_token!(token));
         }
         use End::*;
@@ -69,10 +73,7 @@ impl<'a> Variables for Lexer<'a> {
                     if end == End::Continue {
                         return Err(unclosed_token!(nt));
                     }
-                    return Ok((
-                        Continue,
-                        Statement::Call(token, params),
-                    ));
+                    return Ok((Continue, Statement::Call(token, params)));
                 }
                 Category::LeftBrace => {
                     self.token();
@@ -84,7 +85,7 @@ impl<'a> Variables for Lexer<'a> {
                         return Ok((Continue, Statement::Array(token, Some(Box::new(lookup)))));
                     }
                 }
-                _ => {},
+                _ => {}
             }
         }
         Ok((Continue, Statement::Variable(token)))
@@ -94,15 +95,14 @@ impl<'a> Variables for Lexer<'a> {
 #[cfg(test)]
 mod test {
     use crate::{
-        {AssignOrder, Statement},
         parse,
         token::{Category, Token},
+        {AssignOrder, Statement},
     };
 
-    
+    use crate::IdentifierType::*;
     use Category::*;
     use Statement::*;
-    use crate::IdentifierType::*;
 
     fn token(category: Category, start: usize, end: usize) -> Token {
         Token {
@@ -117,7 +117,10 @@ mod test {
 
     #[test]
     fn variables() {
-        assert_eq!(result("a;"), Variable(token(Identifier(Undefined("a".to_owned())), 1, 1)));
+        assert_eq!(
+            result("a;"),
+            Variable(token(Identifier(Undefined("a".to_owned())), 1, 1))
+        );
     }
 
     #[test]
@@ -277,5 +280,4 @@ mod test {
             )
         );
     }
-
 }

--- a/rust/nasl-syntax/tests/parsing.rs
+++ b/rust/nasl-syntax/tests/parsing.rs
@@ -5,7 +5,6 @@
 #[cfg(test)]
 mod test {
 
-    
     use nasl_syntax::parse;
 
     #[test]

--- a/rust/redis-sink/src/dberror.rs
+++ b/rust/redis-sink/src/dberror.rs
@@ -33,7 +33,9 @@ impl fmt::Display for DbError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             DbError::NoAvailDbErr(e) => write!(f, "No DB available: {}", e),
-            DbError::ConfigurationError(e) => write!(f, "Unable to use redis due to wrong configuration: {}", e),
+            DbError::ConfigurationError(e) => {
+                write!(f, "Unable to use redis due to wrong configuration: {}", e)
+            }
             DbError::SystemError(e) => write!(f, "Operation system of redis has issues: {}", e),
             DbError::LibraryError(e) => write!(f, "Library issue: {}", e),
             DbError::ConnectionLost(e) => write!(f, "Connection lost: {}", e),
@@ -69,7 +71,6 @@ impl From<RedisError> for DbError {
     }
 }
 
-
 impl From<DbError> for SinkError {
     fn from(err: DbError) -> Self {
         match err {
@@ -83,4 +84,3 @@ impl From<DbError> for SinkError {
         }
     }
 }
-

--- a/rust/redis-sink/src/lib.rs
+++ b/rust/redis-sink/src/lib.rs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/// Module with structures and methods to access redis.
+pub mod connector;
 /// Module to handle custom errors
 pub mod dberror;
 /// Module to handle Nvt metadata. The Nvt structure is defined here as well
 /// as the methods to set and get the struct members.
 pub mod nvt;
-/// Module with structures and methods to access redis.
-pub mod connector;

--- a/rust/redis-sink/src/nvt.rs
+++ b/rust/redis-sink/src/nvt.rs
@@ -4,7 +4,7 @@
 
 use crate::dberror::RedisSinkResult;
 use chrono::prelude::*;
-use sink::nvt::{NvtRef, NvtPreference, ACT};
+use sink::nvt::{NvtPreference, NvtRef, ACT};
 
 ///Alias for time stamps
 type TimeT = i64;
@@ -39,7 +39,6 @@ pub fn parse_nvt_timestamp(str_time: &str) -> TimeT {
     ret
 }
 
-
 /// Structure to store NVT Severities
 // Severities are stored in redis under the Tag item
 // Currently not used
@@ -59,8 +58,6 @@ pub struct NvtSeverity {
     value: String,
 }
 
-
-
 #[derive(Clone, Debug)]
 /// Structure to hold a NVT
 pub struct Nvt {
@@ -68,19 +65,19 @@ pub struct Nvt {
     name: String,
     filename: String,
     tag: Vec<(String, String)>,
-    cvss_base: String, //Stored in redis under Tag item. Not in use.
-    summary: String,          //Stored in redis under Tag item. Not in use.
-    insight: String,          //Stored in redis under Tag item. Not in use.
-    affected: String,         //Stored in redis under Tag item. Not in use.
-    impact: String,           //Stored in redis under Tag item. Not in use.
-    creation_time: TimeT,     //Stored in redis under Tag item. Not in use.
-    modification_time: TimeT, //Stored in redis under Tag item. Not in use.
-    solution: String,         //Stored in redis under Tag item. Not in use.
-    solution_type: String,    //Stored in redis under Tag item. Not in use.
-    solution_method: String,  //Stored in redis under Tag item. Not in use.
-    detection: String, //Stored in redis under Tag item. Not in use.
-    qod_type: String,  //Stored in redis under Tag item. Not in use.
-    qod: String,       //Stored in redis under Tag item. Not in use.
+    cvss_base: String,            //Stored in redis under Tag item. Not in use.
+    summary: String,              //Stored in redis under Tag item. Not in use.
+    insight: String,              //Stored in redis under Tag item. Not in use.
+    affected: String,             //Stored in redis under Tag item. Not in use.
+    impact: String,               //Stored in redis under Tag item. Not in use.
+    creation_time: TimeT,         //Stored in redis under Tag item. Not in use.
+    modification_time: TimeT,     //Stored in redis under Tag item. Not in use.
+    solution: String,             //Stored in redis under Tag item. Not in use.
+    solution_type: String,        //Stored in redis under Tag item. Not in use.
+    solution_method: String,      //Stored in redis under Tag item. Not in use.
+    detection: String,            //Stored in redis under Tag item. Not in use.
+    qod_type: String,             //Stored in redis under Tag item. Not in use.
+    qod: String,                  //Stored in redis under Tag item. Not in use.
     severities: Vec<NvtSeverity>, //Stored in redis under Tag item. Not in use.
     dependencies: Vec<String>,
     required_keys: Vec<String>,

--- a/rust/sink/src/lib.rs
+++ b/rust/sink/src/lib.rs
@@ -6,7 +6,10 @@
 //! NASL Sink defines technology independent sink traits, structs ..{w;
 
 pub mod nvt;
-use std::{sync::{Arc, Mutex}, fmt::Display};
+use std::{
+    fmt::Display,
+    sync::{Arc, Mutex},
+};
 
 use nvt::{NVTField, NVTKey};
 

--- a/rust/sink/src/nvt.rs
+++ b/rust/sink/src/nvt.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-//! Defines NVT 
+//! Defines NVT
 use std::str::FromStr;
 
 use crate::SinkError;
@@ -74,7 +74,7 @@ impl FromStr for ACT {
             "8" => ACT::KillHost,
             "9" => ACT::Flood,
             "10" => ACT::End,
-            _ => return Err(SinkError::UnexpectedData(s.to_owned()) ),
+            _ => return Err(SinkError::UnexpectedData(s.to_owned())),
         })
     }
 }


### PR DESCRIPTION
In NASL `typeof('hello')` returns data therefore we need to add a new
Data TokenCategory to represent that.

This commit allows differentiation between
- "test" -> String("test")
- 'test' -> Data([116,101,115,116])

However in NASL scripts strings and data are used fluently that requires
all string based methods to handle data as an ordinary string.
