### PR TITLE
Adjust CI to allow c library dependency

### DIFF
--- a/.github/prepare-feed.sh
+++ b/.github/prepare-feed.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This script prepares the feed used for integration tests.
+# We don't use the download action because it is not capapble of a fork based
+# workflow.
+[ -z $FEED_DIR ] && FEED_DIR="/var/lib/openvas/plugins"
+DOCKER_CMD=docker
+FEED_IMAGE="greenbone/vulnerability-tests"
+set -e
+printf "Copying feed $FEED_IMAGE "
+FEED_VERSION=$($DOCKER_CMD run --rm $FEED_IMAGE sh -c 'ls /var/lib/openvas/' | sort -r | head -n 1)
+printf "(version: $FEED_VERSION) to $FEED_DIR\n"
+# instanciate container
+CFP="/var/lib/openvas/$FEED_VERSION/vt-data/nasl/"
+CID=$($DOCKER_CMD create $FEED_IMAGE)
+rm -rf $FEED_DIR
+mkdir -p $FEED_DIR
+$DOCKER_CMD cp $CID:$CFP $FEED_DIR
+mv $FEED_DIR/nasl/* $FEED_DIR
+rm -r $FEED_DIR/nasl
+$DOCKER_CMD rm $CID

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,8 +30,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: rustup update stable && rustup default stable
       - run: cargo install cross
-      - run: cross build --release --target aarch64-unknown-linux-gnu
-      - run: cross build --release --target x86_64-unknown-linux-gnu
+      - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
+      - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
       - name: archive nasl-cli aarch64-unknown-linux-gnu
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -107,23 +107,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [releases]
     steps:
-      - name: download feed
-        uses: greenbone/actions/download-artifact@v2
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: "greenbone/vulnerability-tests"
-          workflow: feed-deployment.yml
-          name: vulnerability-tests-community-main
-      - name: simplify feed structure
-        run: |
-          tar -xf vulnerability-tests-community-main.tar.xz
-          rm -rf feed 
-          mkdir feed 
-          mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
+      - uses: actions/checkout@v3
+      - run: FEED_DIR="feed/" sh .github/prepare-feed.sh
       - uses: actions/download-artifact@v3
         with:
           name: nasl-cli
-      - run: ls -las
       - name: verify syntax parsing
         run: chmod a+x ./nasl-cli && ./nasl-cli syntax --quiet feed/
   verify-feed-update:
@@ -143,22 +131,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: download feed
-        uses: greenbone/actions/download-artifact@v2
-        with:
-          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          repository: "greenbone/vulnerability-tests"
-          workflow: feed-deployment.yml
-          name: vulnerability-tests-community-main
-      - name: simplify feed structure
-        run: |
-          # we need xz to extract, probably better to put in image?
-          apt update
-          apt install -y xz-utils
-          tar -xvf vulnerability-tests-community-main.tar.xz
-          rm -rf feed 
-          mkdir feed 
-          mv ./community/vulnerability-feed/$(ls ./community/vulnerability-feed/ | sort -r | head -n 1)/vt-data/nasl/* feed/
+      - uses: actions/checkout@v3
+      - run: apt-get update && apt-get install -y docker.io
+      - run: FEED_DIR="feed/" sh .github/prepare-feed.sh
       - uses: actions/download-artifact@v3
         with:
           name: nasl-cli

--- a/rust/Cross.toml
+++ b/rust/Cross.toml
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "cross_aarch64.Dockerfile"
+[target.x86_64-unknown-linux-gnu]
+dockerfile = "cross.Dockerfile"

--- a/rust/cross.Dockerfile
+++ b/rust/cross.Dockerfile
@@ -1,0 +1,4 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+RUN apt-get update && apt-get install -y \
+  libpcap-dev

--- a/rust/cross_aarch64.Dockerfile
+++ b/rust/cross_aarch64.Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
+# it is based on xenial and therefore doesn't have
+# libpcap-dev available as a install candidate for aarach64.
+# The edge version (as written in 2023-03-08) is based on 
+# 20.4 and would have a candidate ready; however the build time
+# is very bad on edge therefore we wait until it is stable.
+RUN apt-get update && apt-get install -y \
+  bison \
+  flex \
+  curl
+RUN curl -o /tmp/pcap.tar.gz https://www.tcpdump.org/release/libpcap-1.10.3.tar.gz
+WORKDIR /tmp
+RUN tar xvf pcap.tar.gz
+RUN ls -las
+WORKDIR /tmp/libpcap-1.10.3
+ENV CC=aarch64-linux-gnu-gcc
+ENV CFLAGS='-Os'
+RUN ./configure --host=aarch64-unknown-linux-gnu --with-pcap=linux
+RUN cat config.log
+RUN make install


### PR DESCRIPTION
Adds libpcap-dev into the cross build as a preparation for https://github.com/greenbone/openvas-scanner/pull/1351
Changes the feed-download to be capable of running with forks by using a docker image.