### PR TITLE
release build

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -13,7 +13,8 @@ RUN DESTDIR=/install cmake --build /build -- install
 FROM rust AS build-nasl-cli
 COPY ./rust /source
 WORKDIR /source
-RUN cargo build --release
+RUN cargo build --lib --release
+RUN cargo build --bins --release
 
 FROM greenbone/gvm-libs:$VERSION
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -5,15 +5,17 @@ ARG REPOSITORY=greenbone/openvas-scanner
 FROM greenbone/openvas-smb AS openvas-smb
 
 FROM ${REPOSITORY}-build:$VERSION AS build
-
 COPY . /source
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
-
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM greenbone/gvm-libs:$VERSION
+FROM rust AS build-nasl-cli
+COPY ./rust /source
+WORKDIR /source
+RUN cargo build --release
 
+FROM greenbone/gvm-libs:$VERSION
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     bison \
     libjson-glib-1.0-0 \
@@ -38,12 +40,12 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     libhdb9-heimdal \
     libpopt0 \
     && rm -rf /var/lib/apt/lists/*
-
 COPY .docker/openvas.conf /etc/openvas/
 COPY --from=build /install/ /
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/
-
+COPY --from=build-nasl-cli /source/target/release/nasl-cli /usr/local/bin/
+RUN chmod a+x /usr/local/bin/nasl-cli
 RUN ldconfig
 # allow openvas to access raw sockets and all kind of network related tasks
 RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -10,12 +10,6 @@ COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM rust AS build-nasl-cli
-COPY ./rust /source
-WORKDIR /source
-RUN cargo build --lib --release
-RUN cargo build --bins --release
-
 FROM greenbone/gvm-libs:$VERSION
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     bison \
@@ -45,8 +39,6 @@ COPY .docker/openvas.conf /etc/openvas/
 COPY --from=build /install/ /
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/
-COPY --from=build-nasl-cli /source/target/release/nasl-cli /usr/local/bin/
-RUN chmod a+x /usr/local/bin/nasl-cli
 RUN ldconfig
 # allow openvas to access raw sockets and all kind of network related tasks
 RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,45 +10,6 @@ on:
   repository_dispatch:
 
 jobs:
-  # due to the long build time we prebuild the binaries
-  # for x86_64 and aarch64 linux.
-  nasl-cli-release:
-    runs-on:
-     - ubuntu-20.04
-    defaults:
-      run:
-        working-directory: rust
-    steps:
-      # install rustup
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: rustup update stable && rustup default stable
-      - run: rustup target add x86_64-unknown-linux-gnu
-      - run: rustup target add aarch64-unknown-linux-gnu
-      - run: cargo build --release --target x86_64-unknown-linux-gnu
-      - run: cargo build --release --target aarch64-unknown-linux-gnu
-      - name: archive nasl-cli x86_64
-        uses: actions/upload-artifact@v3
-        with:
-          # reuse docker platform notation
-          name: nasl-cli-amd64
-          path: rust/target/x86_64-unknown-linux-gnu/release/nasl-cli
-          retention-days: 1
-      - name: archive nasl-cli aarch64
-        uses: actions/upload-artifact@v3
-        with:
-          # reuse docker platform notation
-          name: nasl-cli-aarch64
-          path: rust/target/aarch64-unknown-linux-gnu/release/nasl-cli
-          retention-days: 1
   main:
     name: "Upload production image"
     runs-on: ubuntu-latest

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,6 +10,45 @@ on:
   repository_dispatch:
 
 jobs:
+  # due to the long build time we prebuild the binaries
+  # for x86_64 and aarch64 linux.
+  nasl-cli-release:
+    runs-on:
+     - ubuntu-20.04
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      # install rustup
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup update stable && rustup default stable
+      - run: rustup target add x86_64-unknown-linux-gnu
+      - run: rustup target add aarch64-unknown-linux-gnu
+      - run: cargo build --release --target x86_64-unknown-linux-gnu
+      - run: cargo build --release --target aarch64-unknown-linux-gnu
+      - name: archive nasl-cli x86_64
+        uses: actions/upload-artifact@v3
+        with:
+          # reuse docker platform notation
+          name: nasl-cli-amd64
+          path: rust/target/x86_64-unknown-linux-gnu/release/nasl-cli
+          retention-days: 1
+      - name: archive nasl-cli aarch64
+        uses: actions/upload-artifact@v3
+        with:
+          # reuse docker platform notation
+          name: nasl-cli-aarch64
+          path: rust/target/aarch64-unknown-linux-gnu/release/nasl-cli
+          retention-days: 1
   main:
     name: "Upload production image"
     runs-on: ubuntu-latest

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -88,7 +88,7 @@ jobs:
             ~/.cargo/git/db/
             rust/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: rustup update beta && rustup default beta
+      - run: rustup update stable && rustup default stable
       - run: cargo build --lib --release
       - run: cargo build --bins --release
       - name: archive nasl-cli

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -88,6 +88,7 @@ jobs:
         with:
           path: rust/target
           key: cargo-target
+      - run: rustup update stable && rustup default stable && rustup component add clippy
       - run: cargo build --lib --release
       - run: cargo build --bins --release
       - name: archive nasl-cli

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -72,8 +72,6 @@ jobs:
       - uses: actions/checkout@v3
   releases:
     runs-on:
-   # uses ubuntu 20.4 for lib 2.31 so that we can easily identify issues for
-   # this libc version because we are using debian:stable within our docker image
      - ubuntu-20.04
     defaults:
       run:
@@ -81,7 +79,16 @@ jobs:
     steps:
       # install rustup
       - uses: actions/checkout@v3
-      - run: rustup update stable && rustup default stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup update beta && rustup default beta
       - run: cargo build --lib --release
       - run: cargo build --bins --release
       - name: archive nasl-cli

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -81,14 +81,7 @@ jobs:
     steps:
       # install rustup
       - uses: actions/checkout@v3
-        # use cache to spped up compile time
-      - name: cache build
-        id: cache-release
-        uses: actions/cache@v3
-        with:
-          path: rust/target
-          key: cargo-target
-      - run: rustup update stable && rustup default stable && rustup component add clippy
+      - run: rustup update stable && rustup default stable
       - run: cargo build --lib --release
       - run: cargo build --bins --release
       - name: archive nasl-cli

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update stable && rustup default stable && rustup component add clippy
-      - run: cargo clippy
+      - run: cargo clippy -- -D warnings
   audit:
     runs-on: ubuntu-latest
     defaults:

--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -23,7 +23,6 @@ pub(crate) trait AssignExtension {
     ) -> InterpretResult;
 }
 
-#[inline(always)]
 fn prepare_array(idx: &NaslValue, left: NaslValue) -> (usize, Vec<NaslValue>) {
     let idx = i64::from(idx) as usize;
     let mut arr: Vec<NaslValue> = match left {
@@ -39,7 +38,6 @@ fn prepare_array(idx: &NaslValue, left: NaslValue) -> (usize, Vec<NaslValue>) {
     (idx, arr)
 }
 
-#[inline(always)]
 fn prepare_dict(left: NaslValue) -> HashMap<String, NaslValue> {
     match left {
         NaslValue::Array(x) => x
@@ -54,14 +52,12 @@ fn prepare_dict(left: NaslValue) -> HashMap<String, NaslValue> {
 }
 
 impl<'a> Interpreter<'a> {
-    #[inline(always)]
     fn save(&mut self, idx: usize, key: &str, value: NaslValue) {
         self.registrat
             .add_to_index(idx, key, ContextType::Value(value))
             .unwrap();
     }
 
-    #[inline(always)]
     fn named_value(&self, key: &str) -> Result<(usize, NaslValue), InterpretError> {
         match self
             .registrat()
@@ -73,7 +69,6 @@ impl<'a> Interpreter<'a> {
         }
     }
     #[allow(clippy::too_many_arguments)]
-    #[inline(always)]
     fn handle_dict(
         &mut self,
         ridx: usize,
@@ -104,7 +99,6 @@ impl<'a> Interpreter<'a> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[inline(always)]
     fn handle_array(
         &mut self,
         ridx: usize,
@@ -133,7 +127,6 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    #[inline(always)]
     fn store_return(
         &mut self,
         key: &str,
@@ -144,7 +137,6 @@ impl<'a> Interpreter<'a> {
         self.dynamic_return(key, &AssignOrder::AssignReturn, lookup, right, result)
     }
 
-    #[inline(always)]
     fn dynamic_return(
         &mut self,
         key: &str,
@@ -181,7 +173,6 @@ impl<'a> Interpreter<'a> {
         };
         Ok(result)
     }
-    #[inline(always)]
     fn without_right(
         &mut self,
         order: &AssignOrder,

--- a/rust/nasl-interpreter/src/built_in_functions/array.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/array.rs
@@ -54,7 +54,7 @@ pub fn make_list(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue
 /// NASL function to sorts the values of a dict/array. WARNING: drops the keys of a dict and returns an array.
 pub fn nasl_sort(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
     let mut values = nasl_make_list(register)?;
-    values.sort_by(|a, b| a.cmp(&b));
+    values.sort();
     Ok(NaslValue::Array(values))
 }
 
@@ -66,7 +66,7 @@ pub fn keys(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, Fun
         match val {
             NaslValue::Dict(x) => keys.extend(x.keys().map(|a| NaslValue::from(a.to_string()))),
             NaslValue::Array(x) =>
-                keys.extend((0..(x.len() as i64)).map(|a| NaslValue::from(a))),
+                keys.extend((0..(x.len() as i64)).map(NaslValue::from)),
             _ => return Ok(NaslValue::Null)
         }
     }

--- a/rust/nasl-interpreter/src/built_in_functions/misc.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/misc.rs
@@ -54,7 +54,7 @@ pub fn dec2str(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, 
 // typeof is a reserved keyword, therefore it is prefixed with "nasl_"
 pub fn nasl_typeof(_: &str, _: &dyn Sink, register: &Register) -> Result<NaslValue, FunctionError> {
     let positional = register.positional();
-    if positional.len() == 0 {
+    if positional.is_empty() {
         return Ok(NaslValue::Null);
     }
     match positional[0] {

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -16,7 +16,6 @@ pub(crate) trait CallExtension {
 }
 
 impl<'a> CallExtension for Interpreter<'a> {
-    #[inline(always)]
     fn call(&mut self, name: &Token, arguments: &[Statement]) -> InterpretResult {
         let name = &Self::identifier(name)?;
         // get the context

--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -14,7 +14,6 @@ pub(crate) trait OperatorExtension {
 }
 
 impl<'a> Interpreter<'a> {
-    #[inline(always)]
     fn execute(
         &mut self,
         stmts: &[Statement],
@@ -35,7 +34,6 @@ impl<'a> Interpreter<'a> {
     }
 }
 
-#[inline(always)]
 fn as_i64(left: NaslValue, right: Option<NaslValue>) -> (i64, i64) {
     (
         i64::from(&left),

--- a/rust/nasl-syntax/src/statement.rs
+++ b/rust/nasl-syntax/src/statement.rs
@@ -90,7 +90,6 @@ impl Statement {
     ///
     /// Since nasl is a dynamic, typeless language there is no guarantee.
     /// In uncertain things like a function it returns true.
-    #[inline(always)]
     pub fn is_returnable(&self) -> bool {
         matches!(
             self,
@@ -110,7 +109,6 @@ impl Statement {
     }
 
     /// Returns Self when it is returnable otherwise a unexpected statement error
-    #[inline(always)]
     pub fn as_returnable_or_err(self) -> Result<Self, SyntaxError> {
         if self.is_returnable() {
             Ok(self)
@@ -119,7 +117,6 @@ impl Statement {
         }
     }
 
-    #[inline(always)]
     fn first_stmts_token(stmts: &[Statement]) -> Option<&Token> {
         match stmts.first() {
             Some(stmt) => stmt.as_token(),
@@ -131,7 +128,6 @@ impl Statement {
     ///
     /// If a Statement contains multiple Statements (e.g. Declare) than just the first one is returned.
     /// Returns None on EoF, when a slice of vectors is empty or on AttackCategory
-    #[inline(always)]
     pub fn as_token(&self) -> Option<&Token> {
         match self {
             Statement::Primitive(token) => Some(token),

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -442,7 +442,6 @@ impl<'a> Tokenizer<'a> {
     // >>>=
     // >!<
     // most operators don't have triple or tuple variant
-    #[inline(always)]
     fn tokenize_greater(&mut self) -> Category {
         use Category::*;
         let next = self.cursor.peek(0);
@@ -487,7 +486,6 @@ impl<'a> Tokenizer<'a> {
     // we break out of the macro since < can be parsed to:
     // <<=
     // most operators don't have triple or tuple variant
-    #[inline(always)]
     fn tokenize_less(&mut self) -> Category {
         use Category::*;
         let next = self.cursor.peek(0);
@@ -512,7 +510,6 @@ impl<'a> Tokenizer<'a> {
     }
 
     // Skips initial and ending data identifier ' and verifies that a string is closed
-    #[inline(always)]
     fn tokenize_string(&mut self) -> Category {
         //'"' => self.tokenize_string(StringCategory::Unquotable, |c| c != '"'),
         let start = self.cursor.len_consumed();
@@ -538,7 +535,6 @@ impl<'a> Tokenizer<'a> {
     }
 
     // Skips initial and ending string identifier ' || " and verifies that a string is closed
-    #[inline(always)]
     fn tokenize_data(&mut self) -> Category {
         // we don't want the lookup to contain "
         let start = self.cursor.len_consumed();
@@ -565,7 +561,6 @@ impl<'a> Tokenizer<'a> {
             Category::Data(raw)
         }
     }
-    #[inline(always)]
     fn may_parse_ipv4(&mut self, base: Base, start: usize) -> Option<Category> {
         use Base::*;
         // IPv4Address start as Base10
@@ -605,7 +600,6 @@ impl<'a> Tokenizer<'a> {
     }
 
     // checks if a number is binary, octal, base10 or hex
-    #[inline(always)]
     fn tokenize_number(&mut self, mut start: usize, current: char) -> Category {
         use Base::*;
         let may_base = {
@@ -666,7 +660,6 @@ impl<'a> Tokenizer<'a> {
     }
 
     // Checks if an identifier is a Keyword or not
-    #[inline(always)]
     fn tokenize_identifier(&mut self, start: usize) -> Category {
         self.cursor
             .skip_while(|c| c.is_alphabetic() || c == '_' || c.is_numeric());

--- a/rust/nasl-syntax/src/variable_extension.rs
+++ b/rust/nasl-syntax/src/variable_extension.rs
@@ -22,7 +22,6 @@ pub(crate) trait CommaGroup {
 }
 
 impl<'a> CommaGroup for Lexer<'a> {
-    #[inline(always)]
     fn parse_comma_group(
         &mut self,
         category: Category,


### PR DESCRIPTION
Set clippy to fail on warning, remove inline always

- Speeds up compile time by removing inline always statements.
- Changes the clippy job to fail when a warning occurs.
