### PR TITLE
Add: Docker: openvasd, helm template

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -44,7 +44,9 @@ COPY .docker/openvas.conf /etc/openvas/
 # usually this image is created within in a ci ensuring that the
 # binary is available.
 COPY assets/$TARGETPLATFORM/nasl-cli /usr/local/bin/nasl-cli
+COPY assets/$TARGETPLATFORM/openvasd /usr/local/bin/openvasd
 RUN chmod +x /usr/local/bin/nasl-cli
+RUN chmod +x /usr/local/bin/openvasd
 COPY --from=build /install/ /
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/
@@ -54,3 +56,5 @@ RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas
 # allow nmap to send e.g. UDP or TCP SYN probes without root permissions
 ENV NMAP_PRIVILEGED=1
 RUN setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/nmap
+CMD /usr/local/bin/openvasd
+

--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -1,9 +1,8 @@
 name: "rs-build"
 
-on: [workflow_call] 
+on: [workflow_call]
 
-
-# This job builds the targets for x86_64 as well as aarch64. It is intented to 
+# This job builds the targets for x86_64 as well as aarch64. It is intented to
 # be included in the other jobs by calling:
 # ```
 # jobs:
@@ -48,6 +47,8 @@ jobs:
           patchelf --replace-needed libz.so libz.so.1 target/aarch64-unknown-linux-gnu/release/nasl-cli
           patchelf --replace-needed libz.so libz.so.1 target/x86_64-unknown-linux-gnu/release/nasl-cli
       - run: mkdir assets/
+      - run: mv rust/target/aarch64-unknown-linux-gnu/release/openvasd assets/openvasd-aarch64-unknown-linux-gnu
+      - run: mv rust/target/x86_64-unknown-linux-gnu/release/openvasd assets/openvasd-x86_64-unknown-linux-gnu
       - run: mv rust/target/aarch64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-aarch64-unknown-linux-gnu
       - run: mv rust/target/x86_64-unknown-linux-gnu/release/nasl-cli assets/nasl-cli-x86_64-unknown-linux-gnu
       - run: mv rust/target/aarch64-unknown-linux-gnu/release/feed-verifier assets/feed-verifier-aarch64-unknown-linux-gnu

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,12 +19,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: 'set IS_VERSION_TAG'
+      - name: "set IS_VERSION_TAG"
         run: |
           echo "IS_VERSION_TAG=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}" >> $GITHUB_ENV
           # set defaults
           echo "IS_LATEST_TAG=false" >> $GITHUB_ENV
-      - name: 'set IS_LATEST_TAG'
+      - name: "set IS_LATEST_TAG"
         if: ( env.IS_VERSION_TAG )
         run: |
           # find the latest version that is not ourself
@@ -44,7 +44,7 @@ jobs:
             # set this tag to latest and stable
             echo "IS_LATEST_TAG=true" >> $GITHUB_ENV
           fi
-      - name: 'Setup meta information (IS_VERSION_TAG: ${{ env.IS_VERSION_TAG }}, IS_LATEST_TAG: ${{ env.IS_LATEST_TAG }} )'
+      - name: "Setup meta information (IS_VERSION_TAG: ${{ env.IS_VERSION_TAG }}, IS_LATEST_TAG: ${{ env.IS_LATEST_TAG }} )"
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -80,6 +80,8 @@ jobs:
           path: assets
       - run: mkdir -p assets/linux/amd64
       - run: mkdir -p assets/linux/arm64
+      - run: mv assets/openvasd-aarch64-unknown-linux-gnu assets/linux/arm64/openvasd
+      - run: mv assets/openvasd-x86_64-unknown-linux-gnu assets/linux/amd64/openvasd
       - run: mv assets/nasl-cli-aarch64-unknown-linux-gnu assets/linux/arm64/nasl-cli
       - run: mv assets/nasl-cli-x86_64-unknown-linux-gnu assets/linux/amd64/nasl-cli
       - name: Set up QEMU

