### PR TITLE
Add: nasl-cli: scan-config command

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1278,10 +1278,15 @@ dependencies = [
  "configparser",
  "feed",
  "json-storage",
+ "models",
  "nasl-interpreter",
  "nasl-syntax",
  "redis-storage",
+ "scanconfig",
+ "serde_json",
  "storage",
+ "tracing",
+ "tracing-subscriber",
  "walkdir",
 ]
 
@@ -1865,6 +1870,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "scanconfig"
+version = "0.1.0"
+dependencies = [
+ "models",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "storage",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2063,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "time",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,5 +21,6 @@ members = [
   "feed-verifier",
   "models",
   "osp",
-  "openvasd",
+  "openvasd", 
+  "scanconfig",
 ]

--- a/rust/feed/src/update/mod.rs
+++ b/rust/feed/src/update/mod.rs
@@ -89,7 +89,7 @@ where
         loader: L,
         storage: S,
         verifier: V,
-    ) -> impl Iterator<Item = Result<String, Error>> {
+    ) -> Self {
         let initial = vec![
             ("description".to_owned(), true.into()),
             ("OPENVAS_VERSION".to_owned(), openvas_version.into()),

--- a/rust/json-storage/src/lib.rs
+++ b/rust/json-storage/src/lib.rs
@@ -147,6 +147,15 @@ where
             }
         })
     }
+
+    fn retrieve_by_field(
+        &self,
+        _: &storage::Field,
+        _: &storage::Retrieve,
+    ) -> Result<Vec<(K, Vec<storage::Field>)>, StorageError> {
+        // currently not supported
+        Ok(vec![])
+    }
 }
 
 #[cfg(test)]

