### PR TITLE
Add: openvas-scanner debian testing

### DIFF
--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=unstable
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
-ARG GVM_LIBS_VERSION=testing
+ARG GVM_LIBS_VERSION=testing-edge
 
 FROM greenbone/openvas-smb:testing-edge AS openvas-smb
 

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -1,0 +1,58 @@
+ARG VERSION=unstable
+# this allows to work on forked repository
+ARG REPOSITORY=greenbone/openvas-scanner
+ARG GVM_LIBS_VERSION=testing
+
+FROM greenbone/openvas-smb:testing-edge AS openvas-smb
+
+FROM greenbone/gvm-libs:${GVM_LIBS_VERSION} AS build
+COPY . /source
+RUN sh /source/.github/install-openvas-dependencies.sh
+
+COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /source
+RUN DESTDIR=/install cmake --build /build -- install
+
+FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
+ARG TARGETPLATFORM
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+  bison \
+  libglib2.0-0 \
+  libjson-glib-1.0-0 \
+  libksba8 \
+  nmap \
+  libcap2-bin \
+  snmp \
+  netdiag \
+  pnscan \
+  libbsd0 \
+  rsync \
+  # net-tools is required by some nasl plugins.
+  # nasl_pread: Failed to execute child process “netstat” (No such file or directory)
+  net-tools \
+  # for openvas-smb support
+  python3-impacket \
+  libgnutls30 \
+  libgssapi3-heimdal \
+  libkrb5-26-heimdal \
+  libasn1-8-heimdal \
+  libroken18-heimdal \
+  libhdb9-heimdal \
+  libpopt0 \
+  zlib1g\
+  && rm -rf /var/lib/apt/lists/*
+COPY .docker/openvas.conf /etc/openvas/
+# must be pre built within the rust dir and moved to the bin dir
+# usually this image is created within in a ci ensuring that the
+# binary is available.
+COPY assets/$TARGETPLATFORM/nasl-cli /usr/local/bin/nasl-cli
+RUN chmod +x /usr/local/bin/nasl-cli
+COPY --from=build /install/ /
+COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
+COPY --from=openvas-smb /usr/local/bin/ /usr/local/bin/
+RUN ldconfig
+# allow openvas to access raw sockets and all kind of network related tasks
+RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas
+# allow nmap to send e.g. UDP or TCP SYN probes without root permissions
+ENV NMAP_PRIVILEGED=1
+RUN setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/nmap

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libgssapi3-heimdal \
   libkrb5-26-heimdal \
   libasn1-8-heimdal \
-  libroken18-heimdal \
+  libroken19-heimdal \
   libhdb9-heimdal \
   libpopt0 \
   zlib1g\

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -100,7 +100,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: "Setup meta information (IS_VERSION_TAG: ${{ env.IS_VERSION_TAG }}, IS_LATEST_TAG: ${{ env.IS_LATEST_TAG }} )"
+      - name: "Setup meta information debian:oldstable"
         id: old_stable_meta
         uses: docker/metadata-action@v4
         with:
@@ -126,3 +126,30 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.old_stable_meta.outputs.tags }}
           labels: ${{ steps.old_stable_meta.outputs.labels }}
+
+      - name: "Setup meta information debian:testing"
+        id: test_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.vendor=Greenbone
+            org.opencontainers.image.base.name=greenbone/gvm-libs
+          flavor: latest=false # no auto latest container tag for git tags
+          tags: |
+            # for the images provided for debian:testing we just provide
+            # testing on an new version or testing-edge when it is on main.
+            # testing-branch-sha on a branch
+            type=raw,value=testing,enable=${{ env.IS_LATEST_TAG }}
+            type=raw,value=testing-edge,enable=${{ github.ref_name == 'main' }}
+            type=raw,value=testing-{{branch}}-{{sha}},enable=${{ github.ref_type == 'branch' && github.event_name == 'push' && github.ref_name != 'main' }}
+            type=ref,event=pr
+      - name: Build and push Container image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'main') }}
+          file: .docker/prod-testing.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.test_meta.outputs.tags }}
+          labels: ${{ steps.test_meta.outputs.labels }}


### PR DESCRIPTION
Adds a new image for openvas-scanner based on debian:testing

The tags for that are:

- testing - releases
- testing-edge - any change

That way we can buy some time for adjusting our workflow for new debian releases.
SC-861