### PR TITLE
rs kb

### DIFF
--- a/rust/feed/src/update/mod.rs
+++ b/rust/feed/src/update/mod.rs
@@ -10,7 +10,7 @@ use std::{fmt::Display, fs::File, marker::PhantomData};
 use nasl_interpreter::{
     AsBufReader, Context, ContextType, DefaultLogger, Interpreter, Loader, NaslValue, Register,
 };
-use storage::{nvt::NVTField, Dispatcher};
+use storage::{nvt::NVTField, Dispatcher, NoOpRetriever};
 
 use crate::verify;
 
@@ -82,9 +82,10 @@ where
         let feed_info_key = "plugin_feed_info.inc";
         let code = self.loader.load(feed_info_key)?;
         let mut register = Register::default();
-        let logger = DefaultLogger::new();
+        let logger = DefaultLogger::default();
         let k: K = Default::default();
-        let context = Context::new(&k, &self.dispatcher, &self.loader, &logger);
+        let fr = NoOpRetriever::default();
+        let context = Context::new(&k, &self.dispatcher, &fr, &self.loader, &logger);
         let mut interpreter = Interpreter::new(&mut register, &context);
         for stmt in nasl_syntax::parse(&code) {
             match stmt {
@@ -110,8 +111,9 @@ where
         let code = self.loader.load(key.as_ref())?;
 
         let mut register = Register::root_initial(&self.initial);
-        let logger = DefaultLogger::new();
-        let context = Context::new(key, &self.dispatcher, &self.loader, &logger);
+        let logger = DefaultLogger::default();
+        let fr = NoOpRetriever::default();
+        let context = Context::new(key, &self.dispatcher, &fr, &self.loader, &logger);
         let mut interpreter = Interpreter::new(&mut register, &context);
         for stmt in nasl_syntax::parse(&code) {
             match interpreter.retry_resolve(&stmt?, self.max_retry) {

--- a/rust/nasl-interpreter/README.md
+++ b/rust/nasl-interpreter/README.md
@@ -25,9 +25,9 @@ use storage::DefaultDispatcher;
 let storage = DefaultDispatcher::new(false);
 let mut register = Register::default();
 let loader = NoOpLoader::default();
-let logger = DefaultLogger::new();
+let logger = DefaultLogger::default();
 let oid = "0.0.0.0.0.0".to_owned();
-let context = Context::new(&oid, &storage, &loader, &logger);
+let context = Context::new(&oid, &storage, &storage, &loader, &logger);
 let code = "display('hi');";
 let mut interpreter = Interpreter::new(&mut register, &context);
 let mut parser =

--- a/rust/nasl-interpreter/src/built_in_functions/description.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/description.rs
@@ -5,12 +5,14 @@
 use std::str::FromStr;
 
 use crate::{
-    context::{Context, ContextType, Register},
+    context::{Context, Register},
     error::FunctionErrorKind,
     FunctionError, NaslFunction, NaslValue,
 };
 
 use storage::nvt::{NVTField, NvtPreference, NvtRef, PreferenceType, TagKey, TagValue};
+
+use super::get_named_parameter;
 
 /// Makes a storage function based on a very small DSL.
 ///
@@ -103,33 +105,6 @@ macro_rules! make_storage_function {
             }
         }
     };
-}
-
-fn get_named_parameter<'a>(
-    function: &'a str,
-    registrat: &'a Register,
-    key: &'a str,
-    required: bool,
-) -> Result<&'a NaslValue, FunctionError> {
-    match registrat.named(key) {
-        None => {
-            if required {
-                Err(FunctionError::new(
-                    function,
-                    FunctionErrorKind::MissingArguments(vec![key.to_owned()]),
-                ))
-            } else {
-                Ok(&NaslValue::Exit(0))
-            }
-        }
-        Some(ct) => match ct {
-            ContextType::Value(value) => Ok(value),
-            _ => Err(FunctionError::new(
-                function,
-                (key, "value", "function").into(),
-            )),
-        },
-    }
 }
 
 type Transform = Result<Vec<NVTField>, FunctionError>;

--- a/rust/nasl-interpreter/src/built_in_functions/description.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/description.rs
@@ -90,7 +90,7 @@ macro_rules! make_storage_function {
             )?
             let db_args = $transform(ctxconfigs.key(), &variables)?;
             for db_arg in db_args {
-              ctxconfigs.storage().dispatch(ctxconfigs.key(), storage::Field::NVT(db_arg))?;
+              ctxconfigs.dispatcher().dispatch(ctxconfigs.key(), storage::Field::NVT(db_arg))?;
             }
             Ok(NaslValue::Null)
         }

