### PR TITLE
Add: Register builder to add predefined nasl variables

### DIFF
--- a/rust/examples/hello.nasl
+++ b/rust/examples/hello.nasl
@@ -10,3 +10,9 @@ if (description == 1) {
 }
 
 display("Hello, world!");
+
+
+display("de nuevo");
+display(TEST1);
+display(IPPROTO_IP);
+display(ARP_PROTO_LEN);

--- a/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
@@ -18,19 +18,19 @@ use nasl_builtin_utils::{Context, ContextType, NaslFunction, Register};
 use nasl_syntax::NaslValue;
 
 /// Hardware type ethernet
-const ARPHRD_ETHER: u16 = 0x0001;
+pub const ARPHRD_ETHER: u16 = 0x0001;
 /// Protocol type IP
-const ETHERTYPE_IP: u16 = 0x0800;
+pub const ETHERTYPE_IP: u16 = 0x0800;
 /// Protocol type ARP
-const ETHERTYPE_ARP: u16 = 0x0806;
+pub const ETHERTYPE_ARP: u16 = 0x0806;
 /// Length in bytes of an ethernet mac address
-const ETH_ALEN: u8 = 0x0006;
+pub const ETH_ALEN: u8 = 0x0006;
 /// Protocol length for ARP
-const ARP_PROTO_LEN: u8 = 0x0004;
+pub const ARP_PROTO_LEN: u8 = 0x0004;
 /// ARP operation request
-const ARPOP_REQUEST: u16 = 0x0001;
+pub const ARPOP_REQUEST: u16 = 0x0001;
 /// Default Timeout for received
-const DEFAULT_TIMEOUT: i32 = 5000;
+pub const DEFAULT_TIMEOUT: i32 = 5000;
 
 #[derive(Debug)]
 /// Structure to hold a datalink layer frame

--- a/rust/nasl-builtin-raw-ip/src/lib.rs
+++ b/rust/nasl-builtin-raw-ip/src/lib.rs
@@ -1,5 +1,6 @@
 mod frame_forgery;
-use nasl_builtin_utils::{Context, Register};
+use nasl_builtin_utils::{Context, NaslVars, Register};
+use nasl_syntax::NaslValue;
 
 pub struct RawIp;
 