--- a/.github/workflows/helm-build-chart.yml
+++ b/.github/workflows/helm-build-chart.yml
@@ -1,0 +1,32 @@
+name: helm-charts
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  openvasd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start a local k8s cluster
+        uses: jupyterhub/action-k3s-helm@v3
+        with:
+          k3s-channel: latest
+          metrics-enabled: false
+      - name: deploy openvasd
+        run: |
+          helm uninstall openvasd || true 
+          helm install openvasd charts/openvasd/ --values charts/openvasd/values.yaml
+          kubectl rollout status --watch --timeout 600s deployment/openvasd
+          helm test openvasd
+      - uses: greenbone/actions/helm-build-push@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          chart-name: openvasd
+          registry: ${{ vars.IMAGE_REGISTRY }}
+          registry-subpath: helm-charts/
+          registry-user: ${{ secrets.GREENBONE_BOT }}
+          registry-token: ${{ secrets.GREENBONE_BOT_PACKAGES_WRITE_TOKEN }}

--- a/.github/workflows/helm-release-on-tag.yml
+++ b/.github/workflows/helm-release-on-tag.yml
@@ -1,0 +1,51 @@
+name: helm-chart release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release-helm-chart:
+    name: Release helm chart
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chart:
+          - openvasd
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get version from tag
+        shell: bash
+        run: |
+          vtag='${{github.ref_name}}'
+          echo "TAG=${vtag:1}" >> $GITHUB_ENV
+
+      - name: Run helm version upgrade
+        uses: greenbone/actions/helm-version-upgrade@v2
+        with:
+          chart-path: ${{ github.workspace }}/charts/${{ matrix.chart }}
+          chart-version: ${{ env.TAG }}
+
+      - name: Print Chart.yaml
+        run: |
+          cat '${{ github.workspace }}/charts/${{ matrix.chart }}/Chart.yaml'
+
+      - name: Upload to github registry
+        uses: greenbone/actions/helm-build-push@v2
+        with:
+          chart-name: ${{ matrix.chart }}
+          registry: ${{ vars.IMAGE_REGISTRY }}
+          registry-subpath: helm-charts/
+          registry-user: ${{ secrets.GREENBONE_BOT }}
+          registry-token: ${{ secrets.GREENBONE_BOT_PACKAGES_WRITE_TOKEN }}
+
+      - name: Trigger product helm chart upgrade
+        uses: greenbone/actions/trigger-workflow@v2
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          repository: "greenbone/product-helm-chart"
+          workflow: product-chart-upgrade.yml
+          inputs: '{"chart": "${{ matrix.chart }}", "tag": "${{ github.ref_name }}"}'

--- a/charts/openvasd/.helmignore
+++ b/charts/openvasd/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/openvasd/Chart.yaml
+++ b/charts/openvasd/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: openvasd
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/openvasd/README.md
+++ b/charts/openvasd/README.md
@@ -15,7 +15,7 @@ As an example imagine you want to override the openvas image to your forked one 
 ```
 # Contains openvasd
 openvas:
-  repository: nichtsfrei/openvas-scanner
+  repository: example/openvas-scanner
   pullPolicy: Always
   tag: "edge"
 ```

--- a/charts/openvasd/README.md
+++ b/charts/openvasd/README.md
@@ -34,8 +34,7 @@ it will use `nichtsfrei/openvas-scanner` instead of `greenbone/openvas-scanner`.
 Although it is possible to start OSPD with TLS, it is used in unix socket mode to prevent a user to bypass openvasd and interfere with those scans.
 
 Unfortunately the redis instance is shared between ospd and openvas without any clear separation. It is crucial that the redis instance used by them cannot be modified elsewhere. 
-
-To ensure that redis is also started in unix socket mode.
+To ensure redis is not used by another container, it is also started in unix socket mode.
 
 ## No scaling
 

--- a/charts/openvasd/README.md
+++ b/charts/openvasd/README.md
@@ -31,9 +31,9 @@ it will use `nichtsfrei/openvas-scanner` instead of `greenbone/openvas-scanner`.
 
 ## OSPD and Redis via unix socket
 
-Although it is possible to start OSPD with TLS it is used in unix socket mode to prevent a user to bypass openvasd and interfere with those scans.
+Although it is possible to start OSPD with TLS, it is used in unix socket mode to prevent a user to bypass openvasd and interfere with those scans.
 
-Unfortunately the redis instance is shared between ospd and openvas without any clear separation it is crucial that the redis instance used by them cannot be modified elsewhere. 
+Unfortunately the redis instance is shared between ospd and openvas without any clear separation. It is crucial that the redis instance used by them cannot be modified elsewhere. 
 
 To ensure that redis is also started in unix socket mode.
 