--- a/rust/nasl-interpreter/src/built_in_functions/kb.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/kb.rs
@@ -65,7 +65,7 @@ fn set_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, Func
             Err(_) => 0,
         }
     });
-    c.storage()
+    c.dispatcher()
         .dispatch(
             c.key(),
             Field::KB(Kb {

--- a/rust/nasl-interpreter/src/built_in_functions/kb.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/kb.rs
@@ -52,8 +52,7 @@ fn set_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, Func
                 FunctionErrorKind::Diagnostic(
                     format!("expected expires to be a number but is {x}."),
                     None,
-                )
-                .into(),
+                ),
             ))
         }
         Err(e) => return Err(e),

--- a/rust/nasl-interpreter/src/built_in_functions/kb.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/kb.rs
@@ -1,0 +1,112 @@
+// ## ERRORS
+
+// parameter *name* is missing
+
+// parameter *value* is missing
+
+// parameter *value* is *int* and its value is -1
+
+// parameter *expire* is -1
+
+// ## EXAMPLES
+
+// **1**: Create an entry, which expires after 10 minutes
+// ```cpp
+// set_kb_item(name: "foo", value: "bar", expire: 600);
+// ```
+
+// **2**: Create an entry, which does not expire
+// ```cpp
+// set_kb_item(name: "age", value: "42");
+// ```
+
+// **3**: Create a list
+// ```cpp
+// set_kb_item(name: "hosts", value: "foo");
+// set_kb_item(name: "hosts", value: "bar");
+// ```
+// get_kb_item("foo");
+//
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use storage::{Field, Kb};
+
+use crate::{
+    error::{FunctionError, FunctionErrorKind},
+    Context, NaslFunction, NaslValue, Register,
+};
+
+use super::get_named_parameter;
+
+/// NASL function to set a knowledge base
+fn set_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, FunctionError> {
+    let name = get_named_parameter("set_kb_item", register, "name", true)?;
+    let value = get_named_parameter("set_kb_item", register, "value", true)?;
+    let expires = match get_named_parameter("set_kb_item", register, "expires", false) {
+        Ok(NaslValue::Number(x)) => Some(*x),
+        Ok(NaslValue::Exit(0)) => None,
+        Ok(x) => {
+            return Err(FunctionError::new(
+                "set_kb_item",
+                FunctionErrorKind::Diagnostic(
+                    format!("expected expires to be a number but is {x}."),
+                    None,
+                )
+                .into(),
+            ))
+        }
+        Err(e) => return Err(e),
+    }
+    .map(|seconds| {
+        let start = SystemTime::now();
+        match start.duration_since(UNIX_EPOCH) {
+            Ok(x) => x.as_secs() + seconds as u64,
+            Err(_) => 0,
+        }
+    });
+    c.storage()
+        .dispatch(
+            c.key(),
+            Field::KB(Kb {
+                key: name.to_string(),
+                value: value.clone().as_primitive(),
+                expire: expires,
+            }),
+        )
+        .map(|_| NaslValue::Null)
+        .map_err(|e| FunctionError::new("set_kb_item", e.into()))
+}
+
+/// Returns found function for key or None when not found
+pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+    match key {
+        "set_kb_item" => Some(set_kb_item),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nasl_syntax::parse;
+
+    use crate::{DefaultContext, Interpreter, NaslValue, Register};
+
+    #[test]
+    fn set_kb_item() {
+        let code = r###"
+        set_kb_item(name: "test", value: 1);
+        set_kb_item(name: "test");
+        set_kb_item(value: 1);
+        "###;
+        let mut register = Register::default();
+        let binding = DefaultContext::default();
+        let context = binding.as_context();
+        let mut interpreter = Interpreter::new(&mut register, &context);
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
+        assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
+        assert!(matches!(parser.next(), Some(Err(_))));
+        assert!(matches!(parser.next(), Some(Err(_))));
+    }
+}

--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -2,20 +2,68 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use crate::{lookup_keys::FC_ANON_ARGS, ContextType, NaslValue, Register};
+use crate::{
+    error::{FunctionError, FunctionErrorKind},
+    lookup_keys::FC_ANON_ARGS,
+    ContextType, NaslFunction, NaslValue, Register,
+};
 
