### PR TITLE
Change: Docker: remove python3-impacket

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   # nasl_pread: Failed to execute child process “netstat” (No such file or directory)
   net-tools \
   # for openvas-smb support
-  python3-impacket \
   libgnutls30 \
   libgssapi3-heimdal \
   libkrb5-26-heimdal \


### PR DESCRIPTION
With changes in ospd-openvas the python3-impacket is not required
anymore in the openvas image.

This does mean that each party that wants to execute wmipacket, and is
using the openvas image, is required to install themselves.

Jira: SC-897
