### PR TITLE
Refactor remove unwrap calls from production code

### DIFF
--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -57,8 +57,7 @@ where
 {
     fn save(&mut self, idx: usize, key: &str, value: NaslValue) {
         self.registrat
-            .add_to_index(idx, key, ContextType::Value(value))
-            .unwrap();
+            .add_to_index(idx, key, ContextType::Value(value));
     }
 
     fn named_value(&self, key: &str) -> Result<(usize, NaslValue), InterpretError> {

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_cbc.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_cbc.rs
@@ -55,8 +55,7 @@ where
             }
             let res = Decryptor::<D>::new_from_slices(key, iv);
             match res {
-                Ok(decryptor) => Ok(decryptor.decrypt_padded_vec_mut::<NoPadding>(data).unwrap()
-                    [..len]
+                Ok(decryptor) => Ok(decryptor.decrypt_padded_vec_mut::<NoPadding>(data)?[..len]
                     .to_vec()
                     .into()),
                 Err(e) => Err(crate::error::FunctionErrorKind::WrongArgument(

--- a/rust/nasl-interpreter/src/built_in_functions/string.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/string.rs
@@ -242,7 +242,7 @@ fn hexstr_to_data<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, F
 /// The first positional argument must be byte data, all other arguments are ignored. If either the no argument was given or the first positional is not byte data, a error is returned.
 fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
     match resolve_positional_arguments(register).get(0) {
-        Some(NaslValue::Data(x)) => Ok(encode_hex(x).into()),
+        Some(NaslValue::Data(x)) => Ok(encode_hex(x)?.into()),
         Some(x) => Err(("first positional argument", "data", x.to_string().as_str()).into()),
         None => Err("0".into()),
     }

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -4,10 +4,16 @@
 
 use std::{convert::Infallible, io};
 
+use aes::cipher::block_padding::UnpadError;
 use nasl_syntax::{Statement, SyntaxError, TokenCategory};
 use storage::StorageError;
 
 use crate::{ContextType, LoadError, NaslValue};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CryptErrorKind {
+    Unpad,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionErrorKind {
@@ -21,6 +27,13 @@ pub enum FunctionErrorKind {
     // Diagnostic string is informational and the second arg is the return value for the user
     Diagnostic(String, Option<NaslValue>),
     GeneralError(String),
+    CryptError(CryptErrorKind),
+}
+
+impl From<UnpadError> for FunctionErrorKind {
+    fn from(_: UnpadError) -> Self {
+        FunctionErrorKind::CryptError(CryptErrorKind::Unpad)
+    }
 }
 
 impl From<(&str, &str, &str)> for FunctionErrorKind {

--- a/rust/nasl-interpreter/src/helper.rs
+++ b/rust/nasl-interpreter/src/helper.rs
@@ -4,6 +4,8 @@
 
 use std::{fmt::Write, num::ParseIntError};
 
+use crate::error::FunctionErrorKind;
+
 pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
     (0..s.len())
         .step_by(2)
@@ -11,10 +13,10 @@ pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
         .collect()
 }
 
-pub fn encode_hex(bytes: &[u8]) -> String {
+pub fn encode_hex(bytes: &[u8]) -> Result<String, FunctionErrorKind> {
     let mut s = String::with_capacity(bytes.len() * 2);
     for &b in bytes {
-        write!(&mut s, "{:02x}", b).unwrap();
+        write!(&mut s, "{:02x}", b)?;
     }
-    s
+    Ok(s)
 }

--- a/rust/nasl-interpreter/src/interpreter.rs
+++ b/rust/nasl-interpreter/src/interpreter.rs
@@ -157,8 +157,8 @@ where
                 Ok(value) => {
                     if bool::from(value) {
                         return self.resolve(if_block);
-                    } else if else_block.is_some() {
-                        return self.resolve(else_block.as_ref().unwrap());
+                    } else if let Some(else_block) = else_block {
+                        return self.resolve(else_block.as_ref());
                     }
                     Ok(NaslValue::Null)
                 }

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -388,7 +388,9 @@ where
 
     /// Reset the NVT Cache and release the redis namespace
     pub fn reset(&self) -> RedisStorageResult<()> {
-        let mut cache = Arc::as_ref(&self.cache).lock().unwrap();
+        let mut cache = Arc::as_ref(&self.cache)
+            .lock()
+            .map_err(|e| DbError::SystemError(format!("{e:?}")))?;
         cache.delete_namespace()
     }
 }
@@ -399,12 +401,12 @@ where
     K: AsRef<str>,
 {
     fn dispatch_nvt(&self, nvt: Nvt) -> Result<(), StorageError> {
-        let mut cache = Arc::as_ref(&self.cache).lock().unwrap();
+        let mut cache = Arc::as_ref(&self.cache).lock()?;
         cache.redis_add_nvt(nvt).map_err(|e| e.into())
     }
 
     fn dispatch_feed_version(&self, version: String) -> Result<(), StorageError> {
-        let mut cache = Arc::as_ref(&self.cache).lock().unwrap();
+        let mut cache = Arc::as_ref(&self.cache).lock()?;
         cache.rpush(CACHE_KEY, &[&version]).map_err(|e| e.into())
     }
 


### PR DESCRIPTION
Instead of using unwrap most cases are wrapping an error to a
FunctionErrorKind of InterpretError.

Fixes: SC-797