-pub mod array;
-pub mod cryptography;
-pub mod description;
-pub mod frame_forgery;
-pub mod function;
-pub mod hostname;
-pub mod misc;
-pub mod string;
+mod array;
+mod cryptography;
+mod description;
+mod frame_forgery;
+mod function;
+mod hostname;
+mod kb;
+mod misc;
+mod string;
 
 pub(crate) fn resolve_positional_arguments(register: &Register) -> Vec<NaslValue> {
     match register.named(FC_ANON_ARGS).cloned() {
         Some(ContextType::Value(NaslValue::Array(arr))) => arr,
         _ => vec![],
     }
+}
+
+pub(crate) fn get_named_parameter<'a>(
+    function: &'a str,
+    registrat: &'a Register,
+    key: &'a str,
+    required: bool,
+) -> Result<&'a NaslValue, FunctionError> {
+    match registrat.named(key) {
+        None => {
+            if required {
+                Err(FunctionError::new(
+                    function,
+                    FunctionErrorKind::MissingArguments(vec![key.to_owned()]),
+                ))
+            } else {
+                // we missuse exit here because a named value can be intentionally set to null
+                Ok(&NaslValue::Exit(0))
+            }
+        }
+        Some(ct) => match ct {
+            ContextType::Value(value) => Ok(value),
+            _ => Err(FunctionError::new(
+                function,
+                (key, "value", "function").into(),
+            )),
+        },
+    }
+}
+
+pub(crate) fn lookup<K>(function_name: &str) -> Option<NaslFunction<K>>
+where
+    K: AsRef<str>,
+{
+    description::lookup(function_name)
+        .or_else(|| kb::lookup(function_name))
+        .or_else(|| hostname::lookup(function_name))
+        .or_else(|| misc::lookup(function_name))
+        .or_else(|| string::lookup(function_name))
+        .or_else(|| array::lookup(function_name))
+        .or_else(|| function::lookup(function_name))
+        .or_else(|| cryptography::lookup(function_name))
+        .or_else(|| frame_forgery::lookup(function_name))
 }

--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -25,6 +25,13 @@ pub(crate) fn resolve_positional_arguments(register: &Register) -> Vec<NaslValue
     }
 }
 
+/// gets a named parameter
+///
+/// The function name is required for the error cases that can occur when either the found
+/// parameter is a function or when required is set to true and no parameter was found.
+///
+/// Additionally when a parameter is not required it will return Exit(0) instead of Null. This is
+/// done to allow differentiation between a parameter that is set to Null on purpose.
 pub(crate) fn get_named_parameter<'a>(
     function: &'a str,
     registrat: &'a Register,
@@ -39,7 +46,8 @@ pub(crate) fn get_named_parameter<'a>(
                     FunctionErrorKind::MissingArguments(vec![key.to_owned()]),
                 ))
             } else {
-                // we missuse exit here because a named value can be intentionally set to null
+                // we use exit because a named value can be intentionally set to null and may be
+                // treated differently when it is not set compared to set but null.
                 Ok(&NaslValue::Exit(0))
             }
         }

--- a/rust/nasl-interpreter/src/context.rs
+++ b/rust/nasl-interpreter/src/context.rs
@@ -296,7 +296,7 @@ impl<'a, K> Context<'a, K> {
         self.key
     }
     /// Get the storage
