### PR TITLE
Change: Make the NVT Tag member a BTreeMap instead of HashMap

### DIFF
--- a/rust/json-storage/src/lib.rs
+++ b/rust/json-storage/src/lib.rs
@@ -151,7 +151,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use storage::nvt::{Nvt, ACT};
 
@@ -165,11 +165,11 @@ mod tests {
             .join(".")
     }
 
-    fn generate_tags() -> HashMap<storage::nvt::TagKey, storage::nvt::TagValue> {
+    fn generate_tags() -> BTreeMap<storage::nvt::TagKey, storage::nvt::TagValue> {
         use storage::nvt::TagKey::*;
         use storage::nvt::TagValue;
         let ts = "2012-09-23 02:15:34 -0400";
-        HashMap::from([
+        BTreeMap::from([
             (Affected, TagValue::parse(Affected, "Affected").unwrap()),
             (CreationDate, TagValue::parse(CreationDate, ts).unwrap()),
             (

--- a/rust/storage/src/nvt.rs
+++ b/rust/storage/src/nvt.rs
@@ -4,12 +4,13 @@
 
 //! Defines NVT
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fmt::Display,
     marker::PhantomData,
     str::FromStr,
     sync::{Arc, Mutex},
 };
+
 
 use crate::{time::AsUnixTimeStamp, types, Dispatcher, Field, Kb, Retriever, StorageError};
 
@@ -96,7 +97,7 @@ impl FromStr for ACT {
 macro_rules! make_str_lookup_enum {
     ($enum_name:ident: $doc:expr => { $($matcher:ident => $key:ident),+ }) => {
         #[doc = $doc]
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord,PartialOrd)]
         #[cfg_attr(feature = "serde_support",
                    derive(serde::Serialize, serde::Deserialize),
                    serde(rename_all = "snake_case")
@@ -141,6 +142,7 @@ impl Display for TagKey {
         write!(f, "{}", self.as_ref())
     }
 }
+
 
 make_str_lookup_enum! {
     TagKey: "Allowed keys for a tag" => {
@@ -416,7 +418,7 @@ pub struct Nvt {
     /// The filename of the nvt.
     pub filename: String,
     /// The tags of the nvt.
-    pub tag: HashMap<TagKey, TagValue>,
+    pub tag: BTreeMap<TagKey, TagValue>,
     /// The direct dependencies of the nvt.
     pub dependencies: Vec<String>,
     /// The required keys to run the NVT.


### PR DESCRIPTION
**What**:
Change: Make the NVT Tag member a BTreeMap instead of HashMap
This is because BTreeMap is an ordered collection of key-value pairs. 
Jira: SC-820
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This PR solves an issue in which two generateed json files from the same feed were different, because the the tags were stored in a different order.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
