### PR TITLE
Not all versions of net-snmp support DES anymore.

### DIFF
--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -313,7 +313,8 @@ snmpv3_get (const snmpv3_request_t request, snmp_result_t result)
       else
         {
 #ifdef NETSNMP_DISABLE_DES
-          result->name = g_strdup ("DES not supported in this net-snmp version.");
+          result->name =
+            g_strdup ("DES not supported in this net-snmp version.");
           return -1;
 #else
           session.securityPrivProto = usmDESPrivProtocol;

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -312,8 +312,13 @@ snmpv3_get (const snmpv3_request_t request, snmp_result_t result)
         }
       else
         {
+#ifdef NETSNMP_DISABLE_DES
+          result->name = g_strdup ("DES not supported in this net-snmp version.");
+          return -1;
+#else
           session.securityPrivProto = usmDESPrivProtocol;
           session.securityPrivProtoLen = USM_PRIV_PROTO_DES_LEN;
+#endif
         }
       session.securityPrivKeyLen = USM_PRIV_KU_LEN;
       if (generate_Ku (session.securityAuthProto, session.securityAuthProtoLen,


### PR DESCRIPTION
**What**:
On net-snmp lib's without DES support the build fails.

**Why**:

Not all versions of the  net-snmp has support for the old DES cypher.

**How**:

Detect this problem and report is as an error, when try using it.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
