### PR TITLE
Add: openvasd: example to start a discovery scan

### DIFF
--- a/rust/examples/openvasd/discovery.json
+++ b/rust/examples/openvasd/discovery.json
@@ -1,7 +1,6 @@
 {
   "target": {
     "hosts": [
-      "127.0.0.1",
       "localhost"
     ],
     "ports": [

--- a/rust/examples/openvasd/start-discovery.sh
+++ b/rust/examples/openvasd/start-discovery.sh
@@ -8,8 +8,8 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
 payload=$(sed "s/localhost/$TARGET/" "$SCRIPTPATH/discovery.json")
-id=$(curl -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d "$payload" "http://$SENSOR/scans" | sed 's/"//g')
+id=$(curl -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d "$payload" "$SENSOR/scans" | sed 's/"//g')
 echo "Scan ID: $id"
-curl --fail-with-body -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d '{"action": "start"}' "http://$SENSOR/scans/$id" || exit 1
-echo "Status: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"http://$SENSOR/scans/$id/status\""
-echo "Results: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"http://$SENSOR/scans/$id/results\""
+curl --fail-with-body -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d '{"action": "start"}' "$SENSOR/scans/$id" || exit 1
+echo "Status: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"$SENSOR/scans/$id/status\""
+echo "Results: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"$SENSOR/scans/$id/results\""

--- a/rust/examples/openvasd/start-discovery.sh
+++ b/rust/examples/openvasd/start-discovery.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# To execute: ./start-discovery.sh <target>
+# Example: SENSOR=<sensor> ./start-discovery.sh
+[ -z "$API_KEY" ] && API_KEY="changeme"
+[ -z "$SENSOR" ] && SENSOR="localhost:3000"
+[ -z "$1" ] && TARGET="127.0.0.1" || TARGET="$1"
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+payload=$(sed "s/localhost/$TARGET/" "$SCRIPTPATH/discovery.json")
+id=$(curl -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d "$payload" "http://$SENSOR/scans" | sed 's/"//g')
+echo "Scan ID: $id"
+curl --fail-with-body -s -H "Content-Type: application/json" -H "X-Api-Key: $API_KEY" -d '{"action": "start"}' "http://$SENSOR/scans/$id" || exit 1
+echo "Status: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"http://$SENSOR/scans/$id/status\""
+echo "Results: curl --fail-with-body -H \"X-Api-Key: $API_KEY\" \"http://$SENSOR/scans/$id/results\""

--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -130,7 +130,7 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let resp = entrypoint(req, Arc::clone(&controller)).await.unwrap();
-        assert_eq!(resp.headers().get("version").unwrap(), "1");
+        assert_eq!(resp.headers().get("api-version").unwrap(), "1");
         assert_eq!(resp.headers().get("authentication").unwrap(), "");
     }
     async fn get_scan_status<S>(id: &str, ctx: Arc<Context<S>>) -> Response<Body>

--- a/rust/openvasd/src/response.rs
+++ b/rust/openvasd/src/response.rs
@@ -43,8 +43,8 @@ impl Response {
     fn default_response_builder(&self) -> hyper::http::response::Builder {
         hyper::Response::builder()
             .header("authentication", &self.authentication)
-            .header("version", &self.version)
-            .header("feed_version", &self.feed_version)
+            .header("api-version", &self.version)
+            .header("feed-version", &self.feed_version)
     }
 
     #[tracing::instrument]


### PR DESCRIPTION
Adds an example to start a simplified discovery scan using openvasd.

To execute it run the script `sh start-discovery.sh <target>` you can
override the used api key and sensor by setting the environment
variables `SENSOR`, `API_KEY`.