--- a/charts/openvasd/README.md
+++ b/charts/openvasd/README.md
@@ -1,0 +1,46 @@
+Contains the helm chart to deploy openvasd.
+
+# Install
+
+To install openvasd helm chart from a local path execute
+
+``` 
+helm install openvasd ./openvasd/ -f openvasd/values.yaml
+```
+
+You can also provide override the initial values within `openvasd/values.yaml` by providing an additional `-f` flag.
+
+As an example imagine you want to override the openvas image to your forked one you can create `~/openvasd.yaml` file containing: 
+
+```
+# Contains openvasd
+openvas:
+  repository: nichtsfrei/openvas-scanner
+  pullPolicy: Always
+  tag: "edge"
+```
+
+if you then execute: 
+``` 
+helm install openvasd ./openvasd/ -f openvasd/values.yaml -f ~/openvasd.yaml
+```
+
+it will use `nichtsfrei/openvas-scanner` instead of `greenbone/openvas-scanner`.
+
+# Design decisions
+
+## OSPD and Redis via unix socket
+
+Although it is possible to start OSPD with TLS it is used in unix socket mode to prevent a user to bypass openvasd and interfere with those scans.
+
+Unfortunately the redis instance is shared between ospd and openvas without any clear separation it is crucial that the redis instance used by them cannot be modified elsewhere. 
+
+To ensure that redis is also started in unix socket mode.
+
+## No scaling
+
+Due to the current architectural limitation replica count and auto-scaling is completely disabled. 
+
+The reason for that is that openvasd requires ospd which has no cluster capabilities nor a database setup that allows sharing via multiple instances. 
+
+That means that each replica would have a completely own state and reqires vertical scaling via deployment so that a customer can choose which openvasd to use.

