### PR TITLE
Fix: prod.Dockerfile multi-arch support and workflow

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -12,6 +12,7 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /sou
 RUN DESTDIR=/install cmake --build /build -- install
 
 FROM greenbone/gvm-libs:$VERSION
+ARG TARGETPLATFORM
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
   bison \
   libjson-glib-1.0-0 \
@@ -40,7 +41,7 @@ COPY .docker/openvas.conf /etc/openvas/
 # must be pre built within the rust dir and moved to the bin dir
 # usually this image is created within in a ci ensuring that the
 # binary is available.
-COPY bin/nasl-cli/nasl-cli /usr/local/bin/nasl-cli
+COPY bin/nasl-cli/$TARGETPLATFORM/nasl-cli /usr/local/bin/nasl-cli
 RUN chmod a+x /usr/local/bin/nasl-cli
 COPY --from=build /install/ /
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,4 +1,4 @@
-name: Container
+name: Build Container
 
 on:
   push:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,7 +30,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: sudo apt update && sudo apt-get install -y libpcap-dev libssl-dev
       - run: rustup update stable && rustup default stable
-      - run: cargo install cross
+      # This command will attempt to install 'cross', but if it's already
+      # installed due to caching, it will do nothing and proceed without error.
+      - run: cargo install cross || true
       - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
       - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
       - name: archive nasl-cli aarch64-unknown-linux-gnu
@@ -48,11 +50,6 @@ jobs:
   production-image:
     runs-on: ubuntu-latest
     needs: [nasl-cli-release]
-    strategy:
-      matrix:
-        platform:
-          - amd64
-          - aarch64
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -112,8 +109,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
-          name: nasl-cli-${{ matrix.platform }}
-          path: bin/nasl-cli
+          name: nasl-cli-amd64
+          path: bin/nasl-cli/linux/amd64
+      - uses: actions/download-artifact@v3
+        with:
+          name: nasl-cli-aarch64
+          path: bin/nasl-cli/linux/arm64
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -126,6 +127,6 @@ jobs:
           file: .docker/prod.Dockerfile
           build-args: |
             REPOSITORY=${{ github.repository }}
-          platforms: linux/${{ matrix.platform }}
+          platforms: linux/amd64,linux/aarch64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
When running the 'docker build push' action in a matrix, it overrides the previously existing platform tag instead of adding it.

To solve this issue, differentiate defined platforms within the 'prod.Dockerfile' and adjust the settings accordingly.