### PR TITLE
Use FunctionErrorKind instead of FunctionError within builtin functions

### DIFF
--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_ccm.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_ccm.rs
@@ -11,7 +11,7 @@ use ccm::{
 };
 use digest::generic_array::ArrayLength;
 
-use crate::{error::FunctionError, Context, NaslFunction, NaslValue, Register};
+use crate::{error::FunctionErrorKind, Context, NaslFunction, NaslValue, Register};
 
 use super::{get_data, get_iv, get_key, get_len, Crypt};
 
@@ -35,24 +35,23 @@ where
 }
 
 /// Base function for ccm en- and decryption. Sets the tag length to 16.
-fn ccm<D>(register: &Register, crypt: Crypt, function: &str) -> Result<NaslValue, FunctionError>
+fn ccm<D>(register: &Register, crypt: Crypt) -> Result<NaslValue, FunctionErrorKind>
 where
     D: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + BlockDecrypt + KeyInit,
 {
     // Get parameters
-    let key = get_key(register, function)?;
-    let data = get_data(register, function)?;
-    let nonce = get_iv(register, function)?;
-    let tag_size = get_len(register, function)?.unwrap_or(16);
+    let key = get_key(register)?;
+    let data = get_data(register)?;
+    let nonce = get_iv(register)?;
+    let tag_size = get_len(register)?.unwrap_or(16);
     // Switch mode dependent on iv length
-    let res = ccm_typed::<D>(tag_size, nonce.len(), crypt, key, nonce, data, function)?;
+    let res = ccm_typed::<D>(tag_size, nonce.len(), crypt, key, nonce, data)?;
 
     // Error handling
     match res {
         Ok(x) => Ok(NaslValue::Data(x)),
-        Err(_) => Err(FunctionError::new(
-            function,
-            crate::error::FunctionErrorKind::GeneralError("unable to en-/decrypt data".to_string()),
+        Err(_) => Err(crate::error::FunctionErrorKind::GeneralError(
+            "unable to en-/decrypt data".to_string(),
         )),
     }
 }
@@ -64,8 +63,11 @@ where
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes128>(register, Crypt::Encrypt, "aes128_ccm_encrypt")
+fn aes128_ccm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes128>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt aes256 ccm encrypted data. The tag size is set to 16.
@@ -75,8 +77,11 @@ fn aes128_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes128>(register, Crypt::Decrypt, "aes128_ccm_decrypt")
+fn aes128_ccm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes128>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes256 ccm. The tag size is set to 16.
@@ -86,8 +91,11 @@ fn aes128_ccm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes192>(register, Crypt::Encrypt, "aes192_ccm_encrypt")
+fn aes192_ccm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes192>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt aes256 ccm encrypted data. The tag size is set to 16.
@@ -97,8 +105,11 @@ fn aes192_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes192>(register, Crypt::Decrypt, "aes192_ccm_decrypt")
+fn aes192_ccm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes192>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes256 ccm. The tag size is set to 16.
@@ -108,8 +119,11 @@ fn aes192_ccm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes256>(register, Crypt::Encrypt, "aes256_ccm_encrypt")
+fn aes256_ccm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes256>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt aes256 ccm encrypted data. The tag size is set to 16.
@@ -119,8 +133,11 @@ fn aes256_ccm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ccm::<Aes256>(register, Crypt::Decrypt, "aes256_ccm_decrypt")
+fn aes256_ccm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ccm::<Aes256>(register, Crypt::Decrypt)
 }
 
 pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
@@ -137,7 +154,7 @@ pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
 
 macro_rules! ccm_call_typed {
     ($(($t1s: expr, $t1: ty) => $(($t2s: expr, $t2: ty)),*);*) => {
-        fn ccm_typed<D>(tag_size: usize, iv_size: usize, crypt: Crypt, key: &[u8], nonce: &[u8], data: &[u8], function: &str) -> Result<Result<Vec<u8>, aError>, FunctionError>
+        fn ccm_typed<D>(tag_size: usize, iv_size: usize, crypt: Crypt, key: &[u8], nonce: &[u8], data: &[u8]) -> Result<Result<Vec<u8>, aError>, FunctionErrorKind>
         where D: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + BlockDecrypt + KeyInit
         {
             match tag_size {
@@ -149,11 +166,11 @@ macro_rules! ccm_call_typed {
                                     Ok(ccm_crypt::<D, $t1, $t2>(crypt, key, nonce, data))
                                 }
                             ),*
-                            other => Err(FunctionError::new(function, ("iv", "between 7 and 13", other.to_string().as_str()).into()))
+                            other => Err(("iv must be between 7 and 13", other.to_string().as_str()).into())
                         }
                     }
                 ),*
-                other => Err(FunctionError::new(function, ("tag_size", "4, 6, 8, 10, 12, 14 or 16", other.to_string().as_str()).into()))
+                other => Err(("tag_size must be 4, 6, 8, 10, 12, 14 or 16", other.to_string().as_str()).into())
             }
          }
      }

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_ctr.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_ctr.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use crate::Context;
+use crate::{error::FunctionErrorKind, Context};
 use aes::{
     cipher::{
         BlockCipher, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyIvInit, StreamCipher,
@@ -12,11 +12,11 @@ use aes::{
 };
 use digest::typenum::U16;
 
-use crate::{error::FunctionError, NaslFunction, NaslValue, Register};
+use crate::{NaslFunction, NaslValue, Register};
 
 use super::{get_data, get_iv, get_key, get_len, Crypt};
 
-fn ctr<D>(register: &Register, crypt: Crypt, function: &str) -> Result<NaslValue, FunctionError>
+fn ctr<D>(register: &Register, crypt: Crypt) -> Result<NaslValue, FunctionErrorKind>
 where
     D: BlockSizeUser<BlockSize = U16>
         + aes::cipher::KeyInit
@@ -25,11 +25,11 @@ where
         + BlockDecrypt,
 {
     // Get data
-    let key = get_key(register, function)?;
-    let data = get_data(register, function)?;
+    let key = get_key(register)?;
+    let data = get_data(register)?;
     let data_len = data.len();
-    let iv = get_iv(register, function)?;
-    let len = match get_len(register, function)? {
+    let iv = get_iv(register)?;
+    let len = match get_len(register)? {
         Some(x) => x,
         None => data_len,
     };
@@ -57,8 +57,11 @@ where
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes128_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes128>(register, Crypt::Encrypt, "aes128_ctr_encrypt")
+fn aes128_ctr_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes128>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes128 ctr.
@@ -69,8 +72,11 @@ fn aes128_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes128_ctr_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes128>(register, Crypt::Decrypt, "aes128_ctr_decrypt")
+fn aes128_ctr_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes128>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes192 ctr.
@@ -80,8 +86,11 @@ fn aes128_ctr_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes192_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes192>(register, Crypt::Encrypt, "aes192_ctr_encrypt")
+fn aes192_ctr_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes192>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes192 ctr.
@@ -92,8 +101,11 @@ fn aes192_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes192_ctr_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes192>(register, Crypt::Decrypt, "aes192_ctr_decrypt")
+fn aes192_ctr_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes192>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes256 ctr.
@@ -103,8 +115,11 @@ fn aes192_ctr_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes256_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes256>(register, Crypt::Encrypt, "aes256_ctr_encrypt")
+fn aes256_ctr_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes256>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes256 ctr.
@@ -115,8 +130,11 @@ fn aes256_ctr_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes256_ctr_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    ctr::<Aes256>(register, Crypt::Decrypt, "aes256_ctr_decrypt")
+fn aes256_ctr_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    ctr::<Aes256>(register, Crypt::Decrypt)
 }
 
 pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_gcm.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_gcm.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use crate::{error::FunctionErrorKind::GeneralError, Context};
+use crate::{
+    error::FunctionErrorKind::{self, GeneralError},
+    Context,
+};
 use aes::{
     cipher::{BlockCipher, BlockDecrypt, BlockEncrypt, BlockSizeUser, KeyInit},
     Aes128, Aes192, Aes256,
@@ -10,11 +13,11 @@ use aes::{
 use aes_gcm::{aead::Aead, AesGcm};
 use digest::typenum::{U12, U16};
 
-use crate::{error::FunctionError, NaslFunction, NaslValue, Register};
+use crate::{NaslFunction, NaslValue, Register};
 
 use super::{get_data, get_iv, get_key, get_len, Crypt};
 
-fn gcm<D>(register: &Register, crypt: Crypt, function: &str) -> Result<NaslValue, FunctionError>
+fn gcm<D>(register: &Register, crypt: Crypt) -> Result<NaslValue, FunctionErrorKind>
 where
     D: BlockSizeUser<BlockSize = U16>
         + aes::cipher::KeyInit
@@ -23,10 +26,10 @@ where
         + BlockDecrypt,
 {
     // Get data
-    let key = get_key(register, function)?;
-    let data = get_data(register, function)?;
-    let iv = get_iv(register, function)?;
-    let len = get_len(register, function)?;
+    let key = get_key(register)?;
+    let data = get_data(register)?;
+    let iv = get_iv(register)?;
+    let len = get_len(register)?;
 
     let cipher = AesGcm::<D, U12>::new(key.into());
 
@@ -53,10 +56,7 @@ where
             },
             Crypt::Encrypt => Ok(x.into()),
         },
-        Err(_) => Err(FunctionError::new(
-            function,
-            GeneralError("Authentication failed".to_string()),
-        )),
+        Err(_) => Err(GeneralError("Authentication failed".to_string())),
     }
 }
 
@@ -69,8 +69,11 @@ where
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes128_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes128>(register, Crypt::Encrypt, "aes128_gcm_encrypt")
+fn aes128_gcm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes128>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes128 gcm.
@@ -82,8 +85,11 @@ fn aes128_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes128_gcm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes128>(register, Crypt::Decrypt, "aes128_gcm_decrypt")
+fn aes128_gcm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes128>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes192 gcm.
@@ -95,8 +101,11 @@ fn aes128_gcm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes192_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes192>(register, Crypt::Encrypt, "aes192_gcm_encrypt")
+fn aes192_gcm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes192>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes192 gcm.
@@ -108,8 +117,11 @@ fn aes192_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes192_gcm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes192>(register, Crypt::Decrypt, "aes192_gcm_decrypt")
+fn aes192_gcm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes192>(register, Crypt::Decrypt)
 }
 
 /// NASL function to encrypt data with aes256 gcm.
@@ -121,8 +133,11 @@ fn aes192_gcm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes256_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes256>(register, Crypt::Encrypt, "aes256_gcm_encrypt")
+fn aes256_gcm_encrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes256>(register, Crypt::Encrypt)
 }
 
 /// NASL function to decrypt data with aes256 gcm.
