### PR TITLE
rs add ci

### DIFF
--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -1,0 +1,138 @@
+name: rs
+
+on:
+  push:
+    branches: [ main, stable, oldstable ]
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unittests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo test
+  clippy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update stable && rustup default stable && rustup component add clippy
+      - run: cargo clippy
+  audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update stable && rustup default stable
+      - run: cargo install cargo-audit
+      - run: cargo audit
+  typos:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update stable && rustup default stable
+      - run: cargo install typos-cli
+      - run: typos
+  formatting:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    strategy:
+      matrix:
+        crates:
+          # we verify each dir separately to make it easier to verify formatting issues or even ignore
+          # crates we deem not important for checking (e.g. feed-verifier)
+          - nasl-syntax
+          - sink
+          - nasl-interpreter
+          - redis-sink
+          - nasl-cli
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustfmt --check ${{ matrix.crates }}/**/*.rs
+  build-releases:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - name: cache build
+        id: cache-release
+        uses: actions/cache@v3
+        with:
+          path: rust/target
+          key: ${{ github.sha }}-target
+      - run: rustup update beta && rustup default beta
+      - run: cargo build --release
+  feed:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - name: cache feed
+        id: cache-feed
+        uses: actions/cache@v3
+        with:
+          path: rust/feed
+          key: ${{ runner.os }}-feed
+      - name: download feed
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        uses: greenbone/actions/download-artifact@v2
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/vulnerability-tests"
+          workflow: feed-deployment.yml
+          name: vulnerability-tests-community-main
+          path: rust
+      - name: extract feed
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        run: tar -xf vulnerability-tests-community-main.tar.xz
+      - name: simplify feed structure
+        if: steps.cache-feed.outputs.cache-hit != 'true'
+        run: rm -rf feed && mkdir feed && mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
+  verify-syntax:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    needs: [build-releases, feed]
+    steps:
+      - uses: actions/checkout@v3
+      - name: cache feed
+        id: cache-feed
+        uses: actions/cache@v3
+        with:
+          path: rust/feed
+          key: ${{ runner.os }}-feed
+      - name: cache build
+        id: cache-release
+        uses: actions/cache@v3
+        with:
+          path: rust/target
+          key: ${{ github.sha }}-target
+      - name: verify syntax parsing
+        run: ./target/release/nasl-cli syntax -p feed/ --no-progress

--- a/rust/.rustfmt.toml
+++ b/rust/.rustfmt.toml
@@ -1,3 +1,0 @@
-format_code_in_doc_comments = true
-format_macro_matchers = true
-format_macro_bodies = true