@@ -15,5 +16,46 @@ impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for RawIp {
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
         frame_forgery::lookup::<K>(name).is_some()
+    }
+}
+
+impl nasl_builtin_utils::NaslVarDefiner for RawIp {
+    fn nasl_var_define(&self) -> NaslVars {
+        let builtin_vars: NaslVars = [
+            // Hardware type ethernet
+            (
+                "ARPHRD_ETHER",
+                NaslValue::Number(frame_forgery::ARPHRD_ETHER.into()),
+            ),
+            // Protocol type IP
+            (
+                "ETHERTYPE_IP",
+                NaslValue::Number(frame_forgery::ETHERTYPE_IP.into()),
+            ),
+            // Protocol type ARP
+            (
+                "ETHERTYPE_ARP",
+                NaslValue::Number(frame_forgery::ETHERTYPE_ARP.into()),
+            ),
+            // Length in bytes of an ethernet mac address
+            (
+                "ETH_ALEN",
+                NaslValue::Number(frame_forgery::ETH_ALEN.into()),
+            ),
+            // Protocol length for ARP
+            (
+                "ARP_PROTO_LEN",
+                NaslValue::Number(frame_forgery::ARP_PROTO_LEN.into()),
+            ),
+            // ARP operation request
+            (
+                "ARPOP_REQUEST",
+                NaslValue::Number(frame_forgery::ARPOP_REQUEST.into()),
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        builtin_vars
     }
 }

--- a/rust/nasl-builtin-std/README.md
+++ b/rust/nasl-builtin-std/README.md
@@ -34,6 +34,35 @@ and then extend the builder within [nasl_std_functions] with the implementation 
 builder = builder.push_register(nasl_builtin_string::NaslString)
 ```
 
+## Add predefined variables
+
+In some cases, from a nasl script, is desirable to have access to builtin variables or even to ones coming from libraries , like in the following nasl script
+
+```
+display(IPPROTO_IP);
+```
+For this purpose, it is possible to add predefined variables to the Register. The way to do it is similar to for functions. 
+
+All you have to do is to create a builder for the register:
+
+```
+let mut register = nasl_builtin_std::RegisterBuilder::build();
+```
+
+To add the variables to the register as global, you have to add the function crate to the Cargo.toml, which youprobably have done for adding the functions (see above),
+
+```toml
+[dependencies]
+nasl-builtin-raw-ip = {path = "../nasl-builtin-raw-ip"}
+```
+and then extend the register builder within the [nasl_std_variables] with the implementation of the [nasl_built_uitls::NaslVarsDefiner] of those variables:
+
+``` rust
+builder = builder.push_register(nasl_builtin_raw_ip::RawIp)
+
+```
+
+
 ### Mark as experimental
 
 When you have to mark your functions as experimental than you have to declare that crate as optional and add it to the experimental feature.

--- a/rust/nasl-builtin-std/README.md
+++ b/rust/nasl-builtin-std/README.md
@@ -38,7 +38,7 @@ builder = builder.push_register(nasl_builtin_string::NaslString)
 
 In some cases, from a nasl script, is desirable to have access to builtin variables or even to ones coming from libraries , like in the following nasl script
 
-```
+```text
 display(IPPROTO_IP);
 ```
 For this purpose, it is possible to add predefined variables to the Register. The way to do it is similar to for functions. 
@@ -57,7 +57,7 @@ nasl-builtin-raw-ip = {path = "../nasl-builtin-raw-ip"}
 ```
 and then extend the register builder within the [nasl_std_variables] with the implementation of the [nasl_built_uitls::NaslVarsDefiner] of those variables:
 
-``` rust
+```text
 builder = builder.push_register(nasl_builtin_raw_ip::RawIp)
 
 ```

--- a/rust/nasl-cli/src/interpret/mod.rs
+++ b/rust/nasl-cli/src/interpret/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use feed::HashSumNameLoader;
 use nasl_interpreter::{
     load_non_utf8_path, logger::DefaultLogger, logger::NaslLogger, ContextBuilder, FSPluginLoader,
-    Interpreter, KeyDispatcherSet, LoadError, Loader, NaslValue, NoOpLoader, Register,
+    Interpreter, KeyDispatcherSet, LoadError, Loader, NaslValue, NoOpLoader, RegisterBuilder,
 };
 use storage::{DefaultDispatcher, Dispatcher, Retriever};
 
@@ -35,6 +35,7 @@ impl Run<String> {
             None => context_builder.loader(NoOpLoader::default()),
         }
         .target(target.unwrap_or_default());
+
         Self {
             context_builder,
             feed,
@@ -73,7 +74,7 @@ impl Run<String> {
     fn run(&self, script: &str, verbose: bool) -> Result<(), CliErrorKind> {
         let logger = DefaultLogger::default();
         let context = self.context_builder.build();
-        let mut register = Register::default();
+        let mut register = RegisterBuilder::build();
         let mut interpreter = Interpreter::new(&mut register, &context);
         let code = self.load(script)?;
         for stmt in nasl_syntax::parse(&code) {

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -20,9 +20,9 @@ pub use error::InterpretError;
 pub use error::InterpretErrorKind;
 pub use interpreter::Interpreter;
 // we expose the other libraries to allow users to use them without having to import them
-pub use nasl_builtin_std::{nasl_std_functions, ContextBuilder, KeyDispatcherSet};
+pub use nasl_builtin_std::{nasl_std_functions, ContextBuilder, KeyDispatcherSet, RegisterBuilder};
 pub use nasl_builtin_utils::{
-    Context, ContextType, FunctionErrorKind, NaslFunctionRegister, Register,
+    Context, ContextType, FunctionErrorKind, NaslFunctionRegister, NaslVarRegister, Register,
 };
 pub use nasl_syntax::{
     load_non_utf8_path, logger, parse, AsBufReader, FSPluginLoader, LoadError, Loader, NaslValue,

--- a/rust/nasl-syntax/src/lib.rs
+++ b/rust/nasl-syntax/src/lib.rs
@@ -10,19 +10,21 @@ mod grouping_extension;
 mod infix_extension;
 mod keyword_extension;
 mod lexer;
+mod loader;
+mod naslvalue;
 mod operation;
 mod postfix_extension;
 mod prefix_extension;
 mod statement;
 mod token;
 mod variable_extension;
-mod naslvalue;
-mod loader;
 // should be replaced with tracing
 pub mod logger;
 
 pub use error::{ErrorKind, SyntaxError};
 pub use lexer::Lexer;
+pub use loader::*;
+pub use naslvalue::*;
 pub use statement::*;
 pub use storage::nvt::ACT;
 pub use token::Base as NumberBase;
@@ -30,8 +32,6 @@ pub use token::Category as TokenCategory;
 pub use token::IdentifierType;
 pub use token::Token;
 pub use token::Tokenizer;
-pub use naslvalue::*;
-pub use loader::*;
 
 /// Parses given code and returns found Statements and Errors
 ///

--- a/rust/nasl-syntax/src/naslvalue.rs
+++ b/rust/nasl-syntax/src/naslvalue.rs
@@ -260,4 +260,3 @@ impl From<storage::types::Primitive> for NaslValue {
         }
     }
 }
-

--- a/rust/openvasd/src/controller/entry.rs
+++ b/rust/openvasd/src/controller/entry.rs
@@ -8,10 +8,10 @@
 
 use std::{fmt::Display, sync::Arc};
 
-use hyper::{Response, Body, Method, Request};
-use super::{quit_on_poison, context::Context};
+use super::{context::Context, quit_on_poison};
+use hyper::{Body, Method, Request, Response};
 
-use crate::scan::{Error, ScanStarter, ScanStopper, ScanDeleter};
+use crate::scan::{Error, ScanDeleter, ScanStarter, ScanStopper};
 /// The supported paths of scannerd
 enum KnownPaths {
     /// /scans/{id}
@@ -67,7 +67,6 @@ impl Display for KnownPaths {
         }
     }
 }
-
 
 /// Is used to call a blocking function and return a response.
 ///
@@ -167,9 +166,7 @@ where
                             {
                                 use models::Phase::*;
                                 let expected = &[Stored, Stopped, Failed, Succeeded];
-                                Ok(ctx
-                                    .response
-                                    .not_accepted(&progress.status.status, expected))
+                                Ok(ctx.response.not_accepted(&progress.status.status, expected))
                             }
                             (models::Action::Start, Some(progress)) => {
                                 tracing::debug!(
@@ -265,9 +262,7 @@ where
         (&Method::GET, Vts) => {
             let (_, oids) = ctx.oids.read()?.clone();
             Ok(ctx.response.ok(&oids))
-        },
+        }
         _ => Ok(ctx.response.not_found("path", req.uri().path())),
     }
 }
-
-

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -571,10 +571,7 @@ mod tests {
                         "filename:test.nasl" => {
                             let values = values.first().unwrap().clone();
                             let oid = String::from_utf8(values);
-                            assert_eq!(
-                                Ok("0.0.0.0.0.0.0.0.0.1".to_owned()),
-                                oid
-                            );
+                            assert_eq!(Ok("0.0.0.0.0.0.0.0.0.1".to_owned()), oid);
                         }
                         _ => panic!("{key} should not occur"),
                     }


### PR DESCRIPTION
**What**:
Add: Register builder to add predefined nasl variables
Jira: SC-855
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
With this change, the nasl script have access to built-in predefined nasl variables added as globals
<!-- Why are these changes necessary? -->

**How**:
Run in the nasl-cli folder the following cmd:
`cargo install -F nasl-builtin-raw-ip --path .`

Execute the following nasl script with `nasl-cli execute examples/hello.nasl`
`$ cat examples/hello.nasl `
```
$ cat examples/hello.nasl 
# SPDX-FileCopyrightText: 2023 Greenbone AG
# Some text descriptions might be excerpted from (a) referenced
# source(s), and are Copyright (C) by the respective right holder(s).
#
# SPDX-License-Identifier: GPL-2.0-or-later

if (description == 1) {
  script_oid("0.0.0.0.0.0.0.0.0.0.0.1");
  exit(0);
}
display(ETHERTYPE_ARP);
display(ARP_PROTO_LEN);
```
You will see that both globals vars are printed.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