@@ -134,8 +149,11 @@ fn aes256_gcm_encrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes256_gcm_decrypt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    gcm::<Aes256>(register, Crypt::Decrypt, "aes256_gcm_decrypt")
+fn aes256_gcm_decrypt<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    gcm::<Aes256>(register, Crypt::Decrypt)
 }
 
 pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/hmac.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/hmac.rs
@@ -17,9 +17,9 @@ use ripemd::Ripemd160;
 use sha1::Sha1;
 use sha2::{Sha256, Sha384, Sha512};
 
-use crate::{error::FunctionError, Context, ContextType, NaslFunction, NaslValue, Register};
+use crate::{error::FunctionErrorKind, Context, ContextType, NaslFunction, NaslValue, Register};
 
-fn hmac<D>(register: &Register, function: &str) -> Result<NaslValue, FunctionError>
+fn hmac<D>(register: &Register) -> Result<NaslValue, FunctionErrorKind>
 where
     D: CoreProxy,
     D::Core: HashMarker
@@ -34,21 +34,16 @@ where
     let key = match register.named("key") {
         Some(ContextType::Value(NaslValue::String(x))) => x,
         Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
-        x => return Err(FunctionError::new(function, ("key", "string", x).into())),
+        x => return Err(("key", "string", x).into()),
     };
     let data = match register.named("data") {
         Some(ContextType::Value(NaslValue::String(x))) => x,
         Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
-        x => return Err(FunctionError::new(function, ("data", "string", x).into())),
+        x => return Err(("data", "string", x).into()),
     };
     let mut hmac = match Hmac::<D>::new_from_slice(key.as_bytes()) {
         Ok(x) => x,
-        Err(InvalidLength) => {
-            return Err(FunctionError::new(
-                function,
-                ("valid size key", "invalid size key").into(),
-            ))
-        }
+        Err(InvalidLength) => return Err(("valid size key", "invalid size key").into()),
     };
     hmac.update(data.as_bytes());
     Ok(NaslValue::String(encode(
@@ -57,38 +52,41 @@ where
 }
 
 /// NASL function to get HMAC MD2 string
-pub fn hmac_md2<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Md2>(register, "HMAC_MD2")
+pub fn hmac_md2<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Md2>(register)
 }
 
 /// NASL function to get HMAC MD5 string
-pub fn hmac_md5<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Md5>(register, "HMAC_MD5")
+pub fn hmac_md5<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Md5>(register)
 }
 
 /// NASL function to get HMAC RIPEMD160 string
