### PR TITLE
rs interpret

### DIFF
--- a/rust/examples/control.nasl
+++ b/rust/examples/control.nasl
@@ -1,0 +1,30 @@
+function append(a, i, b) {
+  a[i] = b;
+  return a;
+}
+
+a = 1;
+a++;
+++a;
+a = a * 2;
+set_kb_item(name: "important/a", value: a);
+for (i = 1; i < 5; i++)
+  if (a % i == 0)
+    display("result: " + (get_kb_item("important/a") + i));
+  else
+    display("nope");
+b = 5;
+while (b) {
+  local_var c;
+  c = (b -= 1);
+  display(c);
+}
+b = append(a: b, i: 1, b: 42);
+foreach d(b) 
+  display(d);
+d = 1;
+repeat {
+  d -= 1;
+  display('hello '+ d); 
+} until d == 0;
+exit(d);

--- a/rust/examples/hello.nasl
+++ b/rust/examples/hello.nasl
@@ -1,0 +1,6 @@
+if (description == 1) {
+  script_oid("0.0.0.0.0.0.0.0.0.0.0.1");
+  exit(0);
+}
+
+display("Hello, world!");

--- a/rust/examples/sha256sums
+++ b/rust/examples/sha256sums
@@ -1,0 +1,2 @@
+a631614edfb63ee8640463bd2e3189f1acdb2f2cfb02aad622a86564efd3bfa4  control.nasl
+873bbf29b527dfca7137a3caa21f55ebb5e9b08bee3fd425557ba6113f3144e1  hello.nasl

--- a/rust/feed/src/lib.rs
+++ b/rust/feed/src/lib.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+mod oid;
 mod update;
 mod verify;
 
+pub use oid::Oid;
 pub use update::Error as UpdateError;
 pub use update::Update;
 pub use verify::Error as VerifyError;

