### PR TITLE
Refactor: Doc: rename SCANNER-API-KEY to X-API-KEY

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -18,7 +18,7 @@ info:
     ## API Key
 
     An API key is a token that the client provides when doing API requests and are used to authorize access.
-    The `SCANNER-API-KEY` must be in the header.
+    The `X-API-KEY` must be in the header.
 
 
     <!--More details about this method follows with its implementation.-->
@@ -660,7 +660,11 @@ components:
       description: "A simple example for creating a scan."
       value:
         {
-          "target": { "hosts": ["127.0.0.1"], "ports": [{ "range": [{ "start": 22}] }] },
+          "target":
+            {
+              "hosts": ["127.0.0.1"],
+              "ports": [{ "range": [{ "start": 22 }] }],
+            },
           "vts": [{ "oid": "1.3.6.1.4.1.25623.1.0.10267" }],
         }
     scan_full:
@@ -682,9 +686,12 @@ components:
                 ],
               "ports":
                 [
-                  { "protocol": "udp", "range": [{"start": 22}, {"start": 1024, "end": 1030}] },
-                  { "protocol": "tcp", "range": [{"start": 24, "end": 30 }]},
-                  { "range": [{"start": 100, "end": 1000 }]},
+                  {
+                    "protocol": "udp",
+                    "range": [{ "start": 22 }, { "start": 1024, "end": 1030 }],
+                  },
+                  { "protocol": "tcp", "range": [{ "start": 24, "end": 30 }] },
+                  { "range": [{ "start": 100, "end": 1000 }] },
                 ],
               "credentials":
                 [
@@ -716,7 +723,10 @@ components:
                   },
                 ],
               "alive_test_ports":
-                [{ "protocol": "tcp", "range": [ {"start": 1, "end": 100 }]}, { "range": [{"start": 443}] }],
+                [
+                  { "protocol": "tcp", "range": [{ "start": 1, "end": 100 }] },
+                  { "range": [{ "start": 443 }] },
+                ],
               "alive_test_methods":
                 ["icmp", "tcp_syn", "tcp_ack", "arp", "consider_alive"],
               "reverse_lookup_unify": true,

--- a/rust/openvasd/src/config.rs
+++ b/rust/openvasd/src/config.rs
@@ -187,7 +187,7 @@ impl Config {
                     .env("API_KEY")
                     .long("api-key")
                     .action(ArgAction::Set)
-                    .help("API key that must be set as SCANNER-API-KEY header to gain access"),
+                    .help("API key that must be set as X-API-KEY header to gain access"),
             )
             .arg(
                 clap::Arg::new("ospd-socket")


### PR DESCRIPTION
Renames the SCANNER-API-KEY to X-API-KEY to indicate that it is service
relevant and not proxy relevant and be more confirm with the widely used
api key naming scheme.

Jira: SC-860