-pub fn hmac_ripemd160<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Ripemd160>(register, "HMAC_RIPEMD160")
+pub fn hmac_ripemd160<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Ripemd160>(register)
 }
 
 /// NASL function to get HMAC SHA1 string
-pub fn hmac_sha1<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Sha1>(register, "HMAC_SHA1")
+pub fn hmac_sha1<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Sha1>(register)
 }
 
 /// NASL function to get HMAC SHA256 string
-pub fn hmac_sha256<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Sha256>(register, "HMAC_SHA256")
+pub fn hmac_sha256<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Sha256>(register)
 }
 
 /// NASL function to get HMAC SHA384 string
-pub fn hmac_sha384<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Sha384>(register, "HMAC_SHA384")
+pub fn hmac_sha384<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Sha384>(register)
 }
 
 /// NASL function to get HMAC SHA512 string
-pub fn hmac_sha512<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
-    hmac::<Sha512>(register, "HMAC_SHA512")
+pub fn hmac_sha512<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    hmac::<Sha512>(register)
 }
 
 /// Returns found function for key or None when not found

--- a/rust/nasl-interpreter/src/built_in_functions/function.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/function.rs
@@ -4,7 +4,7 @@
 
 //! Defines various built-in functions for NASL functions.
 
-use crate::{error::FunctionError, Context, ContextType, NaslFunction, NaslValue, Register};
+use crate::{error::FunctionErrorKind, Context, ContextType, NaslFunction, NaslValue, Register};
 
 use super::resolve_positional_arguments;
 
