### PR TITLE
rs ci verify feed update

### DIFF
--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -70,69 +70,106 @@ jobs:
           - nasl-cli
     steps:
       - uses: actions/checkout@v3
-      - run: rustfmt --check ${{ matrix.crates }}/**/*.rs
-  build-releases:
-    runs-on: ubuntu-latest
+  releases:
+    runs-on:
+   # uses ubuntu 20.4 for lib 2.31 so that we can easily identify issues for
+   # this libc version because we are using debian:stable within our docker image
+     - ubuntu-20.04
     defaults:
       run:
         working-directory: rust
     steps:
+      # install rustup
       - uses: actions/checkout@v3
+        # use cache to spped up compile time
       - name: cache build
         id: cache-release
         uses: actions/cache@v3
         with:
           path: rust/target
-          key: ${{ github.sha }}-target
-      - run: rustup update beta && rustup default beta
-      - run: cargo build --release
-  feed:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust
-    steps:
-      - uses: actions/checkout@v3
-      - name: cache feed
-        id: cache-feed
-        uses: actions/cache@v3
+          key: cargo-target
+      - run: cargo build --lib --release
+      - run: cargo build --bins --release
+      - name: archive nasl-cli
+        uses: actions/upload-artifact@v3
         with:
-          path: rust/feed
-          key: ${{ runner.os }}-feed
+          name: nasl-cli
+          path: rust/target/release/nasl-cli
+          retention-days: 1
+      - name: archive feed-verifier
+        uses: actions/upload-artifact@v3
+        with:
+          name: feed-verifier
+          path: rust/target/release/feed-verifier
+          retention-days: 1
+  verify-syntax:
+    runs-on: ubuntu-latest
+    needs: [releases]
+    steps:
       - name: download feed
-        if: steps.cache-feed.outputs.cache-hit != 'true'
         uses: greenbone/actions/download-artifact@v2
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           repository: "greenbone/vulnerability-tests"
           workflow: feed-deployment.yml
           name: vulnerability-tests-community-main
-          path: rust
-      - name: extract feed
-        if: steps.cache-feed.outputs.cache-hit != 'true'
-        run: tar -xf vulnerability-tests-community-main.tar.xz
       - name: simplify feed structure
-        if: steps.cache-feed.outputs.cache-hit != 'true'
-        run: rm -rf feed && mkdir feed && mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
-  verify-syntax:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust
-    needs: [build-releases, feed]
-    steps:
-      - uses: actions/checkout@v3
-      - name: cache feed
-        id: cache-feed
-        uses: actions/cache@v3
+        run: |
+          tar -xf vulnerability-tests-community-main.tar.xz
+          rm -rf feed 
+          mkdir feed 
+          mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
+      - uses: actions/download-artifact@v3
         with:
-          path: rust/feed
-          key: ${{ runner.os }}-feed
-      - name: cache build
-        id: cache-release
-        uses: actions/cache@v3
-        with:
-          path: rust/target
-          key: ${{ github.sha }}-target
+          name: nasl-cli
+      - run: ls -las
       - name: verify syntax parsing
-        run: ./target/release/nasl-cli syntax feed/ --quiet
+        run: chmod a+x ./nasl-cli && ./nasl-cli syntax --quiet feed/
+  verify-feed-update:
+    runs-on: ubuntu-latest
+    needs: [releases]
+    container:
+      # maybe better to use builder, build openvas to have
+      # the version of this checkout rather than a dataed official one?
+      image: greenbone/openvas-scanner:unstable
+      options: --privileged
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: download feed
+        uses: greenbone/actions/download-artifact@v2
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/vulnerability-tests"
+          workflow: feed-deployment.yml
+          name: vulnerability-tests-community-main
+      - name: simplify feed structure
+        run: |
+          # we need xz to extract, probably better to put in image?
+          apt update
+          apt install -y xz-utils
+          tar -xvf vulnerability-tests-community-main.tar.xz
+          rm -rf feed 
+          mkdir feed 
+          mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
+      - uses: actions/download-artifact@v3
+        with:
+          name: nasl-cli
+      - uses: actions/download-artifact@v3
+        with:
+          name: feed-verifier
+      - name: prepare setup
+        run: |
+          install -m 755 feed-verifier /usr/local/bin/
+          install -m 755 nasl-cli /usr/local/bin/
+          echo "db_address = tcp://redis:6379" >> /etc/openvas/openvas.conf
+          mv ./feed/* "$(openvas -s | grep plugins_folder | sed 's/plugins_folder = //')/"
+      - run: openvas -s
+      - run: feed-verifier || (cat /var/log/gvm/openvas.log && false)
+      

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_lex 0.3.1",
@@ -287,18 +287,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dns-lookup"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
-dependencies = [
- "cfg-if",
- "libc",
- "socket2",
- "winapi",
 ]
 
 [[package]]
@@ -555,7 +543,7 @@ dependencies = [
 name = "nasl-cli"
 version = "0.1.0"
 dependencies = [
- "clap 4.1.4",
+ "clap 4.1.6",
  "configparser",
  "nasl-interpreter",
  "nasl-syntax",
@@ -569,7 +557,6 @@ name = "nasl-interpreter"
 version = "0.1.0"
 dependencies = [
  "digest",
- "dns-lookup",
  "flate2",
  "hex",
  "hmac",
@@ -612,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -852,16 +839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,9 +878,9 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "af0097eaf301d576d0b2aead7a59facab6d53cc636340f0291fab8446a2e8613"
 dependencies = [
  "serde",
  "time-core",

--- a/rust/feed-verifier/src/main.rs
+++ b/rust/feed-verifier/src/main.rs
@@ -140,6 +140,8 @@ fn main() {
             .expect("openvas -s must contain db_address");
         if dba.starts_with("redis://") || dba.starts_with("unix://") {
             dba
+        } else if dba.starts_with("tcp://") {
+            dba.replace("tcp://", "redis://")
         } else {
             format!("unix://{dba}")
         }

--- a/rust/nasl-cli/src/main.rs
+++ b/rust/nasl-cli/src/main.rs
@@ -148,6 +148,8 @@ impl AsConfig<FeedUpdateConfiguration> for FeedAction {
                             .expect("openvas -s must contain db_address");
                         if dba.starts_with("redis://") || dba.starts_with("unix://") {
                             dba
+                        } else if dba.starts_with("tcp://") {
+                            dba.replace("tcp://", "redis://")
                         } else {
                             format!("unix://{dba}")
                         }

--- a/rust/nasl-interpreter/Cargo.toml
+++ b/rust/nasl-interpreter/Cargo.toml
@@ -9,9 +9,6 @@ nasl-syntax = {path = "../nasl-syntax"}
 sink = {path = "../sink"}
 # used for !~ =~ string regex operations
 regex = "1"
-# used for get-hostnames; an alternative implementation without dependency can be found in:
-# ee3f7e1ed6da946e5eace08d074b320f80087a3c
-dns-lookup = "1.0.8"
 hmac = "0.12.1"
 hex = "0.4.3"
 digest = "0.10.6"


### PR DESCRIPTION
Adds a tests that verify `openvas -u` and `nasl-cli feed update` behave the same by executing `feed-verifier`.

Since we support `debian:stable` it additionally checks that `nasl-cli` is able to compile with libc 2.31 by utilizing ubuntu-20.4 instead of the latest ubuntu version.

Depends on https://github.com/greenbone/openvas-scanner/pull/1340