### PR TITLE
Fix: Docker: x86_64 nasl-cli

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -36,14 +36,14 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libroken18-heimdal \
   libhdb9-heimdal \
   libpopt0 \
-  zlib1g-dev \
+  zlib1g\
   && rm -rf /var/lib/apt/lists/*
 COPY .docker/openvas.conf /etc/openvas/
 # must be pre built within the rust dir and moved to the bin dir
 # usually this image is created within in a ci ensuring that the
 # binary is available.
-COPY bin/nasl-cli/$TARGETPLATFORM/nasl-cli /usr/local/bin/nasl-cli
-RUN chmod a+x /usr/local/bin/nasl-cli
+COPY assets/$TARGETPLATFORM/nasl-cli /usr/local/bin/nasl-cli
+RUN chmod +x /usr/local/bin/nasl-cli
 COPY --from=build /install/ /
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -1,0 +1,60 @@
+name: "rs-build"
+
+on: [workflow_call] 
+
+
+# This job builds the targets for x86_64 as well as aarch64. It is intented to 
+# be included in the other jobs by calling:
+# ```
+# jobs:
+#   name:
+#     uses: ./.github/workflows/build-rust.yml
+# ```
+#
+# It saves the binaris:
+# - nasl-cli
+# - feed-verofier
+#
+# as rs-binaries.
+#
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      # create branch of version
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: rustup update stable && rustup default stable
+        # ignore failing install, it may already be installed
+      - run: cargo install cross || true
+      - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
+        working-directory: rust
+      - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
+        working-directory: rust
+      - name: "patch for debian stable"
+        working-directory: rust
+        run: |
+          find . -type f -name "nasl-cli"
+          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/aarch64-unknown-linux-gnu/release/nasl-cli
+          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/x86_64-unknown-linux-gnu/release/nasl-cli
+          patchelf --replace-needed libz.so libz.so.1 target/aarch64-unknown-linux-gnu/release/nasl-cli
+          patchelf --replace-needed libz.so libz.so.1 target/x86_64-unknown-linux-gnu/release/nasl-cli
+      - run: mkdir assets/
+      - run: mv rust/target/aarch64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-aarch64-unknown-linux-gnu
+      - run: mv rust/target/x86_64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-x86_64-unknown-linux-gnu
+      - run: mv rust/target/aarch64-unknown-linux-gnu/release/feed-verifier assets/feed-verifier-aarch64-unknown-linux-gnu
+      - run: mv rust/target/x86_64-unknown-linux-gnu/release/feed-verifier assets/feed-verifier-x86_64-unknown-linux-gnu
+      - name: archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: rs-binaries
+          path: assets/*
+          retention-days: 1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -10,39 +10,12 @@ on:
   repository_dispatch:
 
 jobs:
-  nasl-cli-release:
-    runs-on:
-     - ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust
-    steps:
-      # install rustup
-      - uses: actions/checkout@v3
-      - run: rustup update stable && rustup default stable
-      # This command will attempt to install 'cross', but if it's already
-      # installed due to caching, it will do nothing and proceed without error.
-      - run: cargo install cross || true
-      - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
-      - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
-      - name: "patch for debian stable"
-        run: |
-          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/aarch64-unknown-linux-gnu/release/nasl-cli
-      - name: archive nasl-cli aarch64-unknown-linux-gnu
-        uses: actions/upload-artifact@v3
-        with:
-          name: nasl-cli-aarch64
-          path: rust/target/aarch64-unknown-linux-gnu/release/nasl-cli
-          retention-days: 1
-      - name: archive nasl-cli x86_64-unknown-linux-gnu
-        uses: actions/upload-artifact@v3
-        with:
-          name: nasl-cli-amd64
-          path: rust/target/x86_64-unknown-linux-gnu/release/nasl-cli
-          retention-days: 1
+  rs-build-binaries:
+    uses: ./.github/workflows/build-rust.yml
+
   production-image:
     runs-on: ubuntu-latest
-    needs: [nasl-cli-release]
+    needs: [rs-build-binaries]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -100,14 +73,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: actions/download-artifact@v3
         with:
-          name: nasl-cli-amd64
-          path: bin/nasl-cli/linux/amd64
-      - uses: actions/download-artifact@v3
-        with:
-          name: nasl-cli-aarch64
-          path: bin/nasl-cli/linux/arm64
+          name: rs-binaries
+          path: assets
+      - run: mkdir -p assets/linux/amd64
+      - run: mkdir -p assets/linux/arm64
+      - run: mv assets/nasl-cli-aarch64-unknown-linux-gnu assets/linux/arm64/nasl-cli
+      - run: mv assets/nasl-cli-x86_64-unknown-linux-gnu assets/linux/amd64/nasl-cli
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,16 @@ jobs:
           echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
           echo "project=$(echo "${{ github.repository }}" | sed 's/.*\///' )" >> "$GITHUB_OUTPUT"
 
+  build-binaries:
+    needs: calculate_version
+    uses: ./.github/workflows/build-rust.yml
+
 
   release:
     name: release
-    needs: calculate_version
+    needs: 
+      - build-binaries
+      - calculate_version
     runs-on: "ubuntu-latest"
     env:
       RELEASE_KIND: ${{needs.calculate_version.outputs.release_kind}}
@@ -160,32 +166,10 @@ jobs:
             git commit -m "Automated commit: change version from ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}"
             git push origin ${{ env.RELEASE_REF }}
           fi
-
-      - uses: actions/cache@v3
+      - uses: actions/download-artifact@v3
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: rustup update stable && rustup default stable
-        # ignore failing install, it may already be installed
-      - run: cargo install cross || true
-      - run: CROSS_CONFIG=Cross.toml cross -v build --release --target aarch64-unknown-linux-gnu
-        working-directory: rust
-      - run: CROSS_CONFIG=Cross.toml cross build --release --target x86_64-unknown-linux-gnu
-        working-directory: rust
-      - name: "patch for debian stable"
-        working-directory: rust
-        run: |
-          find . -type f -name "nasl-cli"
-          patchelf --replace-needed libpcap.so.1 libpcap.so.0.8 target/aarch64-unknown-linux-gnu/release/nasl-cli
-      - run: mkdir assets/
-      - run: mv rust/target/aarch64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-aarch64-unknown-linux-gnu
-      - run: mv rust/target/x86_64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-x86_64-unknown-linux-gnu
-
+          name: rs-binaries
+          path: assets
       - uses: greenbone/actions/setup-pontos@v2
       - name: release ${{ env.PROJECT }} ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
         run: |

--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -72,54 +72,25 @@ jobs:
           - nasl-cli
     steps:
       - uses: actions/checkout@v3
-  releases:
-    runs-on:
-     - ubuntu-20.04
-    defaults:
-      run:
-        working-directory: rust
-    steps:
-      # install rustup
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            rust/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: sudo apt update && sudo apt-get install -y libpcap-dev
-      - run: rustup update stable && rustup default stable
-      - run: cargo build --lib --release
-      - run: cargo build --bins --release
-      - name: archive nasl-cli
-        uses: actions/upload-artifact@v3
-        with:
-          name: nasl-cli
-          path: rust/target/release/nasl-cli
-          retention-days: 1
-      - name: archive feed-verifier
-        uses: actions/upload-artifact@v3
-        with:
-          name: feed-verifier
-          path: rust/target/release/feed-verifier
-          retention-days: 1
+  rs-build-binaries:
+    uses: ./.github/workflows/build-rust.yml
   verify-syntax:
     runs-on: ubuntu-latest
-    needs: [releases]
+    needs: [rs-build-binaries]
     steps:
       - uses: actions/checkout@v3
       - run: FEED_DIR="feed/" sh .github/prepare-feed.sh
       - uses: actions/download-artifact@v3
         with:
-          name: nasl-cli
+          name: rs-binaries
+          path: assets
+      - run: mv assets/nasl-cli-x86_64-unknown-linux-gnu ./nasl-cli
+      - run: chmod +x ./nasl-cli
       - name: verify syntax parsing
-        run: chmod a+x ./nasl-cli && ./nasl-cli syntax --quiet feed/
+        run: ./nasl-cli syntax --quiet feed/
   verify-feed-update:
     runs-on: ubuntu-latest
-    needs: [releases]
+    needs: [rs-build-binaries]
     container:
       # maybe better to use builder, build openvas to have
       # the version of this checkout rather than a dataed official one?
@@ -139,10 +110,10 @@ jobs:
       - run: FEED_DIR="feed/" sh .github/prepare-feed.sh
       - uses: actions/download-artifact@v3
         with:
-          name: nasl-cli
-      - uses: actions/download-artifact@v3
-        with:
-          name: feed-verifier
+          name: rs-binaries
+          path: assets
+      - run: mv assets/nasl-cli-x86_64-unknown-linux-gnu ./nasl-cli
+      - run: mv assets/feed-verifier-x86_64-unknown-linux-gnu ./feed-verifier
       - name: prepare setup
         run: |
           install -m 755 feed-verifier /usr/local/bin/

--- a/rust/cross.Dockerfile
+++ b/rust/cross.Dockerfile
@@ -1,4 +1,40 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 RUN apt-get update && apt-get install -y \
-  libpcap-dev libssh-dev zlib1g-dev
+  bison \
+  flex \
+  curl \
+  zlib1g-dev
+RUN curl -o /tmp/pcap.tar.gz https://www.tcpdump.org/release/libpcap-1.10.3.tar.gz
+WORKDIR /tmp
+RUN tar xvf pcap.tar.gz
+RUN ls -las
+WORKDIR /tmp/libpcap-1.10.3
+ENV CC=x86_64-linux-gnu-gcc
+ENV CFLAGS='-Os'
+RUN ./configure --host=x86_64-unknown-linux-gnu --with-pcap=linux
+RUN cat config.log
+RUN make install
+
+RUN curl --output /tmp/zlib.tar.gz https://www.zlib.net/zlib-1.2.13.tar.gz
+WORKDIR /tmp
+RUN tar xvf zlib.tar.gz
+WORKDIR /tmp/zlib-1.2.13
+ENV CC=x86_64-linux-gnu-gcc
+ENV CHOST=amd64
+RUN ./configure
+RUN make install
+RUN ldconfig
+
+RUN curl -o /tmp/openssl.tar.gz https://www.openssl.org/source/old/1.1.1/openssl-1.1.1.tar.gz
+WORKDIR /tmp
+RUN tar xvf openssl.tar.gz
+RUN ls -las
+WORKDIR /tmp/openssl-1.1.1
+ENV CC=x86_64-linux-gnu-gcc
+ENV CFLAGS='-Os'
+RUN ./Configure linux-x86_64 --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+ENV LD_LIBRARY_PATH=/usr/local/ssl/lib:${LD_LIBRARY_PATH}
+RUN ldconfig
+RUN make install
+ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig:${PKG_CONFIG_PATH}


### PR DESCRIPTION
Changes the cross.Dockerfile to also build the dependencies as in the arch64 versions so that we can control the libssh version.

It fixes a bug with zlib and uses zlib.so.1 instead of zlib.so to enable usage of zlib1g instead of zlib1g-dev.

It also moved to building of the rust binaries to `build-rust.yml` which is used in container, rustification as well as release. This ensures that the binaries are build in the same way everywhere.

Fixes: SC-852 GOS-1402