@@ -13,7 +13,7 @@ use super::resolve_positional_arguments;
 /// Uses the first positional argument to verify if a function is defined.
 /// This argument must be a string everything else will return False per default.
 /// Returns NaslValue::Boolean(true) when defined NaslValue::Boolean(false) otherwise.
-pub fn defined_func<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError>
+pub fn defined_func<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind>
 where
     K: AsRef<str>,
 {

--- a/rust/nasl-interpreter/src/built_in_functions/hostname.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/hostname.rs
@@ -5,14 +5,14 @@
 use std::str;
 
 use crate::{
-    error::FunctionError, lookup_keys::TARGET, Context, NaslFunction, NaslValue, Register,
+    error::FunctionErrorKind, lookup_keys::TARGET, Context, NaslFunction, NaslValue, Register,
 };
 
 /// Resolves IP address of target to hostname
 ///
 /// It does lookup TARGET and when not found falls back to 127.0.0.1 to resolve.
 /// If the TARGET is not a IP address than we assume that it already is a fqdn or a hostname and will return that instead.
-fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
+fn resolve_hostname(register: &Register) -> Result<String, FunctionErrorKind> {
     use std::net::ToSocketAddrs;
 
     let default_ip = "127.0.0.1";
@@ -36,7 +36,10 @@ fn resolve_hostname(register: &Register) -> Result<String, FunctionError> {
 ///
 /// As of now (2023-01-20) there is no vhost handling.
 /// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
-pub fn get_host_names<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+pub fn get_host_names<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
     resolve_hostname(register).map(|x| NaslValue::Array(vec![NaslValue::String(x)]))
 }
 
@@ -44,7 +47,10 @@ pub fn get_host_names<K>(register: &Register, _: &Context<K>) -> Result<NaslValu
 ///
 /// As of now (2023-01-20) there is no vhost handling.
 /// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
-pub fn get_host_name<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+pub fn get_host_name<K>(
+    register: &Register,
+    _: &Context<K>,
+) -> Result<NaslValue, FunctionErrorKind> {
     resolve_hostname(register).map(NaslValue::String)
 }
 

--- a/rust/nasl-interpreter/src/built_in_functions/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/mod.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 use crate::{
-    error::{FunctionError, FunctionErrorKind},
-    lookup_keys::FC_ANON_ARGS,
-    ContextType, NaslFunction, NaslValue, Register,
+    error::FunctionErrorKind, lookup_keys::FC_ANON_ARGS, ContextType, NaslFunction, NaslValue,
+    Register,
 };
 
 mod array;
@@ -33,18 +32,14 @@ pub(crate) fn resolve_positional_arguments(register: &Register) -> Vec<NaslValue
 /// Additionally when a parameter is not required it will return Exit(0) instead of Null. This is
 /// done to allow differentiation between a parameter that is set to Null on purpose.
 pub(crate) fn get_named_parameter<'a>(
-    function: &'a str,
     registrat: &'a Register,
     key: &'a str,
     required: bool,
-) -> Result<&'a NaslValue, FunctionError> {
+) -> Result<&'a NaslValue, FunctionErrorKind> {
     match registrat.named(key) {
         None => {
             if required {
-                Err(FunctionError::new(
-                    function,
-                    FunctionErrorKind::MissingArguments(vec![key.to_owned()]),
-                ))
+                Err(FunctionErrorKind::MissingArguments(vec![key.to_owned()]))
             } else {
                 // we use exit because a named value can be intentionally set to null and may be
                 // treated differently when it is not set compared to set but null.
@@ -53,10 +48,7 @@ pub(crate) fn get_named_parameter<'a>(
         }
         Some(ct) => match ct {
             ContextType::Value(value) => Ok(value),
-            _ => Err(FunctionError::new(
-                function,
-                (key, "value", "function").into(),
-            )),
+            _ => Err((key, "value", "function").into()),
         },
     }
 }