--- a/rust/nasl-cli/src/feed_update.rs
+++ b/rust/nasl-cli/src/feed_update.rs
@@ -52,8 +52,10 @@ fn run_single(
 
     // the key is the filename without the root dir and is used to set the filename
     // when script_oid is called in the redis sink implementation
-    let key = entry.to_str().map(|x|&x[root_dir_len..]).unwrap_or_default();
-    
+    let key = entry
+        .to_str()
+        .map(|x| &x[root_dir_len..])
+        .unwrap_or_default();
 
     let mut interpreter = Interpreter::new(key, storage, loader, &mut register);
     if verbose {
@@ -121,15 +123,18 @@ pub fn run(storage: &dyn Sink, path: PathBuf, verbose: bool) -> Result<(), CliEr
     let root_dir = path.clone();
     // needed to strip the root path so that we can build a relative path
     // e.g. 2006/something.nasl
-    let root_dir_len = path.to_str().map(|x|{
-        if x.ends_with('/') {
-            x.len() 
-        } else {
-            // we need to skip `/` when the given path
-            // does not end with it
-            x.len() + 1
-        }
-    }).unwrap_or_default();
+    let root_dir_len = path
+        .to_str()
+        .map(|x| {
+            if x.ends_with('/') {
+                x.len()
+            } else {
+                // we need to skip `/` when the given path
+                // does not end with it
+                x.len() + 1
+            }
+        })
+        .unwrap_or_default();
     let loader: FSPluginLoader =
         root_dir
             .as_path()

--- a/rust/nasl-cli/src/main.rs
+++ b/rust/nasl-cli/src/main.rs
@@ -30,6 +30,9 @@ enum Command {
         /// Prints all parsed statements instead of just errors
         #[arg(short, long, default_value_t = false)]
         verbose: bool,
+        /// Disables printing of progress
+        #[arg(long, default_value_t = false)]
+        no_progress: bool,
     },
     /// Controls the feed
     Feed {
@@ -78,12 +81,13 @@ impl RunAction<()> for FeedAction {
                         filename: String::new(),
                         kind,
                     })?;
-                let redis = RedisCache::init(&update_config.redis_url, redis_sink::FEEDUPDATE_SELECTOR)
-                    .map_err(SinkError::from)
-                    .map_err(|e| CliError {
-                        kind: e.into(),
-                        filename: format!("{path:?}"),
-                    })?;
+                let redis =
+                    RedisCache::init(&update_config.redis_url, redis_sink::FEEDUPDATE_SELECTOR)
+                        .map_err(SinkError::from)
+                        .map_err(|e| CliError {
+                            kind: e.into(),
+                            filename: format!("{path:?}"),
+                        })?;
                 redis
                     .reset()
                     .map_err(SinkError::from)
@@ -101,7 +105,11 @@ impl RunAction<()> for Command {
     type Error = CliError;
     fn run(&self, _: bool) -> Result<(), Self::Error> {
         match self {
-            Command::Syntax { path, verbose } => syntax_check::run(path, *verbose),
+            Command::Syntax {
+                path,
+                verbose,
+                no_progress,
+            } => syntax_check::run(path, *verbose, *no_progress),
             Command::Feed { verbose, action } => action.run(*verbose),
         }
     }

--- a/rust/nasl-cli/src/syntax_check.rs
+++ b/rust/nasl-cli/src/syntax_check.rs
@@ -50,14 +50,16 @@ fn print_results(path: &Path, verbose: bool) -> Result<usize, CliError> {
     Ok(errors)
 }
 
-pub fn run(path: &PathBuf, verbose: bool) -> Result<(), CliError> {
+pub fn run(path: &PathBuf, verbose: bool, no_progress: bool) -> Result<(), CliError> {
     let mut parsed: usize = 0;
     let mut skipped: usize = 0;
     let mut errors: usize = 0;
     println!("verifying NASL syntax in {path:?}.");
     if path.as_path().is_dir() {
         for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
-            print!("\rparsing {parsed}th file");
+            if !no_progress {
+                print!("\rparsing {parsed}th file");
+            }
             let ext = {
                 if let Some(ext) = entry.path().extension() {
                     ext.to_str().unwrap().to_owned()

--- a/rust/nasl-interpreter/src/built_in_functions/misc.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/misc.rs
@@ -52,7 +52,7 @@ pub fn dec2str(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, 
 
 /// Returns the type of given unnamed argument.
 // typeof is a reserved keyword, therefore it is prefixed with "nasl_"
-pub fn nasl_typeof (_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
+pub fn nasl_typeof(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
     let positional = register.positional();
     if positional.len() == 0 {
         return Ok(NaslValue::Null);
@@ -65,7 +65,7 @@ pub fn nasl_typeof (_: &str, _: &dyn Sink, register: &Register) -> Result<NaslVa
         NaslValue::Boolean(_) => Ok(NaslValue::String("int".to_string())),
         NaslValue::Number(_) => Ok(NaslValue::String("int".to_string())),
         NaslValue::Data(_) => Ok(NaslValue::String("data".to_string())),
-        _ => Ok(NaslValue::String("unknown".to_string()))
+        _ => Ok(NaslValue::String("unknown".to_string())),
     }
 }
 

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -108,7 +108,6 @@ impl Register {
         let mut defined = HashMap::with_capacity(initial.len());
         for (k, v) in initial {
             defined.insert(k.to_owned(), v.to_owned());
-
         }
         let root = NaslContext {
             defined,

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -137,11 +137,11 @@ pub enum InterpretErrorKind {
     /// Regex parsing went wrong.
     InvalidRegex(String),
     /// An SyntaxError while including another script
-    IncludeSyntaxError { 
+    IncludeSyntaxError {
         /// The name of the file trying to include
-        filename: String, 
+        filename: String,
         /// The syntactical error that occurred
-        err: SyntaxError 
+        err: SyntaxError,
     },
     /// SyntaxError
     SyntaxError(SyntaxError),

--- a/rust/nasl-interpreter/src/logger.rs
+++ b/rust/nasl-interpreter/src/logger.rs
@@ -1,6 +1,5 @@
 /// Modes that are used by the default logger
-#[derive(PartialEq, PartialOrd)]
-#[derive(Default)]
+#[derive(PartialEq, PartialOrd, Default)]
 pub enum Mode {
     /// Debug Mode, enables all logging
     Debug = 0,

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -201,7 +201,8 @@ mod tests {
         let mut register = Register::default();
         let loader = NoOpLoader::default();
         let mut interpreter = Interpreter::new("1", &storage, &loader, &mut register);
-        let mut interpreter = parse(code).map(|x|interpreter.resolve(&x.expect("unexpected parse error")));
+        let mut interpreter =
+            parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
         assert_eq!(interpreter.next(), Some(Ok(0.into())));
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(interpreter.next(), Some(Ok(5.into())));

--- a/rust/nasl-syntax/src/keyword_extension.rs
+++ b/rust/nasl-syntax/src/keyword_extension.rs
@@ -211,7 +211,10 @@ impl<'a> Lexer<'a> {
     fn parse_for(&mut self) -> Result<(End, Statement), SyntaxError> {
         self.jump_to_left_parenthesis()?;
         let (end, assignment) = self.statement(0, &|c| c == &Category::Semicolon)?;
-        if !matches!(assignment, Statement::Assign(_, _, _, _) | Statement::NoOp(_)) {
+        if !matches!(
+            assignment,
+            Statement::Assign(_, _, _, _) | Statement::NoOp(_)
+        ) {
             return Err(unexpected_statement!(assignment));
         }
         if end == End::Continue {


### PR DESCRIPTION
Adds a CI to verify rust implementation.

It checks:
- unit tests with stable, beta and nightly rustc
- clippy to check for style and simplifications
- audit to find insecure dependencies
- typos to check rudimentary spelling mistakes
- formatting to verify if rustfmt needs to be run
- nasl-cli syntax to verify if our interpreter can parse the community feed

In the moment that https://github.com/greenbone/openvas-scanner/pull/1331 is reviewed rs/audit should succeed.

The rust changes are mostly formatting issues that were discovered and one change
in nasl-cli to not print the progress and stop spamming non interactive terminals (like ga logs).