### PR TITLE
Fix: Docker: aarch64: missing libz.so and libpcap.so.0.8

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libroken18-heimdal \
   libhdb9-heimdal \
   libpopt0 \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 COPY .docker/openvas.conf /etc/openvas/
 # must be pre built within the rust dir and moved to the bin dir

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,22 +19,15 @@ jobs:
     steps:
       # install rustup
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: sudo apt update && sudo apt-get install -y libpcap-dev libssl-dev
       - run: rustup update stable && rustup default stable
       # This command will attempt to install 'cross', but if it's already
       # installed due to caching, it will do nothing and proceed without error.
       - run: cargo install cross || true
       - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
       - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
+      - name: "patch for debian stable"
+        run: |
+          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/aarch64-unknown-linux-gnu/release/nasl-cli
       - name: archive nasl-cli aarch64-unknown-linux-gnu
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,9 @@ jobs:
         working-directory: rust
       - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
         working-directory: rust
+      - name: "patch for debian stable"
+        run: |
+          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/aarch64-unknown-linux-gnu/release/nasl-cli
       - run: mkdir assets/
       - run: mv rust/target/aarch64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-aarch64-unknown-linux-gnu
       - run: mv rust/target/x86_64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-x86_64-unknown-linux-gnu


### PR DESCRIPTION
Using patchelf to patch the binary for debian stable from libpcap.so.1 to libpcap.so.0.8.

Add zlib1g-dev to apt install in prod.Dockerfile so that the libz.so is available on the aarch64 platform.

Lastly, I wanted to mention how much I appreciate NixOS for patchelf.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
