### PR TITLE
Add: support for host_details within the osp crate

### DIFF
--- a/rust/models/src/host_info.rs
+++ b/rust/models/src/host_info.rs
@@ -10,17 +10,17 @@
 )]
 pub struct HostInfo {
     /// Number of all hosts, that are contained in a target
-    pub all: i32,
+    pub all: u32,
     /// Number of hosts, that are excluded from the target
-    pub excluded: i32,
+    pub excluded: u32,
     /// Number of hosts, that are not reachable (alive-test failed)
-    pub dead: i32,
+    pub dead: u32,
     /// Number of hosts, that are reachable (alive-test succeeded)
-    pub alive: i32,
+    pub alive: u32,
     /// Number of hosts, that are currently queued for scanning
-    pub queued: i32,
+    pub queued: u32,
     /// Number of hosts, that are already finished scanning
-    pub finished: i32,
+    pub finished: u32,
     #[cfg_attr(
         feature = "serde_support",
         serde(skip_serializing_if = "Vec::is_empty")

--- a/rust/osp/src/commands.rs
+++ b/rust/osp/src/commands.rs
@@ -67,7 +67,7 @@ impl<'a> ScanCommand<'a> {
                 Some(scan_id),
                 "get_scans",
                 // removes results from ospd-openvas
-                &[("pop_results", "1")],
+                &[("pop_results", "1"), ("progress", "1")],
                 &mut |_| Ok(()),
             ),
             ScanCommand::Get(scan_id) => {


### PR DESCRIPTION
The host_details information are part of the osp response for get_scans. In order to get this details, the request must contain `progress='1'`. The information needed are then all part of the `progress` element.
Within the response message note that finished and alive is currently the same value.
SC-850

To test it
1. Set everything up (openvasd, ospd-openvas, notus-scanner)
2. Create a new Scan with the XML below POST `http://127.0.0.1:3000/scans`. Remember to change the credentials to your setup. This config contains the smallest possible scan, that will trigger Notus as well. This is necessary, as the scan will be too fast to get a good test response. I setup a loop back address as `10.0.0.1` to ensure to have a better response (more running hosts) with `sudo ip addr add 10.0.0.1/32 dev lo`.
```xml
{
  "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
  "target": {
    "hosts": [
      "127.0.0.1",
      "::1",
      "10.0.0.1"
    ],
    "ports": [
      {
        "protocol": "udp",
        "range": [
          {
            "start": 1,
            "end": 3000
          }
        ]
      },
      {
        "protocol": "tcp",
        "range": [
          {
            "start": 1,
            "end": 3000
          }
        ]
      }
    ],
    "credentials": [
      {
        "service": "ssh",
        "port": 22,
        "up": {
          "username": "user",
          "password": "pw"
        }
      }
    ]
  },
  "vts": [
    {
      "oid": "1.3.6.1.4.1.25623.1.0.50282"
    }
  ]
}
```
3. Start the scan with POST `http://127.0.0.1:3000/scans/6c591f83-8f7b-452a-8c78-ba35779e682f`:
```xml
{
  "action": "start"
}
```
4. Send requests until you are satisfied GET `http://127.0.0.1:3000/scans/6c591f83-8f7b-452a-8c78-ba35779e682f/status`. In the end I got:
```xml
{
    "start_time": 1687959628,
    "end_time": 0,
    "status": "running",
    "host_info": {
        "all": 2,
        "excluded": 0,
        "dead": 0,
        "alive": 1,
        "queued": 0,
        "finished": 1,
        "scanning": ["::1", "10.0.0.1"]
    }
}
```