### PR TITLE
Fix ksba

### DIFF
--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -40,7 +40,7 @@ pkg_check_modules (LIBSSH REQUIRED libssh>=0.6.0)
 
 set (KSBA_MIN_VERSION "1.0.7")
 # try with package config
-pkg_check_modules (KSBA REQUIRED ksba>=1.0.7)
+pkg_check_modules (KSBA ksba>=1.0.7)
 if (NOT KSBA_FOUND)
   # try with find library
   find_library (KSBA ksba)


### PR DESCRIPTION
**What**:

The pkgconfig search can fails, when find_library must be used.

**Why**:

The build fails when ksba can only find via find_library.

**How**:

Simple remove the REQUIRED from pkg_check_modules

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
