### PR TITLE
rs verify assign

### DIFF
--- a/rust/nasl-syntax/src/error.rs
+++ b/rust/nasl-syntax/src/error.rs
@@ -235,6 +235,8 @@ mod tests {
     fn missing_semicolon_assignment() {
         let code = "a = 12";
         test_for_missing_semicolon(code);
+        let code = "a = [1, 2, 4]";
+        test_for_missing_semicolon(code);
     }
 
     #[test]

--- a/rust/nasl-syntax/src/grouping_extension.rs
+++ b/rust/nasl-syntax/src/grouping_extension.rs
@@ -70,9 +70,7 @@ impl<'a> Grouping for Lexer<'a> {
             Category::LeftCurlyBracket => self
                 .parse_block(token)
                 .map(|stmt| (End::Done(Category::LeftCurlyBracket), stmt)),
-            Category::LeftBrace => self
-                .parse_brace(token)
-                .map(|stmt| (End::Done(Category::LeftBrace), stmt)),
+            Category::LeftBrace => self.parse_brace(token).map(|stmt| (End::Continue, stmt)),
             _ => Err(unexpected_token!(token)),
         }
     }

--- a/rust/nasl-syntax/src/infix_extension.rs
+++ b/rust/nasl-syntax/src/infix_extension.rs
@@ -168,16 +168,16 @@ mod test {
     use Statement::*;
 
     // simplified resolve method to verify a calculate with a given statement
-    fn resolve(code: &str, s: Statement) -> i64 {
+    fn resolve(s: Statement) -> i64 {
         let callable = |mut stmts: Vec<Statement>, calculus: Box<dyn Fn(i64, i64) -> i64>| -> i64 {
             let right = stmts.pop().unwrap();
             let left = stmts.pop().unwrap();
-            calculus(resolve(code, left), resolve(code, right))
+            calculus(resolve(left), resolve(right))
         };
         let single_callable =
             |mut stmts: Vec<Statement>, calculus: Box<dyn Fn(i64) -> i64>| -> i64 {
                 let left = stmts.pop().unwrap();
-                calculus(resolve(code, left))
+                calculus(resolve(left))
             };
         match s {
             Primitive(token) => match token.category() {
@@ -236,7 +236,7 @@ mod test {
     macro_rules! calculated_test {
         ($code:expr, $expected:expr) => {
             let expr = crate::parse($code).next().unwrap().unwrap();
-            assert_eq!(resolve($code, expr), $expected);
+            assert_eq!(resolve(expr), $expected);
         };
     }
 

--- a/rust/nasl-syntax/src/lexer.rs
+++ b/rust/nasl-syntax/src/lexer.rs
@@ -163,7 +163,8 @@ impl<'a> Iterator for Lexer<'a> {
                 if matches!(stmt, Statement::NoOp(_)) {
                     Some(Ok(stmt))
                 } else {
-                    println!("here?");
+                    // This verifies if a statement was not finished yet; this can happen on assignments
+                    // and missing semicolons.
                     Some(Err(unexpected_statement!(stmt)))
                 }
             }


### PR DESCRIPTION
- Refactor remove unnecessary code pass through
- Fixes statement verification for a = [1, 2, 3]