--- a/rust/feed/src/oid/mod.rs
+++ b/rust/feed/src/oid/mod.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2023 Greenbone Networks GmbH
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//! Is a module to get oids within a feed
+
+use std::fs::File;
+
+use nasl_interpreter::{AsBufReader, Loader};
+use nasl_syntax::{IdentifierType, Statement, TokenCategory};
+
+use crate::{update, verify};
+/// Updates runs nasl plugin with description true and uses given storage to store the descriptive
+/// information
+pub struct Oid<L, V> {
+    /// Is used to load nasl plugins by a relative path
+    loader: L,
+    verifier: V,
+}
+impl<L, V> Oid<L, V>
+where
+    L: Sync + Send + Loader + AsBufReader<File>,
+    V: Iterator<Item = Result<String, verify::Error>>,
+{
+    /// Creates an oid finder. Returns a tuple of (filename, oid).
+    ///
+    /// It will iterate through the filenames retrieved by the verifier and execute each found
+    /// `.nasl` script in description mode to return the OID set in script_oid.
+    ///
+    /// It is used to find all oids within a feed.
+    pub fn init(
+        loader: L,
+        verifier: V,
+    ) -> impl Iterator<Item = Result<(String, String), update::Error>> {
+        Self { loader, verifier }
+    }
+
+    fn script_oid(stmt: &Statement) -> Option<String> {
+        match stmt {
+            Statement::Call(t, stms) => match t.category() {
+                TokenCategory::Identifier(IdentifierType::Undefined(s)) => match s as &str {
+                    "script_oid" => stms.first().map(|x| x.to_string()),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Returns the OID string or update::Error::MissingExit.
+    fn single(&self, key: String) -> Result<String, update::Error> {
+        let code = self.loader.load(key.as_ref())?;
+        for stmt in nasl_syntax::parse(&code) {
+            if let Statement::If(_, stmts, _) = stmt? {
+                if let Statement::Block(x) = &*stmts {
+                    for stmt in x {
+                        if let Some(oid) = Self::script_oid(stmt) {
+                            return Ok(oid);
+                        }
+                    }
+                }
+            }
+        }
+        Err(update::Error::MissingExit(key))
+    }
+}
+
+impl<L, V> Iterator for Oid<L, V>
+where
+    L: Sync + Send + Loader + AsBufReader<File>,
+    V: Iterator<Item = Result<String, verify::Error>>,
+{
+    type Item = Result<(String, String), update::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.verifier.find(|x| {
+            if let Ok(x) = x {
+                x.ends_with(".nasl")
+            } else {
+                true
+            }
+        }) {
+            Some(Ok(k)) => Some(self.single(k.clone()).map(|x| (k, x))),
+            Some(Err(e)) => Some(Err(e.into())),
+            None => None,
+        }
+    }
+}

--- a/rust/nasl-cli/README.md
+++ b/rust/nasl-cli/README.md
@@ -12,6 +12,31 @@ Options:
 
 ## Commands
 
+### execute
+
+Executes a nasl script using a in memory data base.
+
+It executes either a script via a path or an OID. When an OID is provided it requires the `-p` option to be valid feed to find the script belonging to that OID, otherwise the `-p` is optional and when set does not need to have a sha256sums.
+
+When `-v` is set it is printing the statements to be executed as well as the returned NaslValue.
+
+As examples executing: `nasl-cli execute examples/hello.nasl` returns:
+```
+Hello, world!
+```
+while executing `nasl-cli -v execute examples/hello.nasl` returns:
+
+```
+> if (description == 1) {{ ... }}
+=> Null
+> display(Hello, world!)
+Hello, world!
+=> Null
+```
+
+Usage: `nasl-cli execute [OPTIONS] <script>`
+
+
 ### feed
 
 Handles feed related tasks.

--- a/rust/nasl-cli/src/interpret/mod.rs
+++ b/rust/nasl-cli/src/interpret/mod.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2023 Greenbone Networks GmbH
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use std::{fmt::Display, path::PathBuf};
+
+use feed::HashSumNameLoader;
+use nasl_interpreter::{
+    load_non_utf8_path, Context, DefaultLogger, FSPluginLoader, Interpreter, LoadError, Loader,
+    NaslValue, NoOpLoader, Register,
+};
+use storage::{DefaultDispatcher, Dispatcher, Retriever};
+
+use crate::{CliError, CliErrorKind, Db};
+
+struct Run<'a, K> {
+    feed: Option<PathBuf>,
+    dispatcher: &'a dyn Dispatcher<K>,
+    retriever: &'a dyn Retriever<K>,
+    key: K,
+    loader: &'a dyn Loader,
+}
+
+impl<'a, K> Run<'a, K>
+where
+    K: AsRef<str>,
+{
+    fn new(
+        key: K,
+        feed: Option<PathBuf>,
+        dispatcher: &'a dyn Dispatcher<K>,
+        retriever: &'a dyn Retriever<K>,
+        loader: &'a dyn Loader,
+    ) -> Self {
+        Self {
+            feed,
+            dispatcher,
+            retriever,
+            key,
+            loader,
+        }
+    }
+
+    fn load(&self, script: &str) -> Result<String, CliErrorKind> {
+        match load_non_utf8_path(&script) {
+            Ok(x) => Ok(x),
+            Err(LoadError::NotFound(_)) => match self.feed.clone() {
+                Some(f) => {
+                    let loader = FSPluginLoader::new(f);
+                    match HashSumNameLoader::sha256(&loader) {
+                        Ok(hsnl) => {
+                            let oid_filename =
+                                feed::Oid::init(loader.clone(), hsnl).find(|x| match x {
+                                    Ok((_, oid)) => oid == script, //self.loader.load(f).map_err(|e| e.into()),
+                                    Err(_) => false,
+                                });
+                            match oid_filename {
+                                Some(Ok((f, _))) => loader.load(&f).map_err(|e| e.into()),
+                                Some(_) | None => {
+                                    Err(LoadError::NotFound(script.to_string()).into())
+                                }
+                            }
+                        }
+                        Err(_) => todo!(),
+                    }
+                }
+                None => Err(LoadError::NotFound(script.to_string()).into()),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn run(&self, script: &str, verbose: bool) -> Result<(), CliErrorKind> {
+        let logger = DefaultLogger::default();
+
+        let context = Context::new(
+            &self.key,
+            self.dispatcher,
+            self.retriever,
+            self.loader,
+            &logger,
+        );
+        let mut register = Register::default();
+        let mut interpreter = Interpreter::new(&mut register, &context);
+        let code = self.load(script)?;
+        for stmt in nasl_syntax::parse(&code) {
+            match stmt {
+                Ok(stmt) => {
+                    if verbose {
+                        eprintln!("> {stmt}");
+                    }
+                    let r = interpreter.retry_resolve(&stmt, 5)?;
+                    match r {
+                        NaslValue::Exit(rc) => std::process::exit(rc as i32),
+                        _ => {
+                            if verbose {
+                                eprintln!("=> {r:?}");
+                            }
+                        }
+                    }
+                }
+
+                Err(e) => return Err(e.into()),
+            };
+        }
+        Ok(())
+    }
+}
+
+fn build_loader(feed: Option<PathBuf>) -> Box<dyn Loader> {
+    match feed {
+        Some(x) => Box::new(FSPluginLoader::new(x)),
+        None => Box::<NoOpLoader>::default(),
+    }
+}
+
+trait Storage<K>: Dispatcher<K> + Retriever<K> {
+    fn as_retriever(&self) -> &dyn Retriever<K>;
+    fn as_dispatcher(&self) -> &dyn Dispatcher<K>;
+}
+impl<T, K> Storage<K> for T
+where
+    T: Dispatcher<K> + Retriever<K> + Sized,
+{
+    fn as_retriever(&self) -> &dyn Retriever<K> {
+        self
+    }
+
+    fn as_dispatcher(&self) -> &dyn Dispatcher<K> {
+        self
+    }
+}
+fn build_dispatcher<K>(db: &Db) -> Box<dyn Storage<K>>
+where
+    K: AsRef<str> + Display + Default + From<String> + 'static,
+{
+    match db {
+        Db::InMemory => Box::<DefaultDispatcher<K>>::default(),
+        Db::Redis(url) => Box::new(redis_storage::NvtDispatcher::as_dispatcher(url).unwrap()),
+    }
+}
+
+pub fn run(db: &Db, feed: Option<PathBuf>, script: String, verbose: bool) -> Result<(), CliError> {
+    let k = String::default();
+    let storage = build_dispatcher(db);
+    let loader = build_loader(feed.clone());
+
+    let runner = Run::new(
+        k,
+        feed,
+        storage.as_dispatcher(),
+        storage.as_retriever(),
+        &*loader,
+    );
+    runner.run(&script, verbose).map_err(|e| CliError {
+        filename: script,
+        kind: e,
+    })
+}

--- a/rust/nasl-interpreter/src/loader.rs
+++ b/rust/nasl-interpreter/src/loader.rs
@@ -39,11 +39,14 @@ impl Display for LoadError {
 ///
 /// Unfortunately the feed is not completely written in utf8 enforcing us to parse the content
 /// bytewise.
-pub fn load_non_utf8_path(path: &Path) -> Result<String, LoadError> {
+pub fn load_non_utf8_path<P>(path: &P) -> Result<String, LoadError>
+where
+    P: AsRef<Path> + ?Sized,
+{
     let result = fs::read(path).map(|bs| bs.iter().map(|&b| b as char).collect());
     match result {
         Ok(result) => Ok(result),
-        Err(err) => Err((path.to_str().unwrap_or_default(), err).into()),
+        Err(err) => Err((path.as_ref().to_str().unwrap_or_default(), err).into()),
     }
 }
 /// Loader is used to load NASL scripts based on relative paths (e.g. "http_func.inc" )

--- a/rust/nasl-interpreter/src/naslvalue.rs
+++ b/rust/nasl-interpreter/src/naslvalue.rs
@@ -93,7 +93,7 @@ impl Display for NaslValue {
             NaslValue::Null => write!(f, "\0"),
             NaslValue::Exit(rc) => write!(f, "exit({})", rc),
             NaslValue::AttackCategory(category) => {
-                write!(f, "{}", IdentifierType::ACT(*category).to_string())
+                write!(f, "{}", IdentifierType::ACT(*category))
             }
             NaslValue::Return(rc) => write!(f, "return({:?})", *rc),
             NaslValue::Continue => write!(f, "continue"),

--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -83,20 +83,19 @@ impl IdentifierType {
     }
 
 }
+impl Display for IdentifierType {
 
-impl ToString for IdentifierType {
-    fn to_string(&self) -> String {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         $(
-        // special case that is not defined via macro_call
-        if let IdentifierType::Undefined(r) = self {
-            return r.clone();
-        }
-        // cannot use match here because define is an expression
         if self == &$define {
-            return stringify!($matcher).to_owned();
+            return write!(f, stringify!($matcher));
         }
         )*
-        return "".to_owned();
+        if let IdentifierType::Undefined(r) = self {
+            return write!(f, "{r}");
+        } else {
+            return Ok(());
+        }
     }
 }
     };
@@ -314,65 +313,65 @@ pub enum Category {
 impl Display for Category {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Category::LeftParen => write!(f, "LeftParen"),
-            Category::RightParen => write!(f, "RightParen"),
-            Category::LeftBrace => write!(f, "LeftBrace"),
-            Category::RightBrace => write!(f, "RightBrace"),
-            Category::LeftCurlyBracket => write!(f, "LeftCurlyBracket"),
-            Category::RightCurlyBracket => write!(f, "RightCurlyBracket"),
-            Category::Comma => write!(f, "Comma"),
-            Category::Dot => write!(f, "Dot"),
-            Category::Percent => write!(f, "Percent"),
-            Category::PercentEqual => write!(f, "PercentEqual"),
-            Category::Semicolon => write!(f, "Semicolon"),
-            Category::DoublePoint => write!(f, "DoublePoint"),
-            Category::Tilde => write!(f, "Tilde"),
-            Category::Caret => write!(f, "Caret"),
-            Category::Ampersand => write!(f, "Ampersand"),
-            Category::AmpersandAmpersand => write!(f, "AmpersandAmpersand"),
-            Category::Pipe => write!(f, "Pipe"),
-            Category::PipePipe => write!(f, "PipePipe"),
-            Category::Bang => write!(f, "Bang"),
-            Category::BangEqual => write!(f, "BangEqual"),
-            Category::BangTilde => write!(f, "BangTilde"),
-            Category::Equal => write!(f, "Equal"),
-            Category::EqualEqual => write!(f, "EqualEqual"),
-            Category::EqualTilde => write!(f, "EqualTilde"),
-            Category::Greater => write!(f, "Greater"),
-            Category::GreaterGreater => write!(f, "GreaterGreater"),
-            Category::GreaterEqual => write!(f, "GreaterEqual"),
-            Category::GreaterLess => write!(f, "GreaterLess"),
-            Category::Less => write!(f, "Less"),
-            Category::LessLess => write!(f, "LessLess"),
-            Category::LessEqual => write!(f, "LessEqual"),
-            Category::Minus => write!(f, "Minus"),
-            Category::MinusMinus => write!(f, "MinusMinus"),
-            Category::MinusEqual => write!(f, "MinusEqual"),
-            Category::Plus => write!(f, "Plus"),
-            Category::PlusEqual => write!(f, "PlusEqual"),
-            Category::PlusPlus => write!(f, "PlusPlus"),
-            Category::Slash => write!(f, "Slash"),
-            Category::SlashEqual => write!(f, "SlashEqual"),
-            Category::Star => write!(f, "Star"),
-            Category::StarStar => write!(f, "StarStar"),
-            Category::StarEqual => write!(f, "StarEqual"),
-            Category::GreaterGreaterGreater => write!(f, "GreaterGreaterGreater"),
-            Category::GreaterGreaterEqual => write!(f, "GreaterGreaterEqual"),
-            Category::LessLessEqual => write!(f, "LessLessEqual"),
-            Category::GreaterBangLess => write!(f, "GreaterBangLess"),
-            Category::GreaterGreaterGreaterEqual => write!(f, "GreaterGreaterGreaterEqual"),
+            Category::LeftParen => write!(f, "("),
+            Category::RightParen => write!(f, ")"),
+            Category::LeftBrace => write!(f, "["),
+            Category::RightBrace => write!(f, "]"),
+            Category::LeftCurlyBracket => write!(f, "{{"),
+            Category::RightCurlyBracket => write!(f, "}}"),
+            Category::Comma => write!(f, ","),
+            Category::Dot => write!(f, "."),
+            Category::Percent => write!(f, "%"),
+            Category::PercentEqual => write!(f, "%="),
+            Category::Semicolon => write!(f, ";"),
+            Category::DoublePoint => write!(f, ":"),
+            Category::Tilde => write!(f, "~"),
+            Category::Caret => write!(f, "^"),
+            Category::Ampersand => write!(f, "&"),
+            Category::AmpersandAmpersand => write!(f, "&&"),
+            Category::Pipe => write!(f, "|"),
+            Category::PipePipe => write!(f, "||"),
+            Category::Bang => write!(f, "!"),
+            Category::BangEqual => write!(f, "!="),
+            Category::BangTilde => write!(f, "!~"),
+            Category::Equal => write!(f, "="),
+            Category::EqualEqual => write!(f, "=="),
+            Category::EqualTilde => write!(f, "=~"),
+            Category::Greater => write!(f, ">"),
+            Category::GreaterGreater => write!(f, ">>"),
+            Category::GreaterEqual => write!(f, ">="),
+            Category::GreaterLess => write!(f, "><"),
+            Category::Less => write!(f, "<"),
+            Category::LessLess => write!(f, "<<"),
+            Category::LessEqual => write!(f, "<="),
+            Category::Minus => write!(f, "-"),
+            Category::MinusMinus => write!(f, "--"),
+            Category::MinusEqual => write!(f, "-="),
+            Category::Plus => write!(f, "+"),
+            Category::PlusEqual => write!(f, "+="),
+            Category::PlusPlus => write!(f, "++"),
+            Category::Slash => write!(f, "/"),
+            Category::SlashEqual => write!(f, "/="),
+            Category::Star => write!(f, "*"),
+            Category::StarStar => write!(f, "**"),
+            Category::StarEqual => write!(f, "*="),
+            Category::GreaterGreaterGreater => write!(f, ">>>"),
+            Category::GreaterGreaterEqual => write!(f, ">>="),
+            Category::LessLessEqual => write!(f, "<<="),
+            Category::GreaterBangLess => write!(f, ">!<"),
+            Category::GreaterGreaterGreaterEqual => write!(f, ">>>="),
             Category::X => write!(f, "X"),
-            Category::String(_) => write!(f, "String"),
-            Category::Number(_) => write!(f, "Number"),
+            Category::String(x) => write!(f, "\"{x}\""),
+            Category::Number(x) => write!(f, "{x}"),
             Category::IPv4Address(_) => write!(f, "IPv4Address"),
             Category::IllegalIPv4Address => write!(f, "IllegalIPv4Address"),
             Category::IllegalNumber(_) => write!(f, "IllegalNumber"),
             Category::Comment => write!(f, "Comment"),
-            Category::Identifier(_) => write!(f, "Identifier"),
-            Category::Unclosed(_) => write!(f, "Unclosed"),
+            Category::Identifier(x) => write!(f, "{}", x),
+            Category::Unclosed(x) => write!(f, "{x:?}"),
             Category::UnknownBase => write!(f, "UnknownBase"),
             Category::UnknownSymbol => write!(f, "UnknownSymbol"),
-            Category::Data(_) => write!(f, "Data"),
+            Category::Data(x) => write!(f, "{x:?}"),
         }
     }
 }

--- a/rust/storage/src/nvt.rs
+++ b/rust/storage/src/nvt.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{time::AsUnixTimeStamp, types, Dispatcher, Field, Kb, StorageError};
+use crate::{time::AsUnixTimeStamp, types, Dispatcher, Field, Kb, Retriever, StorageError};
 
 /// Attack Category either set by script_category
 ///
@@ -528,6 +528,7 @@ where
     fn dispatch(&self, key: &K, scope: crate::Field) -> Result<(), StorageError> {
         match scope {
             Field::NVT(nvt) => self.store_nvt_field(nvt),
+            // TODO change here to store other fields instead
             Field::KB(kb) => self.dispatcher.dispatch_kb(key, kb),
         }
     }
@@ -540,6 +541,16 @@ where
             .dispatch_nvt(data.clone().unwrap_or_default())?;
         *data = None;
         Ok(())
+    }
+}
+
+impl<S, K> Retriever<K> for PerNVTDispatcher<S, K>
+where
+    K: AsRef<str>,
+    S: NvtDispatcher<K> + Retriever<K>,
+{
+    fn retrieve(&self, key: &K, scope: &crate::Retrieve) -> Result<Vec<Field>, StorageError> {
+        self.dispatcher.retrieve(key, scope)
     }
 }
 


### PR DESCRIPTION
Executes a nasl script using a in memory data base.

It executes either a script via a path or an OID. When an OID is provided it
requires the `-p` option to be valid feed to find the script belonging to that
OID, otherwise the `-p` is optional and when set does not need to have a
sha256sums.

When `-v` is set it is printing the statements to be executed as well as the returned NaslValue.

As examples executing: `nasl-cli execute examples/hello.nasl` returns:
```
Hello, world!
```
while executing `nasl-cli -v execute examples/hello.nasl` returns:

```
> if (description == 1) {{ ... }}
=> Null
> display(Hello, world!)
Hello, world!
=> Null
```

Usage: `nasl-cli execute [OPTIONS] <script>`