--- a/rust/nasl-interpreter/src/built_in_functions/string.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/string.rs
@@ -8,7 +8,7 @@ use core::fmt::Write;
 
 use crate::{
     context::ContextType,
-    error::FunctionError,
+    error::FunctionErrorKind,
     helper::{decode_hex, encode_hex},
     Context, NaslFunction, NaslValue, Register,
 };
@@ -44,7 +44,7 @@ fn append_nasl_value_as_u8(data: &mut Vec<u8>, p: &NaslValue) {
 }
 
 /// NASL function to parse numeric values into characters and combine with additional values
-fn raw_string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn raw_string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut data: Vec<u8> = vec![];
     for p in positional {
@@ -53,7 +53,7 @@ fn raw_string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Funct
     Ok(data.into())
 }
 
-fn write_nasl_string(s: &mut String, value: &NaslValue) -> Result<(), FunctionError> {
+fn write_nasl_string(s: &mut String, value: &NaslValue) -> Result<(), FunctionErrorKind> {
     match value {
         NaslValue::String(x) => write!(s, "{x}"),
         NaslValue::Data(x) => {
@@ -82,11 +82,11 @@ fn write_nasl_string(s: &mut String, value: &NaslValue) -> Result<(), FunctionEr
         }
         _ => write!(s, "."),
     }
-    .map_err(|e| FunctionError::new("string", e.into()))
+    .map_err(|e| e.into())
 }
 
 /// NASL function to parse values into string representations
-fn string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut s = String::with_capacity(2 * positional.len());
     for p in positional {
@@ -95,7 +95,7 @@ fn string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
     Ok(s.into())
 }
 
-fn write_nasl_string_value(s: &mut String, value: &NaslValue) -> Result<(), FunctionError> {
+fn write_nasl_string_value(s: &mut String, value: &NaslValue) -> Result<(), FunctionErrorKind> {
     match value {
         NaslValue::Array(x) => {
             for p in x {
@@ -115,13 +115,13 @@ fn write_nasl_string_value(s: &mut String, value: &NaslValue) -> Result<(), Func
         NaslValue::AttackCategory(x) => write!(s, "{}", *x as i32),
         _ => Ok(()),
     }
-    .map_err(|e| FunctionError::new("string", e.into()))
+    .map_err(|e| e.into())
 }
 
 /// NASL function to return uppercase equivalent of a given string
 ///
 /// If this function retrieves anything but a string it returns NULL
-fn toupper<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn toupper<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.get(0) {
         Some(NaslValue::String(x)) => x.to_uppercase().into(),
@@ -138,7 +138,7 @@ fn toupper<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Function
 /// NASL function to return lowercase equivalent of a given string
 ///
 /// If this function retrieves anything but a string it returns NULL
-fn tolower<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn tolower<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.get(0) {
         Some(NaslValue::String(x)) => x.to_lowercase().into(),
@@ -155,7 +155,7 @@ fn tolower<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Function
 /// NASL function to return the length of string
 ///
 /// If this function retrieves anything but a string it returns 0
-fn strlen<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn strlen<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.get(0) {
         Some(NaslValue::String(x)) => x.len().into(),
@@ -171,7 +171,7 @@ fn strlen<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// The optional third positional argument is an *int* and contains the end index for the slice.
 /// If not given it is set to the end of the string.
 /// If the start integer is higher than the value of the string NULL is returned.
-fn substr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn substr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     if positional.len() < 2 {
         return Ok(NaslValue::Null);
@@ -197,12 +197,12 @@ fn substr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 ///
 /// If the positional arguments are empty it returns NaslValue::Null.
 /// It only uses the first positional argument and when it is not a NaslValue:String than it returns NaslValue::Null.
-fn hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
-    let hexler = |x: &str| -> Result<NaslValue, FunctionError> {
+    let hexler = |x: &str| -> Result<NaslValue, FunctionErrorKind> {
         let mut s = String::with_capacity(2 * x.len());
         for byte in x.as_bytes() {
-            write!(s, "{byte:02X}").map_err(|e| FunctionError::new("hexstr", e.into()))?
+            write!(s, "{byte:02X}")?
         }
         Ok(s.into())
     };
@@ -216,44 +216,35 @@ fn hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// NASL function to convert a hexadecimal representation into byte data.
 ///
 /// The first positional argument must be a string, all other arguments are ignored. If either the no argument was given or the first positional is not a string, a error is returned.
-fn hexstr_to_data<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn hexstr_to_data<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     match resolve_positional_arguments(register).get(0) {
         Some(NaslValue::String(x)) => match decode_hex(x) {
             Ok(y) => Ok(NaslValue::Data(y)),
-            Err(_) => Err(FunctionError::new(
-                "hexstr_to_data",
-                (
-                    "first positional argument",
-                    "a string only containing 0-9a-fA-F of a even length",
-                    x.as_str(),
-                )
-                    .into(),
-            )),
-        },
-        Some(x) => Err(FunctionError::new(
-            "hexstr_to_data",
-            (
+            Err(_) => Err((
                 "first positional argument",
-                "string",
-                x.to_string().as_str(),
+                "a string only containing 0-9a-fA-F of a even length",
+                x.as_str(),
             )
-                .into(),
-        )),
-        None => Err(FunctionError::new("hexstr_to_data", "0".into())),
+                .into()),
+        },
+        Some(x) => Err((
+            "first positional argument",
+            "string",
+            x.to_string().as_str(),
+        )
+            .into()),
+        None => Err("0".into()),
     }
 }
 
 /// NASL function to convert byte data into hexadecimal representation as lower case string.
 ///
 /// The first positional argument must be byte data, all other arguments are ignored. If either the no argument was given or the first positional is not byte data, a error is returned.
-fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     match resolve_positional_arguments(register).get(0) {
         Some(NaslValue::Data(x)) => Ok(encode_hex(x).into()),
-        Some(x) => Err(FunctionError::new(
-            "data_to_hexstr",
-            ("first positional argument", "data", x.to_string().as_str()).into(),
-        )),
-        None => Err(FunctionError::new("data_to_hexstr", "0".into())),
+        Some(x) => Err(("first positional argument", "data", x.to_string().as_str()).into()),
+        None => Err("0".into()),
     }
 }
 
@@ -261,7 +252,7 @@ fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, F
 ///
 /// Length argument is required and can be a named argument or a positional argument.
 /// Data argument is an optional named argument and is taken to be "X" if not provided.
-fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let data = match register.named("data") {
         None => "X",
         Some(ContextType::Value(NaslValue::String(x))) => x,
@@ -270,7 +261,7 @@ fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErr
                 ContextType::Value(a) => ("data", "string", a).into(),
                 ContextType::Function(_, _) => ("data", "string", "function").into(),
             };
-            return Err(FunctionError::new("crap", ek));
+            return Err(ek);
         }
     };
     match register.named("length") {
@@ -278,20 +269,20 @@ fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErr
             let positional = resolve_positional_arguments(register);
             match positional.get(0) {
                 Some(NaslValue::Number(x)) => Ok(NaslValue::String(data.repeat(*x as usize))),
-                x => Err(FunctionError::new("crap", ("0", "numeric", x).into())),
+                x => Err(("0", "numeric", x).into()),
             }
         }
         Some(ContextType::Value(NaslValue::Number(x))) => {
             Ok(NaslValue::String(data.repeat(*x as usize)))
         }
-        x => Err(FunctionError::new("crap", ("length", "numeric", x).into())),
+        x => Err(("length", "numeric", x).into()),
     }
 }
 
 /// NASL function to remove trailing whitespaces from a string
 ///
 /// Takes one required positional argument of string type.
-fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     match positional.get(0) {
         Some(NaslValue::String(x)) => Ok(x.trim_end().to_owned().into()),
@@ -302,7 +293,7 @@ fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionEr
             .trim_end()
             .to_owned()
             .into()),
-        x => Err(FunctionError::new("chomp", ("0", "string", x).into())),
+        x => Err(("0", "string", x).into()),
     }
 }
 
@@ -311,15 +302,15 @@ fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionEr
 /// The first positional argument is the *string* to search through.
 /// The second positional argument is the *string* to search for.
 /// The optional third positional argument is an *int* containing an offset from where to start the search.
-fn stridx<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn stridx<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let haystack = match positional.get(0) {
         Some(NaslValue::String(x)) => x,
-        x => return Err(FunctionError::new("stridx", ("0", "string", x).into())),
+        x => return Err(("0", "string", x).into()),
     };
     let needle = match positional.get(1) {
         Some(NaslValue::String(x)) => x,
-        x => return Err(FunctionError::new("stridx", ("1", "string", x).into())),
+        x => return Err(("1", "string", x).into()),
     };
     let offset = match positional.get(2) {
         Some(NaslValue::Number(x)) => *x as usize,
@@ -334,7 +325,7 @@ fn stridx<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// NASL function to display any number of NASL values
 ///
 /// Internally the string function is used to concatenate the given parameters
-fn display<K>(register: &Register, configs: &Context<K>) -> Result<NaslValue, FunctionError> {
+fn display<K>(register: &Register, configs: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     configs
         .logger()
         .print(string(register, configs)?.to_string());

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -5,7 +5,10 @@
 use nasl_syntax::{Statement, Statement::*, Token};
 
 use crate::{
-    error::InterpretError, interpreter::InterpretResult, lookup, lookup_keys::FC_ANON_ARGS,
+    error::{FunctionError, InterpretError},
+    interpreter::InterpretResult,
+    lookup,
+    lookup_keys::FC_ANON_ARGS,
     ContextType, Interpreter, NaslValue,
 };
 use std::collections::HashMap;
@@ -45,7 +48,8 @@ where
         self.registrat.create_root_child(named);
         let result = match lookup(name) {
             // Built-In Function
-            Some(function) => function(self.registrat, self.ctxconfigs).map_err(|x| x.into()),
+            Some(function) => function(self.registrat, self.ctxconfigs)
+                .map_err(|x| FunctionError::new(name, x).into()),
             // Check for user defined function
             None => {
                 let found = self

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -103,6 +103,12 @@ impl From<io::ErrorKind> for FunctionErrorKind {
     }
 }
 
+impl From<io::Error> for FunctionErrorKind {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e.kind())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionError {
     pub function: String,
@@ -115,20 +121,6 @@ impl FunctionError {
             function: function.to_owned(),
             kind,
         }
-    }
-}
-
-impl From<StorageError> for FunctionError {
-    // TODO remove
-    fn from(e: StorageError) -> Self {
-        Self::new("", e.into())
-    }
-}
-
-// TODO remove
-impl From<Infallible> for FunctionError {
-    fn from(e: Infallible) -> Self {
-        Self::new("", e.into())
     }
 }
 

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -7,7 +7,6 @@
 mod built_in_functions;
 mod error;
 mod naslvalue;
-use error::FunctionError;
 
 mod assign;
 mod call;
@@ -26,6 +25,7 @@ pub use context::Context;
 pub use context::ContextType;
 pub use context::DefaultContext;
 pub use context::Register;
+use error::FunctionErrorKind;
 pub use error::InterpretError;
 pub use error::InterpretErrorKind;
 pub use interpreter::Interpreter;
@@ -35,7 +35,8 @@ pub use naslvalue::NaslValue;
 
 // Is a type definition for built-in functions
 pub(crate) type NaslFunction<'a, K> =
-    fn(&Register, &Context<K>) -> Result<NaslValue, FunctionError>;
+    fn(&Register, &Context<K>) -> Result<NaslValue, FunctionErrorKind>;
+
 pub(crate) fn lookup<K>(function_name: &str) -> Option<NaslFunction<K>>
 where
     K: AsRef<str>,


### PR DESCRIPTION
To make it easier to handle FunctionError while writing builtin function
the NaslFunction is changed to return a FunctionErrorKind instead.

With this change the function name will be set on call when an error
occurs rather than enforcing the developer to copy and paste the
function name while creating the error.
