### PR TITLE
Change: Make installing nvt feed sync script optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if (NOT CMAKE_BUILD_TYPE)
 endif (NOT CMAKE_BUILD_TYPE)
 
 OPTION (ENABLE_COVERAGE "Enable support for coverage analysis" OFF)
+# the shell based script got replaced by https://github.com/greenbone/greenbone-feed-sync/
+OPTION (INSTALL_OLD_SYNC_SCRIPT "Install shell based VT feed sync script" OFF)
 
 ## Retrieve git revision (at configure time)
 include (GetGit)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,17 +234,20 @@ install (TARGETS openvas
 install (FILES ${CMAKE_BINARY_DIR}/src/openvas_log.conf
          DESTINATION ${OPENVAS_SYSCONF_DIR})
 
-install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-nvt-sync
-         DESTINATION ${BINDIR}
-         PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
-                     GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+if (INSTALL_OLD_SYNC_SCRIPT)
+  install (FILES ${CMAKE_BINARY_DIR}/tools/greenbone-nvt-sync
+          DESTINATION ${BINDIR}
+          PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
+                      GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+  install (FILES ${CMAKE_SOURCE_DIR}/doc/greenbone-nvt-sync.8
+          DESTINATION ${DATADIR}/man/man8 )
+endif (INSTALL_OLD_SYNC_SCRIPT)
+
 
 install (FILES ${CMAKE_BINARY_DIR}/doc/openvas.8
          DESTINATION ${DATADIR}/man/man8 )
 
-
-install (FILES ${CMAKE_SOURCE_DIR}/doc/greenbone-nvt-sync.8
-         DESTINATION ${DATADIR}/man/man8 )
 
 install (DIRECTORY DESTINATION ${OPENVAS_NVT_DIR})
 


### PR DESCRIPTION
## What:

A new Python based greenbone-feed-sync script is available at https://github.com/greenbone/greenbone-feed-sync/ and should be used instead of the shell based greenbone-nvt-sync script shipped with openvas-scanner. The new script is easier to maintain, to adapt and can be released independently.

Therefore make installing the shell optional and don't install it by default anymore. To still install the script 
`cmake -DINSTALL_OLD_SYNC_SCRIPTS=ON` can be used.

## Why

Users should switch to the new sync script as soon as possible. Therefore don't install it anymore in the next release by default.

## References

Replaces https://github.com/greenbone/openvas-scanner/pull/1337

DEVOPS-516