### PR TITLE
Fix: override an existing scan

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -311,9 +311,6 @@ components:
       description: "Model representing a scan."
       type: "object"
       properties:
-        scan_id:
-          description: "The scan ID for a scan to create. If left empty, an ID is automatically generated. Must be a UUIDv4."
-          $ref: "#/components/schemas/ScanID"
         target:
           description: "The target to scan"
           $ref: "#/components/schemas/Target"
@@ -671,7 +668,6 @@ components:
       description: "A complex example for creating a scan, that uses all available fields."
       value:
         {
-          "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
           "target":
             {
               "hosts":

--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -82,14 +82,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Scan"
+              $ref: "#/components/schemas/ScanReq"
             examples:
               schema:
                 description: "Schema of a Scan."
               create simple scan:
                 $ref: "#/components/examples/scan_simple"
               create complex scan:
-                $ref: "#/components/examples/scan_full"
+                $ref: "#/components/examples/scan_full_req"
       responses:
         "201":
           description: "Scan created"
@@ -117,10 +117,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Scan"
+                $ref: "#/components/schemas/ScanResp"
               examples:
                 scan:
-                  $ref: "#/components/examples/scan_full"
+                  $ref: "#/components/examples/scan_full_resp"
 
         "404":
           description: "Scan not found"
@@ -307,12 +307,33 @@ components:
       description: "A scan ID to identify a scan."
       type: "string"
 
-    Scan:
-      description: "Model representing a scan."
+    ScanReq:
+      description: "Model representing a scan request."
       type: "object"
       properties:
         target:
-          description: "The target to scan"
+            $ref: "#/components/schemas/Target"
+        scanner_preferences:
+          description: "Overwrite the default settings of the Scanner."
+          type: "array"
+          items:
+            $ref: "#/components/schemas/ScannerPreference"
+        vts:
+          type: "array"
+          description: "A collection of VTs, which are run for the given target."
+          items:
+            $ref: "#/components/schemas/VT"
+      required:
+        - target
+        - vts
+
+    ScanResp:
+      description: "Model representing a scan response."
+      type: "object"
+      properties:
+        scan_id:
+          $ref: "#/components/schemas/ScanID"
+        target:
           $ref: "#/components/schemas/Target"
         scanner_preferences:
           description: "Overwrite the default settings of the Scanner."
@@ -664,10 +685,91 @@ components:
             },
           "vts": [{ "oid": "1.3.6.1.4.1.25623.1.0.10267" }],
         }
