### PR TITLE
Add nasl built-in function aes_cmac

### DIFF
--- a/rust/nasl-interpreter/Cargo.toml
+++ b/rust/nasl-interpreter/Cargo.toml
@@ -27,3 +27,4 @@ ccm = "0.5.0"
 cbc = { version = "0.1.2", features = ["alloc"]}
 ctr = "0.9.2"
 aes-gcm = { version = "0.10.1"}
+cmac = "0.7.2"

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_cmac.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/aes_cmac.rs
@@ -1,0 +1,61 @@
+use aes::Aes128;
+use cmac::{Cmac, Mac};
+
+use crate::{
+    built_in_functions::cryptography::{get_data, get_key},
+    Context, FunctionErrorKind, NaslFunction, NaslValue, Register,
+};
+
+/// NASL function to calculate CMAC wit AES128.
+///
+/// This function expects 2 named arguments key and data either in a string or data type.
+/// It is important to notice, that internally the CMAC algorithm is used and not, as the name
+/// suggests, CBC-MAC.
+fn aes_cmac<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+    let key = get_key(register)?;
+    let data = get_data(register)?;
+
+    let mut mac = Cmac::<Aes128>::new_from_slice(key)?;
+    mac.update(data);
+
+    Ok(mac.finalize().into_bytes().to_vec().into())
+}
+
+pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+    match key {
+        "aes_mac_cbc" => Some(aes_cmac),
+        "aes_cmac" => Some(aes_cmac),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use nasl_syntax::parse;
+
+    use crate::{helper::decode_hex, DefaultContext, Interpreter, Register};
+
+    #[test]
+    fn aes_mac_cbc() {
+        let code = r###"
+        key = hexstr_to_data("e3ceb929b52a6eec02b99b13bf30721b");
+        data = hexstr_to_data("d2e8a3e86ae0b9edc7cc3116d929a16f13ee3643");
+        crypt = aes_mac_cbc(key: key, data: data);
+        "###;
+        let mut register = Register::default();
+        let binding = DefaultContext::default();
+        let context = binding.as_context();
+        let mut interpreter = Interpreter::new(&mut register, &context);
+        let mut parser =
+            parse(code).map(|x| interpreter.resolve(&x.expect("no parse error expected")));
+        parser.next();
+        parser.next();
+        assert_eq!(
+            parser.next(),
+            Some(Ok(crate::NaslValue::Data(
+                decode_hex("10f3d29e89e4039b85e16438b2b2a470").unwrap()
+            )))
+        );
+    }
+}

--- a/rust/nasl-interpreter/src/built_in_functions/cryptography/mod.rs
+++ b/rust/nasl-interpreter/src/built_in_functions/cryptography/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 
 pub mod aes_cbc;
 pub mod aes_ccm;
+pub mod aes_cmac;
 pub mod aes_ctr;
 pub mod aes_gcm;
 pub mod hmac;
@@ -27,6 +28,7 @@ where
         .or_else(|| aes_cbc::lookup(function_name))
         .or_else(|| aes_ctr::lookup(function_name))
         .or_else(|| aes_gcm::lookup(function_name))
+        .or_else(|| aes_cmac::lookup(function_name))
 }
 
 /// Get named argument of Type Data or String from the register with appropriate error handling.

--- a/rust/nasl-interpreter/src/error.rs
+++ b/rust/nasl-interpreter/src/error.rs
@@ -5,6 +5,7 @@
 use std::{convert::Infallible, fmt::Display, io};
 
 use aes::cipher::block_padding::UnpadError;
+use digest::InvalidLength;
 use nasl_syntax::{Statement, SyntaxError, TokenCategory};
 use storage::StorageError;
 
@@ -15,6 +16,8 @@ use crate::{ContextType, LoadError, NaslValue};
 pub enum CryptErrorKind {
     /// Unpadding error
     Unpad,
+    /// Invalid key size
+    KeySize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -71,6 +74,12 @@ impl Display for FunctionErrorKind {
 impl From<UnpadError> for FunctionErrorKind {
     fn from(_: UnpadError) -> Self {
         FunctionErrorKind::CryptError(CryptErrorKind::Unpad)
+    }
+}
+
+impl From<InvalidLength> for FunctionErrorKind {
+    fn from(_: InvalidLength) -> Self {
+        FunctionErrorKind::CryptError(CryptErrorKind::KeySize)
     }
 }
 


### PR DESCRIPTION
**What**:
Add built-in function `aes_cmac` for rust implementation to calculate cmac with AES128.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
