### PR TITLE
 Change: error handling in HashSumNameLoader

### DIFF
--- a/rust/feed/src/verify/mod.rs
+++ b/rust/feed/src/verify/mod.rs
@@ -126,7 +126,7 @@ impl<'a, R: Read> HashSumNameLoader<'a, R> {
         let buf = reader
             .as_bufreader(Hasher::Sha256.sum_file())
             .map(|x| x.lines())
-            .map_err(|_| Error::SumsFileCorrupt(Hasher::Sha256))?;
+            .map_err(Error::LoadError)?;
         Ok(Self::new(buf, reader, Hasher::Sha256))
     }
 }


### PR DESCRIPTION
Refactors the error handling in HashSumNameLoader from SumsFileCorrupt
to LoadError, making it more general and easier to handle.