--- a/rust/nasl-builtin-raw-ip/tests/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/tests/packet_forgery.rs
@@ -317,7 +317,7 @@ mod tests {
     #[should_panic]
     fn copy_from_slice_panic() {
         let mut a = [1u8, 2u8, 3u8, 4u8];
-        let b = ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8];
+        let b = [b'a', b'b', b'c', b'd'];
 
         // this should panic
         a[..2].copy_from_slice(&b[..b.len()]);
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn copy_from_slice_safe() {
         let mut a = [1u8, 2u8, 3u8, 4u8];
-        let b = ['a' as u8, 'b' as u8, 'c' as u8, 'd' as u8];
+        let b = [b'a', b'b', b'c', b'd'];
         let alen = a.len();
         // different range size between origin and destination
         assert_eq!(
@@ -356,6 +356,6 @@ mod tests {
         );
 
         let _r = safe_copy_from_slice(&mut a, 0, 2, &b, 0, 2);
-        assert_eq!(a, ['a' as u8, 'b' as u8, 3u8, 4u8]);
+        assert_eq!(a, [b'a', b'b', 3u8, 4u8]);
     }
 }

--- a/rust/nasl-cli/Cargo.toml
+++ b/rust/nasl-cli/Cargo.toml
@@ -16,10 +16,16 @@ walkdir = "2"
 
 feed = {path = "../feed"}
 nasl-syntax = { path = "../nasl-syntax" }
+scanconfig = { path = "../scanconfig" }
+models = { path = "../models" }
 nasl-interpreter = { path = "../nasl-interpreter", default-features = false }
 storage = { path = "../storage" }
 redis-storage = { path = "../redis-storage" }
 json-storage = {path = "../json-storage"}
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17" }
+serde_json = "1.0.96"
+
 
 [features]
 nasl-builtin-raw-ip = ["nasl-interpreter/nasl-builtin-raw-ip"]

--- a/rust/nasl-cli/README.md
+++ b/rust/nasl-cli/README.md
@@ -214,11 +214,13 @@ For that we need to execute:
 
 ```
 echo '{ "target": { "hosts": ["localhost"], "ports": [] }, "vts": [] }'| \
-nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common -l ~/src/greenbone/data-objects/content/22.04/port-lists/openvas-default-c7e03b6c-3bbe-11e1-a057-406186ea4fc5.xml ~/src/greenbone/data-objects/content/22.04/scan-configs/discovery-8715c877-47a0-438d-98a3-27c7a6ab2196.xml | \
-nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common  ~/src/greenbone/data-objects/content/22.04/scan-configs/full-and-fast-daba56c8-73ec-11df-a475-002264764cea.xml
+nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common \
+  -l ~/src/greenbone/data-objects/content/22.04/port-lists/openvas-default-c7e03b6c-3bbe-11e1-a057-406186ea4fc5.xml \
+  ~/src/greenbone/data-objects/content/22.04/scan-configs/discovery-8715c877-47a0-438d-98a3-27c7a6ab2196.xml \
+  ~/src/greenbone/data-objects/content/22.04/scan-configs/full-and-fast-daba56c8-73ec-11df-a475-002264764cea.xml
 ```
 
-Be aware to resolve the families within a scan-config nasl-cli requires to read the complete feed. Depending on your system that may require some time on each scan-config run.
+Be aware that each call does a description run of the defined feed to gather the meta data, depending on your system and the size of the feed it requires may some time.
 
 #### Usage
 

--- a/rust/nasl-cli/README.md
+++ b/rust/nasl-cli/README.md
@@ -202,6 +202,41 @@ Options:
   -h, --help   Print help
 ```
 
+### scan-config
+
+Transforms a scan-config from gvmds data-objects to scan json of [openvasd](https://greenbone.github.io/scanner-api/#/scan/create_scanl).
+
+To set the target and credentials you can pipe a partial scan json into `nasl-cli scan-config` by providing `-i` flag.
+
+As an example we assume that the data-objects feed is in `~/src/greenbone/data-objects/content/22.04` while the vulnerability feed is in `~/src/greenbone/vulnerability-tests/nasl/common` and we want to create a scan to verify localhost with a discovery and full and fast policy on the openvas default portlist.
+
+For that we need to execute:
+
+```
+echo '{ "target": { "hosts": ["localhost"], "ports": [] }, "vts": [] }'| \
+nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common -l ~/src/greenbone/data-objects/content/22.04/port-lists/openvas-default-c7e03b6c-3bbe-11e1-a057-406186ea4fc5.xml ~/src/greenbone/data-objects/content/22.04/scan-configs/discovery-8715c877-47a0-438d-98a3-27c7a6ab2196.xml | \
+nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common  ~/src/greenbone/data-objects/content/22.04/scan-configs/full-and-fast-daba56c8-73ec-11df-a475-002264764cea.xml
+```
+
+Be aware to resolve the families within a scan-config nasl-cli requires to read the complete feed. Depending on your system that may require some time on each scan-config run.
+
+#### Usage
+
+```
+Transforms a scan-config xml to a scan json for openvasd.
+When piping a scan json it is enriched with the scan-config xml and may the portlist otherwise it will print a scan json without target or credentials.
+
+Usage: nasl-cli scan-config [OPTIONS] <scan-config>
+
+Arguments:
+  <scan-config>  
+
+Options:
+  -p, --path <FILE>      Path to the feed.
+  -i, --input            Parses scan json from stdin.
+  -l, --portlist <FILE>  Path to the port list xml
+  -h, --help             Print help
+```
 ## Build
 
 Run `cargo test` to test and `cargo build --release` to build it.

--- a/rust/nasl-cli/src/feed_update.rs
+++ b/rust/nasl-cli/src/feed_update.rs
@@ -9,13 +9,11 @@ use storage::Dispatcher;
 
 use crate::CliError;
 
-pub fn run<S>(storage: S, path: PathBuf, verbose: bool) -> Result<(), CliError>
+pub fn run<S>(storage: S, path: PathBuf) -> Result<(), CliError>
 where
     S: Sync + Send + Dispatcher<String>,
 {
-    if verbose {
-        eprintln!("description run syntax in {path:?}.");
-    }
+    tracing::debug!("description run syntax in {path:?}.");
     // needed to strip the root path so that we can build a relative path
     // e.g. 2006/something.nasl
     let loader = FSPluginLoader::new(path);
@@ -25,9 +23,7 @@ where
 
     for s in updater {
         let s = s?;
-        if verbose {
-            eprintln!("updated {s}");
-        }
+        tracing::trace!("updated {s}");
     }
 
     Ok(())

--- a/rust/nasl-cli/src/interpret/mod.rs
+++ b/rust/nasl-cli/src/interpret/mod.rs
@@ -71,7 +71,7 @@ impl Run<String> {
         }
     }
 
-    fn run(&self, script: &str, verbose: bool) -> Result<(), CliErrorKind> {
+    fn run(&self, script: &str) -> Result<(), CliErrorKind> {
         let logger = DefaultLogger::default();
         let context = self.context_builder.build();
         let mut register = RegisterBuilder::build();
@@ -80,9 +80,7 @@ impl Run<String> {
         for stmt in nasl_syntax::parse(&code) {
             match stmt {
                 Ok(stmt) => {
-                    if verbose {
-                        eprintln!("> {stmt}");
-                    }
+                    tracing::debug!("> {stmt}");
                     let r = match interpreter.retry_resolve(&stmt, 5) {
                         Ok(x) => x,
                         Err(e) => match &e.kind {
@@ -101,9 +99,7 @@ impl Run<String> {
                     match r {
                         NaslValue::Exit(rc) => std::process::exit(rc as i32),
                         _ => {
-                            if verbose {
-                                eprintln!("=> {r:?}");
-                            }
+                            tracing::debug!("=> {r:?}", r = r);
                         }
                     }
                 }
@@ -141,10 +137,9 @@ pub fn run(
     feed: Option<PathBuf>,
     script: String,
     target: Option<String>,
-    verbose: bool,
 ) -> Result<(), CliError> {
     let runner = Run::new(db, feed, target);
-    runner.run(&script, verbose).map_err(|e| CliError {
+    runner.run(&script).map_err(|e| CliError {
         filename: script,
         kind: e,
     })

--- a/rust/nasl-cli/src/main.rs
+++ b/rust/nasl-cli/src/main.rs
@@ -47,7 +47,7 @@ enum Commands {
     /// Transforms a scan config to scan json for openvasd
     ScanConfig {
         feed: Option<PathBuf>,
-        config: String,
+        config: Vec<String>,
         port_list: Option<String>,
         stdin: bool,
     },
@@ -308,7 +308,7 @@ When ID is used than a valid feed path must be given within the path parameter."
 When piping a scan json it is enriched with the scan-config xml and may the portlist otherwise it will print a scan json without target or credentials.")
                 .arg(arg!(-p --path <FILE> "Path to the feed.") .required(false)
                     .value_parser(value_parser!(PathBuf)))
-                .arg(Arg::new("scan-config").required(true))
+                .arg(Arg::new("scan-config").required(true).action(ArgAction::Append))
                 .arg(arg!(-i --input "Parses scan json from stdin.").required(false).action(ArgAction::SetTrue))
                 .arg(arg!(-l --portlist <FILE> "Path to the port list xml") .required(false))
         )
@@ -374,10 +374,11 @@ When piping a scan json it is enriched with the scan-config xml and may the port
         }
         Some(("scan-config", args)) => {
             let feed = args.get_one::<PathBuf>("path").cloned();
-            let config = match args.get_one::<String>("scan-config").cloned() {
-                Some(path) => path,
-                _ => unreachable!("path is set to required"),
-            };
+            let config = args
+                .get_many::<String>("scan-config")
+                .expect("scan-config is required")
+                .cloned()
+                .collect();
             let port_list = args.get_one::<String>("portlist").cloned();
             tracing::debug!("port_list: {port_list:?}");
             let stdin = args.get_one::<bool>("input").cloned().unwrap_or_default();

--- a/rust/nasl-cli/src/scanconfig.rs
+++ b/rust/nasl-cli/src/scanconfig.rs
@@ -1,0 +1,67 @@
+use std::{io::BufReader, path::PathBuf, sync::Arc};
+
+use crate::{feed_update, get_path_from_openvas, read_openvas_config, CliError, CliErrorKind};
+
+pub(crate) fn run(
+    feed: Option<&PathBuf>,
+    config: &str,
+    port_list: Option<&String>,
+    stdin: bool,
+) -> Result<(), CliError> {
+    let map_error = |f: &str, e: scanconfig::Error| CliError {
+        filename: f.to_string(),
+        kind: CliErrorKind::Corrupt(format!("{e:?}")),
+    };
+    let as_bufreader = |f: &str| {
+        let file = std::fs::File::open(f).map_err(|e| CliError {
+            filename: f.to_string(),
+            kind: CliErrorKind::Corrupt(format!("{e:?}")),
+        })?;
+        let reader = BufReader::new(file);
+        Ok::<BufReader<std::fs::File>, CliError>(reader)
+    };
+    let storage = Arc::new(storage::DefaultDispatcher::new(true));
+    let mut scan = {
+        if stdin {
+            tracing::debug!("reading scan config from stdin");
+            serde_json::from_reader(std::io::stdin()).map_err(|e| CliError {
+                filename: "".to_string(),
+                kind: CliErrorKind::Corrupt(format!("{e:?}")),
+            })?
+        } else {
+            models::Scan::default()
+        }
+    };
+    let feed = match feed {
+        Some(feed) => feed.to_owned(),
+        None => read_openvas_config()
+            .map(|c| get_path_from_openvas(c))
+            .map_err(|e| CliError {
+                filename: "".to_string(),
+                kind: CliErrorKind::Corrupt(format!("{e:?}")),
+            })?,
+    };
+
+    tracing::info!("loading feed. This may take a while.");
+    feed_update::run(Arc::clone(&storage), feed.to_owned())?;
+    tracing::info!("feed loaded.");
+    let ports = match port_list {
+        Some(ports) => {
+            tracing::debug!("reading port list from {ports}");
+            let reader = as_bufreader(ports)?;
+            scanconfig::parse_portlist(reader).map_err(|e| map_error(ports, e))?
+        }
+        None => vec![],
+    };
+    let reader = as_bufreader(config)?;
+    let vts = scanconfig::parse_vts(reader, storage.as_ref(), &scan.vts)
+        .map_err(|e| map_error(config, e))?;
+    scan.vts.extend(vts);
+    scan.target.ports = ports;
+    let out = serde_json::to_string_pretty(&scan).map_err(|e| CliError {
+        filename: config.to_string(),
+        kind: CliErrorKind::Corrupt(format!("{e:?}")),
+    })?;
+    println!("{}", out);
+    Ok(())
+}

--- a/rust/nasl-cli/src/scanconfig.rs
+++ b/rust/nasl-cli/src/scanconfig.rs
@@ -35,7 +35,7 @@ pub(crate) fn run(
     let feed = match feed {
         Some(feed) => feed.to_owned(),
         None => read_openvas_config()
-            .map(|c| get_path_from_openvas(c))
+            .map(get_path_from_openvas)
             .map_err(|e| CliError {
                 filename: "".to_string(),
                 kind: CliErrorKind::Corrupt(format!("{e:?}")),

--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -296,7 +296,7 @@ mod tests {
         let scan: models::Scan = models::Scan::default();
         let ctx = ContextBuilder::new()
             .api_key(Some("mtls_is_preferred".to_string()))
-            .scanner(NoOpScanner::default())
+            .scanner(NoOpScanner)
             .build();
         let controller = Arc::new(ctx);
         let resp = post_scan(&scan, Arc::clone(&controller)).await;

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -442,6 +442,15 @@ where
             }
         })
     }
+
+    fn retrieve_by_field(
+        &self,
+        _: &storage::Field,
+        _: &storage::Retrieve,
+    ) -> Result<Vec<(K, Vec<storage::Field>)>, StorageError> {
+        // currently not supported
+        Ok(vec![])
+    }
 }
 
 #[cfg(test)]

--- a/rust/scanconfig/Cargo.toml
+++ b/rust/scanconfig/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "scanconfig"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+storage = { path = "../storage" }
+models = { path = "../models" }
+serde = { version = "1.0", features = ["derive"]}
+quick-xml = { version = "0.28.1", features = ["serialize"] }
+serde_json = "1.0"
+urlencoding = "2.1.2"
+tracing = "0.1.37"

--- a/rust/scanconfig/src/lib.rs
+++ b/rust/scanconfig/src/lib.rs
@@ -1,0 +1,389 @@
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+    io::BufRead,
+};
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct PortRange {
+    #[serde(rename = "@id")]
+    id: String,
+    start: usize,
+    end: usize,
+    #[serde(rename(deserialize = "type"))]
+    port_type: String,
+    comment: Option<String>,
+}
+
+impl PortRange {
+    fn as_port_range(&self) -> models::PortRange {
+        let end = match self.end {
+            0 => None,
+            _ => Some(self.end),
+        };
+        models::PortRange {
+            start: self.start,
+            end,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct PortRangeList {
+    port_range: Vec<PortRange>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct PortList {
+    #[serde(rename = "@id")]
+    id: String,
+    name: Option<String>,
+    comment: Option<String>,
+    port_ranges: PortRangeList,
+}
+
+impl PortList {
+    fn as_port_list(&self) -> Vec<models::Port> {
+        let mut tcp = vec![];
+        let mut udp = vec![];
+        let mut none = vec![];
+        for p in self.port_ranges.port_range.iter() {
+            match p.port_type.as_str() {
+                "tcp" => tcp.push(p.as_port_range()),
+                "udp" => udp.push(p.as_port_range()),
+                _ => none.push(p.as_port_range()),
+            }
+        }
+        vec![
+            models::Port {
+                protocol: Some(models::Protocol::TCP),
+                range: tcp,
+            },
+            models::Port {
+                protocol: Some(models::Protocol::UDP),
+                range: udp,
+            },
+            models::Port {
+                protocol: None,
+                range: none,
+            },
+        ]
+    }
+}
+
+/// Error types
+#[derive(Debug, Clone)]
+pub enum Error {
+    /// XML parse error
+    ParseError(String),
+    /// Storage error
+    StorageError(storage::StorageError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::ParseError(s) => write!(f, "Parse error: {}", s),
+            Error::StorageError(s) => write!(f, "Storage error: {}", s),
+        }
+    }
+}
+
+impl From<storage::StorageError> for Error {
+    fn from(e: storage::StorageError) -> Self {
+        Error::StorageError(e)
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Parse a port list from a string.
+pub fn parse_portlist<R>(pl: R) -> Result<Vec<models::Port>, Error>
+where
+    R: BufRead,
+{
+    let result = quick_xml::de::from_reader::<R, PortList>(pl)
+        .map_err(|e| Error::ParseError(format!("Error parsing port list: {}", e.to_string())))?;
+    tracing::trace!(
+        "transforming portlist {} {} ({}) with {} entries.",
+        &result.id,
+        result.name.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        result.comment.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        &result.port_ranges.port_range.len()
+    );
+    Ok(result.as_port_list())
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfig {
+    #[serde(rename = "@id")]
+    id: String,
+    name: Option<String>,
+    comment: Option<String>,
+    #[serde(rename(deserialize = "type"))]
+    scan_type: String,
+    #[serde(rename(deserialize = "usage_type"))]
+    usage_type: String,
+    preferences: ScanConfigPreferences,
+    nvt_selectors: ScanConfigNvtSelectors,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfigNvtSelectors {
+    nvt_selector: Vec<ScanConfigNvtSelector>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfigNvtSelector {
+    include: usize,
+    #[serde(rename(deserialize = "type"))]
+    nvt_type: usize,
+    family_or_nvt: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfigPreferences {
+    preference: Vec<ScanConfigPreference>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfigPreference {
+    id: u16,
+    name: String,
+    value: String,
+    #[serde(rename(deserialize = "type"))]
+    preference_type: String,
+    nvt: ScanConfigPreferenceNvt,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct ScanConfigPreferenceNvt {
+    #[serde(rename = "@oid")]
+    oid: String,
+    name: String,
+}
+
+pub fn parse_vts<R, K>(
+    sc: R,
+    retriever: &dyn storage::Retriever<K>,
+    vts: &[models::VT],
+) -> Result<Vec<models::VT>, Error>
+where
+    R: BufRead,
+{
+    let result = quick_xml::de::from_reader::<R, ScanConfig>(sc)
+        .map_err(|e| Error::ParseError(format!("Error parsing vts: {}", e.to_string())))?;
+    tracing::debug!(
+        "transforming vts {} {} ({}) with {} entries.",
+        &result.id,
+        result.name.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        result.comment.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        &result.preferences.preference.len()
+    );
+    let preference_lookup: HashMap<String, Vec<models::Parameter>> = result
+        .preferences
+        .preference
+        .iter()
+        .map(|p| {
+            (
+                p.nvt.oid.clone(),
+                vec![models::Parameter {
+                    id: p.id.clone(),
+                    value: p.value.clone(),
+                }],
+            )
+        })
+        .collect();
+    let oid_to_vt = |oid: &String| -> Result<models::VT, Error> {
+        let parameters = preference_lookup.get(oid).unwrap_or(&vec![]).clone();
+        Ok(models::VT {
+            oid: oid.clone(),
+            parameters,
+        })
+    };
+    let is_not_already_present = |oid: &String| -> bool { !vts.iter().any(|vt| vt.oid == *oid) };
+    result
+        .nvt_selectors
+        .nvt_selector
+        .iter()
+        .flat_map(|s| {
+            if s.nvt_type == 2 {
+                if is_not_already_present(&s.family_or_nvt) {
+                    return vec![oid_to_vt(&s.family_or_nvt)];
+                } else {
+                    return vec![];
+                }
+            } else {
+                // lookup oids via family
+                use storage::nvt::NVTField;
+                use storage::nvt::NVTKey;
+                use storage::Field;
+                use storage::Retrieve;
+                match retriever.retrieve_by_field(
+                    &Field::NVT(NVTField::Family(s.family_or_nvt.clone())),
+                    &Retrieve::NVT(Some(NVTKey::Oid)),
+                ) {
+                    Ok(nvt) => {
+                        tracing::debug!(
+                            "found {} nvt entries for family {}",
+                            nvt.len(),
+                            s.family_or_nvt
+                        );
+                        nvt.iter()
+                            .flat_map(|(_, f)| {
+                                f.iter().filter_map(|f| match f {
+                                    Field::NVT(NVTField::Oid(oid))
+                                        if is_not_already_present(oid) =>
+                                    {
+                                        Some(oid_to_vt(oid))
+                                    }
+                                    _ => None,
+                                })
+                            })
+                            .collect()
+                    }
+                    Err(e) => vec![Err(e.into())],
+                }
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use storage::Storage;
+
+    use super::*;
+
+    #[test]
+    fn parse_portlist() {
+        let pl = r#"
+<port_list id="c7e03b6c-3bbe-11e1-a057-406186ea4fc5">
+  <name>OpenVAS Default</name>
+  <comment>Version 20200827.</comment>
+  <port_ranges>
+    <port_range id="1626ec63-366a-4c1b-b779-da516edfcc33">
+      <start>1</start>
+      <end>5</end>
+      <type>tcp</type>
+      <comment/>
+    </port_range>
+    <port_range id="c492b604-8c97-464c-96d0-95ab54352a79">
+      <start>7</start>
+      <end>7</end>
+      <type>tcp</type>
+      <comment/>
+    </port_range>
+    <port_range id="c492b604-8c97-464c-96d0-95ab54352a79">
+      <start>7</start>
+      <end>7</end>
+      <type>udp</type>
+      <comment/>
+    </port_range>
+    <port_range id="c492b604-8c97-464c-96d0-95ab54352a79">
+      <start>7</start>
+      <end>7</end>
+      <type></type>
+      <comment/>
+    </port_range>
+    </port_ranges>
+</port_list>"#;
+        let presult = quick_xml::de::from_str::<PortList>(pl).unwrap();
+        assert_eq!(presult.port_ranges.port_range.len(), 4);
+
+        let result = super::parse_portlist(pl.as_bytes()).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].protocol, Some(models::Protocol::TCP));
+        assert_eq!(result[0].range.len(), 2);
+        assert_eq!(result[1].protocol, Some(models::Protocol::UDP));
+        assert_eq!(result[1].range.len(), 1);
+        assert_eq!(result[2].protocol, None);
+        assert_eq!(result[2].range.len(), 1);
+    }
+
+    #[test]
+    fn parse_scanconfig() {
+        let sc = r#"
+        <config id="8715c877-47a0-438d-98a3-27c7a6ab2196">
+  <name>Discovery</name>
+  <comment>Network Discovery scan configuration. Version 20201215.</comment>
+  <type>0</type>
+  <usage_type>scan</usage_type>
+  <preferences>
+    <preference>
+      <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+        <name>Ping Host</name>
+      </nvt>
+      <name>Report about unrechable Hosts</name>
+      <type>checkbox</type>
+      <value>no</value>
+      <id>6</id>
+    </preference>
+    <preference>
+      <nvt oid="1.3.6.1.4.1.25623.1.0.10330">
+        <name>Services</name>
+      </nvt>
+      <name>Test SSL based services</name>
+      <type>radio</type>
+      <value>All;Known SSL ports;None</value>
+      <default>All;None</default>
+      <id>1</id>
+    </preference>
+    <preference>
+      <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
+        <name>Ping Host</name>
+      </nvt>
+      <name>Mark unrechable Hosts as dead (not scanning)</name>
+      <type>checkbox</type>
+      <value>yes</value>
+      <id>5</id>
+    </preference>
+  </preferences>
+  <nvt_selectors>
+    <nvt_selector>
+      <include>1</include>
+      <type>2</type>
+      <family_or_nvt>1.3.6.1.4.1.25623.1.0.803575</family_or_nvt>
+    </nvt_selector>
+    <nvt_selector>
+      <include>1</include>
+      <type>1</type>
+      <family_or_nvt>Product detection</family_or_nvt>
+    </nvt_selector>
+    </nvt_selectors>
+    </config>"#;
+        let result = quick_xml::de::from_str::<ScanConfig>(sc).unwrap();
+        assert_eq!(result.nvt_selectors.nvt_selector.len(), 2);
+        assert_eq!(result.preferences.preference.len(), 3);
+        let shop: storage::DefaultDispatcher<String> = storage::DefaultDispatcher::default();
+        let add_product_detection = |oid: &str| {
+            shop.as_dispatcher()
+                .dispatch(
+                    &oid.to_string(),
+                    storage::Field::NVT(storage::nvt::NVTField::Oid(oid.to_owned().to_string())),
+                )
+                .unwrap();
+            shop.as_dispatcher()
+                .dispatch(
+                    &oid.to_string(),
+                    storage::Field::NVT(storage::nvt::NVTField::Family(
+                        "Product detection".to_string(),
+                    )),
+                )
+                .unwrap();
+        };
+        add_product_detection("1");
+        add_product_detection("2");
+        add_product_detection("4");
+        add_product_detection("5");
+        let exists = vec![models::VT {
+            oid: "1".to_string(),
+            parameters: vec![],
+        }];
+
+        let result = super::parse_vts(sc.as_bytes(), &shop, &exists).unwrap();
+        assert_eq!(result.len(), 4);
+    }
+}

--- a/rust/scanconfig/src/lib.rs
+++ b/rust/scanconfig/src/lib.rs
@@ -105,12 +105,12 @@ where
     R: BufRead,
 {
     let result = quick_xml::de::from_reader::<R, PortList>(pl)
-        .map_err(|e| Error::ParseError(format!("Error parsing port list: {}", e.to_string())))?;
+        .map_err(|e| Error::ParseError(format!("Error parsing port list: {}", e)))?;
     tracing::trace!(
         "transforming portlist {} {} ({}) with {} entries.",
         &result.id,
-        result.name.as_ref().map(|s| s.as_str()).unwrap_or(&""),
-        result.comment.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        result.name.as_deref().unwrap_or(""),
+        result.comment.as_deref().unwrap_or(""),
         &result.port_ranges.port_range.len()
     );
     Ok(result.as_port_list())
@@ -174,12 +174,12 @@ where
     R: BufRead,
 {
     let result = quick_xml::de::from_reader::<R, ScanConfig>(sc)
-        .map_err(|e| Error::ParseError(format!("Error parsing vts: {}", e.to_string())))?;
+        .map_err(|e| Error::ParseError(format!("Error parsing vts: {}", e)))?;
     tracing::debug!(
         "transforming vts {} {} ({}) with {} entries.",
         &result.id,
-        result.name.as_ref().map(|s| s.as_str()).unwrap_or(&""),
-        result.comment.as_ref().map(|s| s.as_str()).unwrap_or(&""),
+        result.name.as_deref().unwrap_or(""),
+        result.comment.as_deref().unwrap_or(""),
         &result.preferences.preference.len()
     );
     let preference_lookup: HashMap<String, Vec<models::Parameter>> = result
@@ -190,7 +190,7 @@ where
             (
                 p.nvt.oid.clone(),
                 vec![models::Parameter {
-                    id: p.id.clone(),
+                    id: p.id,
                     value: p.value.clone(),
                 }],
             )
@@ -211,9 +211,9 @@ where
         .flat_map(|s| {
             if s.nvt_type == 2 {
                 if is_not_already_present(&s.family_or_nvt) {
-                    return vec![oid_to_vt(&s.family_or_nvt)];
+                    vec![oid_to_vt(&s.family_or_nvt)]
                 } else {
-                    return vec![];
+                    vec![]
                 }
             } else {
                 // lookup oids via family
@@ -316,7 +316,7 @@ mod tests {
       <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
         <name>Ping Host</name>
       </nvt>
-      <name>Report about unrechable Hosts</name>
+      <name>Report about unreachable Hosts</name>
       <type>checkbox</type>
       <value>no</value>
       <id>6</id>
@@ -335,7 +335,7 @@ mod tests {
       <nvt oid="1.3.6.1.4.1.25623.1.0.100315">
         <name>Ping Host</name>
       </nvt>
-      <name>Mark unrechable Hosts as dead (not scanning)</name>
+      <name>Mark unreachable Hosts as dead (not scanning)</name>
       <type>checkbox</type>
       <value>yes</value>
       <id>5</id>

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-2.0-or-later"
 [dependencies]
 time = {version = "0", features = ["parsing"]}
 serde = { version = "1.0", features = ["derive"], optional = true }
+tracing = "0.1.37"
 
 [features]
 serde_support = ["serde"]

--- a/rust/storage/src/nvt.rs
+++ b/rust/storage/src/nvt.rs
@@ -522,13 +522,12 @@ where
 
 impl<S, K> Dispatcher<K> for PerNVTDispatcher<S, K>
 where
-    K: AsRef<str>,
-    S: NvtDispatcher<K>,
+    K: AsRef<str> + Send + Sync,
+    S: NvtDispatcher<K> + Send + Sync,
 {
     fn dispatch(&self, key: &K, scope: crate::Field) -> Result<(), StorageError> {
         match scope {
             Field::NVT(nvt) => self.store_nvt_field(nvt),
-            // TODO change here to store other fields instead
             Field::KB(kb) => self.dispatcher.dispatch_kb(key, kb),
         }
     }
@@ -551,6 +550,14 @@ where
 {
     fn retrieve(&self, key: &K, scope: &crate::Retrieve) -> Result<Vec<Field>, StorageError> {
         self.dispatcher.retrieve(key, scope)
+    }
+
+    fn retrieve_by_field(
+        &self,
+        field: &Field,
+        scope: &crate::Retrieve,
+    ) -> Result<Vec<(K, Vec<Field>)>, StorageError> {
+        self.dispatcher.retrieve_by_field(field, scope)
     }
 }
 


### PR DESCRIPTION
Transforms a scan-config from gvmds data-objects to scan json of
[openvasd](https://greenbone.github.io/scanner-api/#/scan/create_scanl).

To set the target and credentials you can pipe a partial scan json into
`nasl-cli scan-config` by providing `-i` flag.

As an example we assume that the data-objects feed is in
`~/src/greenbone/data-objects/content/22.04` while the vulnerability feed is in
`~/src/greenbone/vulnerability-tests/nasl/common` and we want to create a scan
to verify localhost with a discovery and full and fast policy on the openvas
default portlist.

For that we need to execute:

```
echo '{ "target": { "hosts": ["localhost"], "ports": [] }, "vts": [] }'| \
nasl-cli scan-config -i -p ~/src/greenbone/vulnerability-tests/nasl/common \
  -l ~/src/greenbone/data-objects/content/22.04/port-lists/openvas-default-c7e03b6c-3bbe-11e1-a057-406186ea4fc5.xml \
  ~/src/greenbone/data-objects/content/22.04/scan-configs/discovery-8715c877-47a0-438d-98a3-27c7a6ab2196.xml
\ 
~/src/greenbone/data-objects/content/22.04/scan-configs/full-and-fast-daba56c8-73ec-11df-a475-002264764cea.xml
```

Be aware to resolve the families within a scan-config nasl-cli requires to read
the complete feed.
Depending on your system that may require some time on each scan-config run.

Usage:

```
Transforms a scan-config xml to a scan json for openvasd.
When piping a scan json it is enriched with the scan-config xml and may the portlist otherwise it will print a scan json without target or credentials.

Usage: nasl-cli scan-config [OPTIONS] <scan-config>

Arguments:
  <scan-config>

Options:
  -p, --path <FILE>      Path to the feed.
  -i, --input            Parses scan json from stdin.
  -l, --portlist <FILE>  Path to the port list xml
  -h, --help             Print help
```

Fixes: SC-892