-    pub fn storage(&self) -> &dyn Dispatcher<K> {
+    pub fn dispatcher(&self) -> &dyn Dispatcher<K> {
         self.dispatcher
     }
     /// Get the loader

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -119,11 +119,13 @@ impl FunctionError {
 }
 
 impl From<StorageError> for FunctionError {
+    // TODO remove
     fn from(e: StorageError) -> Self {
         Self::new("", e.into())
     }
 }
 
+// TODO remove
 impl From<Infallible> for FunctionError {
     fn from(e: Infallible) -> Self {
         Self::new("", e.into())

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -5,17 +5,8 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 mod built_in_functions;
-mod naslvalue;
-use built_in_functions::array;
-use built_in_functions::cryptography;
-use built_in_functions::description;
 mod error;
-use built_in_functions::frame_forgery;
-use built_in_functions::function;
-use built_in_functions::hostname;
-use built_in_functions::misc;
-use built_in_functions::string;
-
+mod naslvalue;
 use error::FunctionError;
 
 mod assign;
@@ -49,12 +40,5 @@ pub(crate) fn lookup<K>(function_name: &str) -> Option<NaslFunction<K>>
 where
     K: AsRef<str>,
 {
-    description::lookup(function_name)
-        .or_else(|| hostname::lookup(function_name))
-        .or_else(|| misc::lookup(function_name))
-        .or_else(|| string::lookup(function_name))
-        .or_else(|| array::lookup(function_name))
-        .or_else(|| function::lookup(function_name))
-        .or_else(|| cryptography::lookup(function_name))
-        .or_else(|| frame_forgery::lookup(function_name))
+    built_in_functions::lookup(function_name)
 }

--- a/rust/nasl-interpreter/src/logger.rs
+++ b/rust/nasl-interpreter/src/logger.rs
@@ -41,9 +41,9 @@ pub struct DefaultLogger {
 }
 
 impl DefaultLogger {
-    /// Create a new DefaultLogger in the Info mode
-    pub fn new() -> Self {
-        Self { mode: Mode::Info }
+    /// Create a new DefaultLogger
+    pub fn new(mode: Mode) -> Self {
+        Self { mode }
     }
 
     /// Change the mode of the Logger

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -27,6 +27,7 @@ mod tests {
     use storage::nvt::{NvtRef, TagValue};
     use storage::DefaultDispatcher;
     use storage::Field::NVT;
+    use storage::Retriever;
 
     use crate::NoOpLoader;
 
@@ -78,7 +79,7 @@ if(description)
         assert_eq!(results, Ok(NaslValue::Exit(23)));
         assert_eq!(
             storage
-                .retrieve(&key, storage::Retrieve::NVT(None))
+                .retrieve(&key, &storage::Retrieve::NVT(None))
                 .unwrap(),
             vec![
                 NVT(Oid("0.0.0.0.0.0.0.0.0.1".to_owned())),

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -64,9 +64,9 @@ if(description)
             ContextType::Value(NaslValue::Number(1)),
         )];
         let mut register = Register::root_initial(&initial);
-        let logger = DefaultLogger::new();
+        let logger = DefaultLogger::default();
         let key = "test.nasl".to_owned();
-        let ctxconfigs = Context::new(&key, &storage, &loader, &logger);
+        let ctxconfigs = Context::new(&key, &storage, &storage, &loader, &logger);
         let mut interpreter = Interpreter::new(&mut register, &ctxconfigs);
         let results = parse(code)
             .map(|stmt| match stmt {

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -30,11 +30,11 @@ pub struct Kb {
     pub key: String,
     /// Value of the knowledge base entry
     pub value: Primitive,
-    /// If set it is the seconds the KB entry will expire
+    /// If set it is the unix timestamp the KB entry will expire
     ///
     /// When an entry expires `get_kb` will not find that entry anymore.
     /// When it is Null the KB entry will stay the whole run.
-    pub expire: Option<i64>,
+    pub expire: Option<u64>,
 }
 
 /// Describes various Fields of supported items.

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -277,15 +277,6 @@ where
     }
 }
 
-impl<K> Default for Box<dyn Dispatcher<K>>
-where
-    K: AsRef<str> + Display + Default + From<String> + 'static,
-{
-    fn default() -> Self {
-        Box::<DefaultDispatcher<K>>::default()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::Field::*;

--- a/rust/storage/src/retrieve.rs
+++ b/rust/storage/src/retrieve.rs
@@ -1,3 +1,8 @@
+use std::marker::PhantomData;
+
+// Copyright (C) 2023 Greenbone Networks GmbH
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
 use crate::{nvt::NVTKey, Field, StorageError};
 /// Retrieve command for a given Field
 ///
@@ -10,6 +15,24 @@ pub enum Retrieve {
     KB(String),
 }
 
+/// Retrieves fields based on a key and scope.
 pub trait Retriever<K> {
+    /// Gets Fields find by key and scope.
     fn retrieve(&self, key: &K, scope: &Retrieve) -> Result<Vec<Field>, StorageError>;
+}
+
+/// A NoOpRetriever is for cases that don't require a retriever but it is needed due to contract.
+///
+/// A use case may be when updating the feed. The context of an interpreter requires a Retriever
+/// but since it is not needed for a description run it wouldn't make sense to instantiate a
+/// reriever instance.
+#[derive(Default)]
+pub struct NoOpRetriever<K> {
+    phantom: PhantomData<K>,
+}
+
+impl<K> Retriever<K> for NoOpRetriever<K> {
+    fn retrieve(&self, _: &K, _: &Retrieve) -> Result<Vec<Field>, StorageError> {
+        Ok(vec![])
+    }
 }

--- a/rust/storage/src/retrieve.rs
+++ b/rust/storage/src/retrieve.rs
@@ -1,0 +1,15 @@
+use crate::{nvt::NVTKey, Field, StorageError};
+/// Retrieve command for a given Field
+///
+/// Defines what kind of information needs to be gathered.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Retrieve {
+    /// Metadata of the NASL script.
+    NVT(Option<NVTKey>),
+    /// Knowledge Base item
+    KB(String),
+}
+
+pub trait Retriever<K> {
+    fn retrieve(&self, key: &K, scope: &Retrieve) -> Result<Vec<Field>, StorageError>;
+}


### PR DESCRIPTION
Implements rudimentary set_kb_item and get_kb_item.

Due to the missing interpreter run functionality neither redis nor json storage currently support it because it is hard to define wanted behavior without the possibility to play around.

Depends on #1366 implements SC-791