### PR TITLE
Change: rename queued to stored 

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -253,8 +253,8 @@ paths:
               examples:
                 schema:
                   description: "Schema of a status response."
-                status of a queued scan:
-                  $ref: "#/components/examples/scan_status_queued"
+                status of a stored scan:
+                  $ref: "#/components/examples/scan_status_stored"
                 status of a running scan:
                   $ref: "#/components/examples/scan_status_running"
                 status of a succeeded scan:
@@ -589,6 +589,7 @@ components:
           description: "In which phase the scan is currently in."
           type: "string"
           enum:
+            - stored
             - requested
             - running
             - stopped
@@ -811,9 +812,9 @@ components:
           "message": "Installed version: 9.53.3\nFixed version:     9.55\nInstallation\npath / port:       /usr/bin/gs",
         }
 
-    scan_status_queued:
+    scan_status_stored:
       description: "Status of a queued Scan"
-      value: { "status": "queued" }
+      value: { "status": "stored" }
 
     scan_status_running:
       description: "Status of a running Scan"

--- a/rust/models/src/status.rs
+++ b/rust/models/src/status.rs
@@ -55,7 +55,7 @@ impl Status {
 pub enum Phase {
     /// A scan has been stored but not started yet
     #[default]
-    Declared,
+    Stored,
     /// A scan has been requested, but not started yet
     Requested,
     /// A scan is currently running
@@ -82,7 +82,7 @@ impl Display for Phase {
             Self::Stopped => write!(f, "stopped"),
             Self::Failed => write!(f, "failed"),
             Self::Succeeded => write!(f, "succeeded"),
-            Self::Declared => write!(f, "stored"),
+            Self::Stored => write!(f, "stored"),
         }
     }
 }

--- a/rust/sensord/src/controller/entry.rs
+++ b/rust/sensord/src/controller/entry.rs
@@ -166,7 +166,7 @@ where
                                 if progress.status.is_running() =>
                             {
                                 use models::Phase::*;
-                                let expected = &[Declared, Stopped, Failed, Succeeded];
+                                let expected = &[Stored, Stopped, Failed, Succeeded];
                                 Ok(ctx
                                     .response
                                     .not_accepted(&progress.status.status, expected))


### PR DESCRIPTION
Instead of queued we use stored to describe that a scan is stored but
not yet started.

This means a scan is stored it gets the status stored and when started
it switches to requested until the scan is actually running and then it
will be in the state running.

- stored => scan is stored
- requested =>  scan is started
- running => scan is running
- stopped | failed | succeeded => scan is done