-    scan_full:
+    scan_full_req:
       description: "A complex example for creating a scan, that uses all available fields."
       value:
         {
+          "target":
+            {
+              "hosts":
+                [
+                  "127.0.0.1",
+                  "192.168.0.1-15",
+                  "10.0.5.0/24",
+                  "::1",
+                  "2001:db8:0000:0000:0000:0000:0000:0001-00ff",
+                  "2002::1234:abcd:ffff:c0a8:101/64",
+                  "examplehost",
+                ],
+              "ports":
+                [
+                  {
+                    "protocol": "udp",
+                    "range": [{ "start": 22 }, { "start": 1024, "end": 1030 }],
+                  },
+                  { "protocol": "tcp", "range": [{ "start": 24, "end": 30 }] },
+                  { "range": [{ "start": 100, "end": 1000 }] },
+                ],
+              "credentials":
+                [
+                  {
+                    "service": "ssh",
+                    "port": 22,
+                    "usk":
+                      {
+                        "username": "user",
+                        "password": "pw",
+                        "private": "ssh-key...",
+                      },
+                  },
+                  {
+                    "service": "smb",
+                    "up": { "username": "user", "password": "pw" },
+                  },
+                  {
+                    "service": "snmp",
+                    "snmp":
+                      {
+                        "username": "user",
+                        "password": "pw",
+                        "community": "my_community",
+                        "auth_algorithm": "md5",
+                        "privacy_password": "priv_pw",
+                        "privacy_algorithm": "aes",
+                      },
+                  },
+                ],
+              "alive_test_ports":
+                [
+                  { "protocol": "tcp", "range": [{ "start": 1, "end": 100 }] },
+                  { "range": [{ "start": 443 }] },
+                ],
+              "alive_test_methods":
+                ["icmp", "tcp_syn", "tcp_ack", "arp", "consider_alive"],
+              "reverse_lookup_unify": true,
+              "reverse_lookup_only": false,
+            },
+          "scanner_preferences":
+            [
+              { "id": "target_port", "value": "443" },
+              { "id": "use_https", "value": "1" },
+              { "id": "profile", "value": "fast_scan" },
+            ],
+          "vts":
+            [
+              {
+                "oid": "1.3.6.1.4.1.25623.1.0.10662",
+                "parameters":
+                  [{ "id": 1, "value": "200" }, { "id": 2, "value": "yes" }],
+              },
+              { "oid": "1.3.6.1.4.1.25623.1.0.10330" },
+            ],
+        }
+    scan_full_resp:
+      description: "A complex example for creating a scan, that uses all available fields."
+      value:
+        {
+          "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
           "target":
             {
               "hosts":

--- a/rust/models/src/lib.rs
+++ b/rust/models/src/lib.rs
@@ -28,10 +28,13 @@ pub use vt::*;
 
 use serde::Serializer;
 
-fn censor<S, T>(_: &T,serializer: S) -> std::result::Result<S::Ok, S::Error> where S: Serializer {
-  serializer.serialize_str("***")
+fn censor<S, T>(_: &T, serializer: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str("***")
 }
-   
+
 #[cfg(test)]
 //#[cfg(feature = "serde_support")]
 mod tests {
@@ -64,7 +67,6 @@ mod tests {
     #[test]
     fn parses_complex_example() {
         let json_str = r#"{
-  "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
   "target": {
     "hosts": [
       "127.0.0.1",
@@ -173,4 +175,118 @@ mod tests {
         // tests that it doesn't panic when parsing the json
         let _: Scan = serde_json::from_str(json_str).unwrap();
     }
+}
+
+#[test]
+#[should_panic]
+fn parses_complex_example_fails() {
+    let json_str = r#"{
+  "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
+  "target": {
+    "hosts": [
+      "127.0.0.1",
+      "192.168.0.1-15",
+      "10.0.5.0/24",
+      "::1",
+      "2001:db8:0000:0000:0000:0000:0000:0001-00ff",
+      "2002::1234:abcd:ffff:c0a8:101/64",
+      "examplehost"
+    ],
+    "ports": [
+      {
+        "protocol": "udp",
+        "range": [{"start": 22}, {"start": 1024, "end": 1030}]
+      },
+      {
+        "protocol": "tcp",
+        "range": [{"start": 24, "end": 30}]
+      },
+      {
+        "range": [{"start": 100, "end": 1000}]
+      }
+    ],
+    "credentials": [
+      {
+        "service": "ssh",
+        "port": 22,
+        "usk": {
+          "username": "user",
+          "password": "pw",
+          "private": "ssh-key..."
+        }
+      },
+      {
+        "service": "smb",
+        "up": {
+          "username": "user",
+          "password": "pw"
+        }
+      },
+      {
+        "service": "snmp",
+        "snmp": {
+          "username": "user",
+          "password": "pw",
+          "community": "my_community",
+          "auth_algorithm": "md5",
+          "privacy_password": "priv_pw",
+          "privacy_algorithm": "aes"
+        }
+      }
+    ],
+    "alive_test_ports": [
+      {
+        "protocol": "tcp",
+        "range": [{"start": 1, "end": 100}]
+      },
+      {
+        "range": [{ "start": 443 }]
+      }
+    ],
+    "alive_test_methods": [
+      "icmp",
+      "tcp_syn",
+      "tcp_ack",
+      "arp",
+      "consider_alive"
+    ],
+    "reverse_lookup_unify": true,
+    "reverse_lookup_only": false
+  },
+  "scanner_preferences": [
+    {
+      "id": "target_port",
+      "value": "443"
+    },
+    {
+      "id": "use_https",
+      "value": "1"
+    },
+    {
+      "id": "profile",
+      "value": "fast_scan"
+    }
+  ],
+  "vts": [
+    {
+      "oid": "1.3.6.1.4.1.25623.1.0.10662",
+      "parameters": [
+        {
+          "id": 1,
+          "value": "200"
+        },
+        {
+          "id": 2,
+          "value": "yes"
+        }
+      ]
+    },
+    {
+      "oid": "1.3.6.1.4.1.25623.1.0.10330"
+    }
+  ]
+}
+"#;
+    // tests that it doesn't panic when parsing the json
+    let _: Scan = serde_json::from_str(json_str).unwrap();
 }

--- a/rust/models/src/scan.rs
+++ b/rust/models/src/scan.rs
@@ -8,12 +8,13 @@ use super::{scanner_preference::ScannerPreference, target::Target, vt::VT};
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
+    derive(serde::Serialize, serde::Deserialize),
+    serde(deny_unknown_fields)
 )]
 pub struct Scan {
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", skip_deserializing)
     )]
     /// Unique ID of a scan
     pub scan_id: Option<String>,

--- a/rust/models/src/status.rs
+++ b/rust/models/src/status.rs
@@ -43,6 +43,10 @@ impl Status {
     pub fn is_done(&self) -> bool {
         !self.is_running()
     }
+
+    pub fn is_stored(&self) -> bool {
+        self.status.is_stored()
+    }
 }
 
 /// Enum of the possible phases of a scan
@@ -71,6 +75,12 @@ pub enum Phase {
 impl Phase {
     pub fn is_running(&self) -> bool {
         matches!(self, Self::Running | Self::Requested)
+    }
+}
+
+impl Phase {
+    pub fn is_stored(&self) -> bool {
+        matches!(self, Self::Stored)
     }
 }
 

--- a/rust/models/src/status.rs
+++ b/rust/models/src/status.rs
@@ -43,10 +43,6 @@ impl Status {
     pub fn is_done(&self) -> bool {
         !self.is_running()
     }
-
-    pub fn is_stored(&self) -> bool {
-        self.status.is_stored()
-    }
 }
 
 /// Enum of the possible phases of a scan
@@ -75,12 +71,6 @@ pub enum Phase {
 impl Phase {
     pub fn is_running(&self) -> bool {
         matches!(self, Self::Running | Self::Requested)
-    }
-}
-
-impl Phase {
-    pub fn is_stored(&self) -> bool {
-        matches!(self, Self::Stored)
     }
 }
 

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -4,7 +4,6 @@
 
 use std::{collections::HashMap, path::PathBuf, sync::RwLock};
 
-
 use storage::DefaultDispatcher;
 
 use crate::{

--- a/rust/openvasd/src/controller/entry.rs
+++ b/rust/openvasd/src/controller/entry.rs
@@ -141,11 +141,10 @@ where
             match crate::request::json_request::<models::Scan>(&ctx.response, req).await {
                 Ok(mut scan) => {
                     response_blocking(move || {
-                        if scan.scan_id.is_none() {
-                            scan.scan_id = Some(uuid::Uuid::new_v4().to_string());
-                        }
+                        scan.scan_id = Some(uuid::Uuid::new_v4().to_string());
                         let mut scans = ctx.scans.write()?;
                         let id = scan.scan_id.clone().unwrap_or_default();
+
                         let resp = ctx.response.created(&id);
                         scans.insert(id.clone(), crate::scan::Progress::from(scan));
                         tracing::debug!("Scan with ID {} created", id);
@@ -287,7 +286,6 @@ where
             let res = match scans.get(&id) {
                 Some(prgss) => &prgss.results,
                 None => return Ok(ctx.response.not_found("scans", &id)),
-
             };
             Ok(ctx.response.ok_stream(res.to_vec()).await)
         }

--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -226,20 +226,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_scan() {
+    #[should_panic]
+    async fn add_scan_with_id_fails() {
         let scan: models::Scan = models::Scan::default();
         let controller = Arc::new(Context::default());
         let id = post_scan_id(&scan, Arc::clone(&controller)).await;
         let resp = get_scan(&id, Arc::clone(&controller)).await;
         let resp = hyper::body::to_bytes(resp.into_body()).await.unwrap();
 
-        let resp = serde_json::from_slice::<models::Scan>(&resp).unwrap();
-
-        let scan: models::Scan = models::Scan {
-            scan_id: Some(id.to_string()),
-            ..Default::default()
-        };
-        assert_eq!(resp, scan);
+        let _ = serde_json::from_slice::<models::Scan>(&resp).unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
**What**:
Fix: override an existing scan only if it is on Stored status
Jira: SC-893
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This patch solves an issue in which a running scan could be overriden if a new scan is post/stored with the same scan ID, producing a reset of the running scan status and results lost
Instead, the API changed and now it is not possible to provide a scan id when creating a scan.
The scan id is automatically generated by openvasd and sent back to the client in the response.

<!-- Why are these changes necessary? -->

**How**:
Create a scan with an scan_id. I will get an error. Create a scan without an scan_id, the scan is created and you get the ID in the response.
Without the patch, you are able to create a scan passing a scan ID. If you repetitively create the scan with the same ID, the already existing scan is override, independent of the status, losing results and any other information. 
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