--- a/charts/openvasd/templates/NOTES.txt
+++ b/charts/openvasd/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openvasd.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "openvasd.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openvasd.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "openvasd.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/openvasd/templates/_helpers.tpl
+++ b/charts/openvasd/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openvasd.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openvasd.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openvasd.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "openvasd.labels" -}}
+helm.sh/chart: {{ include "openvasd.chart" . }}
+{{ include "openvasd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "openvasd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openvasd.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openvasd.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openvasd.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/openvasd/templates/deployment.yaml
+++ b/charts/openvasd/templates/deployment.yaml
@@ -1,0 +1,202 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openvasd.fullname" . }}
+  labels:
+    {{- include "openvasd.labels" . | nindent 4 }}
+spec:
+  replicas: 1 
+  selector:
+    matchLabels:
+      {{- include "openvasd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "openvasd.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openvasd.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      - name: redis-socket
+        emptyDir: {}
+      - name: nasl-plugins
+        emptyDir: {}
+      - name: notus-data
+        emptyDir: {}
+      - name: openvas-config
+        emptyDir: {}
+      - name: scan-config 
+        emptyDir: {}
+      - name: ospd-config
+        emptyDir: {}
+      - name: ospd-socket
+        emptyDir: {}
+      - name: ospd-logs
+        emptyDir: {}
+      initContainers:
+      - name: nasl
+        image: "{{ .Values.vulnerabilitytests.repository }}:{{ .Values.vulnerabilitytests.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: nasl-plugins
+            mountPath: /mnt/nasl
+        command: ['sh', '-c']
+        args: ['cp -rv /var/lib/openvas/22.04/vt-data/nasl/* /mnt/nasl/']
+      - name: notus-advisories
+        image: "{{ .Values.notusdata.repository }}:{{ .Values.notusdata.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: notus-data
+            mountPath: /mnt/notus
+        command: ['cp', '-rv', '/var/lib/notus/advisories', '/mnt/notus/']
+      - name: notus-products
+        image: "{{ .Values.notusdata.repository }}:{{ .Values.notusdata.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: notus-data
+            mountPath: /mnt/notus
+        command: ['cp', '-rv', '/var/lib/notus/products', '/mnt/notus/']
+      - name: mqtt-broker-openvas-fix
+        image: "{{ .Values.ospd.repository }}:{{ .Values.ospd.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: openvas-config
+            mountPath: /mnt/ovc
+        command: ['sh', '-c']
+        args: ["sed 's/mqtt-broker/localhost/' /etc/openvas/openvas.conf > /mnt/ovc/openvas.conf; cp /etc/openvas/openvas_log.conf /mnt/ovc/"]
+      - name: ospd-disable-notus-hashsum-verification #since can mount local volumes which may be altered we have to disable hashsum verification for notus  
+        image: "{{ .Values.ospd.repository }}:{{ .Values.ospd.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: ospd-config
+            mountPath: /mnt/ovc
+        command: ['sh', '-c']
+        args: ["cp /etc/gvm/ospd-openvas.conf /mnt/ovc/ospd-openvas.conf && printf \"disable_notus_hashsum_verification = True\n\" >> /mnt/ovc/ospd-openvas.conf"]
+      - name: create-dummy-openvas-log
+        image: "{{ .Values.ospd.repository }}:{{ .Values.ospd.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: ospd-logs
+            mountPath: /mnt/ovc
+        command: ['sh', '-c']
+        args: ["touch /mnt/ovc/openvas.log && chown ospd-openvas:ospd-openvas /mnt/ovc/openvas.log"]
+      containers:
+      - name: broker
+        image: "{{ .Values.mqtt.repository }}:{{ .Values.mqtt.tag }}"
+        imagePullPolicy: Always
+      - name: redis
+        image: "{{ .Values.redis.repository }}:{{ .Values.redis.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: redis-socket
+          mountPath: /run/redis
+      # although the main purpose is to display openvas logs 
+      # we make it as ospd so that there is a container running
+      # to play around
+      - name: openvas
+        image: "{{ .Values.ospd.repository }}:{{ .Values.ospd.tag }}"
+        imagePullPolicy: Always
+        command: [ "tail", "-f", "/var/log/gvm/openvas.log" ]
+        volumeMounts:
+        - name: scan-config
+          mountPath: /usr/local/src/policies
+        - name: redis-socket
+          mountPath: /run/redis
+        - name: nasl-plugins
+          mountPath: /var/lib/openvas/plugins
+        - name: notus-data
+          mountPath: /var/lib/notus
+        - name: openvas-config
+          mountPath: /etc/openvas
+        - name: ospd-config
+          mountPath: /etc/gvm/
+        - name: ospd-logs
+          mountPath: /var/log/gvm
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+      - name: openvasd
+        image: "{{ .Values.openvas.repository }}:{{ .Values.openvas.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: redis-socket
+          mountPath: /run/redis
+        - name: nasl-plugins
+          mountPath: /var/lib/openvas/plugins
+        - name: notus-data
+          mountPath: /var/lib/notus
+        - name: openvas-config
+          mountPath: /etc/openvas
+        - name: ospd-socket
+          mountPath: /run/ospd/
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+        ports:
+        - containerPort: 3000
+          protocol: TCP 
+        env:
+          - name: LISTENING
+            value: "0.0.0.0:3000"
+          - name: OSPD_SOCKET
+            value: /run/ospd/ospd-openvas.sock
+          - name: OPENVASD_LOG
+            value: {{ .Values.openvasd.loglevel | default "INFO" }} 
+          - name: API_KEY
+            value: {{ .Values.openvasd.apikey }} 
+      - name: ospd
+        image: "{{ .Values.ospd.repository }}:{{ .Values.ospd.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: redis-socket
+          mountPath: /run/redis
+        - name: nasl-plugins
+          mountPath: /var/lib/openvas/plugins
+        - name: notus-data
+          mountPath: /var/lib/notus
+        - name: openvas-config
+          mountPath: /etc/openvas
+        - name: ospd-config
+          mountPath: /etc/gvm/
+        - name: ospd-socket
+          mountPath: /run/ospd/
+        - name: ospd-logs
+          mountPath: /var/log/gvm
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+              - NET_RAW
+      - name: notus
+        image: "{{ .Values.notus.repository }}:{{ .Values.notus.tag }}"
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: notus-data
+          mountPath: /var/lib/notus
+        command: ["notus-scanner", "-f", "--disable-hashsum-verification=True"]
+      # what does it mean?
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/openvasd/templates/ingress.yaml
+++ b/charts/openvasd/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "openvasd.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "openvasd.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/openvasd/templates/service.yaml
+++ b/charts/openvasd/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openvasd.fullname" . }}
+  labels:
+    {{- include "openvasd.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openvasd.selectorLabels" . | nindent 4 }}

--- a/charts/openvasd/templates/serviceaccount.yaml
+++ b/charts/openvasd/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openvasd.serviceAccountName" . }}
+  labels:
+    {{- include "openvasd.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/openvasd/templates/tests/test-connection.yaml
+++ b/charts/openvasd/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "openvasd.fullname" . }}-test-connection"
+  labels:
+    {{- include "openvasd.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['--header', 'x-api-key: {{ .Values.openvasd.apikey }}','{{ include "openvasd.fullname" . }}:{{ .Values.service.port }}/vts']
+  restartPolicy: Never

--- a/charts/openvasd/values.yaml
+++ b/charts/openvasd/values.yaml
@@ -1,0 +1,132 @@
+# Default values for openvasd.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Is currently reqired by openvasd to control openvas
+ospd:
+  repository: greenbone/ospd-openvas
+  pullPolicy: Always
+  tag: "edge"
+
+# Contains openvasd
+openvas:
+  repository: greenbone/openvas-scanner
+  pullPolicy: Always
+  tag: "edge"
+
+# Configuration of openvasd
+openvasd: 
+  # Sets the log level and changes the verbosity of openvasd.
+  # Can be set to TRACE, DEBUG, INFO, WARNING, ERROR
+  # openvasd is provided by the openvas image
+  loglevel: TRACE
+  apikey: changeme
+
+# Required for version checks 
+notus:
+  repository: greenbone/notus-scanner
+  pullPolicy: Always
+  tag: "edge"
+
+# NASL scripts also known as feed
+vulnerabilitytests:
+  # latest is the most current community feed.
+  repository: greenbone/vulnerability-tests
+  pullPolicy: Always
+  tag: "latest"
+
+# Notus description json also known as feed
+notusdata:
+  # latest is the most current community feed.
+  repository: greenbone/notus-data
+  pullPolicy: Always
+  tag: "latest"
+
+# Required by notus
+mqtt:
+  repository: greenbone/mqtt-broker
+  pullPolicy: Always
+  tag: "latest"
+
+# required by openvas and ospd
+redis:
+  repository: greenbone/redis-server
+  pullPolicy: Always
+  tag: "latest"
+
+# When you have access to the enterprise feed add the credentials for the private repository here.
+# Additionally change notus and vulnerabilitytests accordingly.
+imagePullSecrets: []
+nameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+# openvasd listens on root without any service prefix
+# in an environment with multiple http services it is 
+# wisely to configure ingress to rewrite targets to root for openvasd.
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /api/openvasd(/|$)(.*)
+          pathType: Prefix
+          backend:
+            service:
+              name: openvasd
+              port:
+                number: 3000
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/rust/openvasd/src/config.rs
+++ b/rust/openvasd/src/config.rs
@@ -252,7 +252,7 @@ impl Config {
         if let Some(api_key) = cmds.get_one::<String>("api-key") {
             config.endpoints.key = Some(api_key.clone());
         }
-        if let Some(ip) = cmds.get_one::<SocketAddr>("binding-ip") {
+        if let Some(ip) = cmds.get_one::<SocketAddr>("listening") {
             config.listener.address = *ip;
         }
 


### PR DESCRIPTION
Adds openvasd to docker.

Adds the helm chart to deploy openvasd.

To install openvasd helm chart from a local path
execute:

```
helm install openvasd ./openvasd/ -f openvasd/values.yaml
```

You can also provide override the initial values
within `openvasd/values.yaml` by providing an
additional `-f` flag.

As an example imagine you want to override the
openvas image to your forked one you can create
`~/openvasd.yaml` file containing:

```
openvas:
  repository: nichtsfrei/openvas-scanner
  pullPolicy: Always
  tag: "edge"
```

if you then execute:
```
helm install openvasd ./openvasd/ -f openvasd/values.yaml -f ~/openvasd.yaml
```

it will use `nichtsfrei/openvas-scanner` instead
of `greenbone/openvas-scanner`.

Although it is possible to start OSPD with TLS
it is used in unix socket mode to prevent a user
to bypass openvasd and interfere with those scans.

Unfortunately the redis instance is shared between ospd and openvas without any clear separation it
is crucial that the redis instance used by them
cannot be modified elsewhere.

To ensure that redis is also started in unix
socket mode.

Due to the current architectural limitation
replica count and auto-scaling is completely
disabled.

The reason for that is that openvasd requires ospd which has no cluster capabilities nor a database
setup that allows sharing via multiple instances.

That means that each replica would has a
completely own state and reqires vertical scaling
via deployment so that a customer can choose
which openvasd to use.

Required for: SC-857

The helm chart test is failing in this PR because the greenbone/openvas-scanner image will get the openvasd binary with this PR. This will resolve itself after merge.
