### PR TITLE
Add: openvasd: encryption of credentials and results

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -45,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -90,15 +99,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -114,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -124,14 +133,20 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
+
+[[package]]
+name = "async-traits"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b009a4f27206d3d1c853e1e5f8909ca582e846cc124b3035b98bea1db69f06f"
 
 [[package]]
 name = "autocfg"
@@ -140,16 +155,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -198,9 +240,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ccm"
@@ -219,6 +264,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "chrono"
@@ -271,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "b417ae4361bca3f5de378294fc7472d3c4ed86a5ef9f49e93ae722f432aae8d2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -282,27 +338,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "9c90dc0f0e42c64bff177ca9d7be6fcc9ddb0f26a6e062174a61c84dd6c644d4"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -362,9 +417,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -437,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -450,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -487,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,9 +560,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -516,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -556,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -572,9 +639,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -635,7 +702,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -680,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -700,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,9 +780,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -717,7 +790,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -737,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,18 +823,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -802,15 +872,15 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -832,10 +902,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "log",
@@ -847,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -870,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -885,7 +956,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -899,17 +980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,12 +990,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -941,15 +1010,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -970,9 +1039,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -989,7 +1058,7 @@ name = "libssh-rs"
 version = "0.2.0"
 source = "git+https://github.com/wez/libssh-rs.git?branch=main#e572735c6ae4e22754ca305cbe9112a8c791f09f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libssh-rs-sys",
  "openssl-sys",
  "thiserror",
@@ -1007,15 +1076,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1023,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "matchers"
@@ -1033,7 +1102,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1062,9 +1131,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -1286,21 +1355,30 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1345,19 +1423,26 @@ name = "openvasd"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "async-traits",
+ "base64",
+ "chacha20",
  "clap",
  "feed",
  "futures",
  "futures-util",
+ "generic-array",
  "hyper",
  "hyper-rustls",
  "models",
  "nasl-interpreter",
  "osp",
+ "pbkdf2",
+ "rand",
  "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "sha2",
  "storage",
  "tokio",
  "tokio-rustls",
@@ -1396,15 +1481,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
 ]
 
 [[package]]
@@ -1413,7 +1520,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbaa01d616eb84eb35cd085fdeaa8671dc8d951bdc4a75bfc414466e76b039ce"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "libc",
  "libloading",
@@ -1424,15 +1531,15 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -1448,9 +1555,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1461,15 +1568,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
@@ -1567,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1585,9 +1692,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1604,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1687,22 +1794,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1715,6 +1823,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,9 +1841,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "ring"
@@ -1751,14 +1870,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.19"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags",
- "errno 0.3.1",
- "io-lifetimes",
+ "bitflags 2.4.0",
+ "errno 0.3.2",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -1766,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.1"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -1778,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1790,18 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -1809,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -1837,18 +1961,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1862,11 +1986,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1875,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1885,29 +2009,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1916,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -1942,9 +2066,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1980,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -2044,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2055,22 +2179,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2085,10 +2209,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "serde",
  "time-core",
  "time-macros",
@@ -2102,9 +2227,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -2136,11 +2261,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2148,7 +2273,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2161,14 +2286,14 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
@@ -2190,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2202,20 +2327,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2242,13 +2367,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2310,9 +2435,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2341,9 +2466,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2352,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
@@ -2364,9 +2489,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom",
  "rand",
@@ -2403,11 +2528,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -2419,9 +2543,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2429,24 +2553,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2454,28 +2578,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2518,7 +2642,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2536,78 +2660,33 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.48.3",
+ "windows_i686_gnu 0.48.3",
+ "windows_i686_msvc 0.48.3",
+ "windows_x86_64_gnu 0.48.3",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.48.3",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2617,15 +2696,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2635,15 +2708,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2653,15 +2720,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2671,27 +2732,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2701,21 +2750,15 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]

--- a/rust/models/Cargo.toml
+++ b/rust/models/Cargo.toml
@@ -8,7 +8,6 @@ license = "GPL-2.0-or-later"
 
 [dependencies]
 serde = {version = "1", features = ["derive"], optional = true}
-#serde_json = "1"
 
 
 [features]

--- a/rust/models/src/result.rs
+++ b/rust/models/src/result.rs
@@ -20,44 +20,44 @@ pub struct Result {
     pub r_type: ResultType,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// IP address
     pub ip_address: Option<String>,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// DNS
     pub hostname: Option<String>,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// ID of the VT, which generated the result
     pub oid: Option<String>,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// Port
     pub port: Option<i16>,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// Protocol the port corresponds to
     pub protocol: Option<Protocol>,
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
+        serde(skip_serializing_if = "Option::is_none", default)
     )]
     /// Additional information
     pub message: Option<String>,
 
     #[cfg_attr(
         feature = "serde_support",
-        serde(skip_serializing_if = "HashMap::is_empty")
+        serde(skip_serializing_if = "HashMap::is_empty", default)
     )]
     pub details: HashMap<String, String>,
 }

--- a/rust/openvasd/Cargo.toml
+++ b/rust/openvasd/Cargo.toml
@@ -27,5 +27,12 @@ async-trait = "0.1.68"
 clap = { version = "4.3.0", features = ["derive", "env"] }
 toml = "0.7.4"
 futures = "0.3.28"
+chacha20 = "0.9.1"
+rand = "0.8.5"
+pbkdf2 = { version = "0.12.2", features = ["password-hash"] }
+sha2 = "0.10.7"
+generic-array = "0.14.7"
+async-traits = "0.0.0"
+base64 = "0.21.2"
 
 [dev-dependencies]

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -153,11 +153,7 @@ where
     }
 }
 
-impl<S, DB> ContextBuilder<S, DB, Scanner<S>>
-where
-    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug,
-    DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug,
-{
+impl<S, DB> ContextBuilder<S, DB, Scanner<S>> {
     pub fn build(self) -> Context<S, DB> {
         Context {
             scanner: self.scanner.0,
@@ -175,11 +171,7 @@ where
 
 #[derive(Debug)]
 /// The context of the application
-pub struct Context<S, DB>
-where
-    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync,
-    DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync,
-{
+pub struct Context<S, DB> {
     /// The scanner that is used to start, stop and fetch results of scans.
     pub scanner: S,
     /// Creates responses

--- a/rust/openvasd/src/controller/feed.rs
+++ b/rust/openvasd/src/controller/feed.rs
@@ -9,9 +9,10 @@ use crate::feed::FeedIdentifier;
 use super::context::Context;
 use super::quit_on_poison;
 
-pub async fn fetch<S>(ctx: Arc<Context<S>>)
+pub async fn fetch<S, DB>(ctx: Arc<Context<S, DB>>)
 where
-    S: std::marker::Send + std::marker::Sync + 'static,
+    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync,
+    DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync,
 {
     if let Some(cfg) = &ctx.feed_config {
         let interval = cfg.verify_interval;

--- a/rust/openvasd/src/controller/results.rs
+++ b/rust/openvasd/src/controller/results.rs
@@ -8,56 +8,59 @@
 use crate::controller::quit_on_poison;
 use std::sync::Arc;
 
-use crate::scan::ScanResultFetcher;
-
 use super::context::Context;
 
 /// Defines the result fetching loop.
 ///
 /// This loop should be run as background task to fetch results from the scanner.
-pub async fn fetch<S>(ctx: Arc<Context<S>>)
+pub async fn fetch<S, DB>(ctx: Arc<Context<S, DB>>)
 where
-    S: ScanResultFetcher + std::marker::Send + std::marker::Sync + 'static + std::fmt::Debug,
+    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync,
+    DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync,
 {
     if let Some(cfg) = &ctx.result_config {
         let interval = cfg.0;
         tracing::debug!("Starting synchronization loop");
-        tokio::task::spawn_blocking(move || loop {
+        loop {
             if *ctx.abort.read().unwrap() {
                 tracing::trace!("aborting");
                 break;
             }
-            let ls = match ctx.scans.read() {
-                Ok(ls) => ls,
-                Err(_) => quit_on_poison(),
-            };
-            let scans = ls.clone();
-            drop(ls);
-            for (id, prgs) in scans.iter() {
-                if prgs.status.is_done() {
-                    tracing::trace!("{id} skipping status = {}", prgs.status.status);
+            let scans = ctx.db.get_scans().await;
+            if let Err(e) = scans {
+                tracing::warn!("Failed to get scans: {e}");
+                continue;
+            }
+            let scans = scans.unwrap();
+
+            for (scan, status) in scans.iter() {
+                // should never be none, probably makes sense to change scan_id
+                // to not be an option and set a uuid on default when it is
+                // missing on json serialization
+                let id = scan.scan_id.as_ref().unwrap();
+                if status.is_done() {
+                    tracing::trace!("{id} skipping status = {}", status.status);
                     continue;
                 }
-                match ctx.scanner.fetch_results(prgs) {
+                let results = ctx.scanner.fetch_results(id.clone()).await;
+                match results {
                     Ok(fr) => {
-                        tracing::trace!("{id} fetched results");
-                        let mut progress = prgs.clone();
-                        progress.append_results(fr);
-                        let mut ls = match ctx.scans.write() {
-                            Ok(ls) => ls,
-                            Err(_) => quit_on_poison(),
-                        };
-                        ls.insert(progress.scan.scan_id.clone().unwrap(), progress);
-                        drop(ls);
+                        tracing::trace!("{} fetched results", id);
+                        // we panic when we fetched results but are unable to
+                        // store them in the database.
+                        // When this happens we effectively lost the results
+                        // and need to escalate this.
+                        ctx.db.append_fetch_result(id, fr).await.unwrap();
+                    }
+                    Err(crate::scan::Error::Poisoned) => {
+                        quit_on_poison::<()>();
                     }
                     Err(e) => {
-                        tracing::warn!("Failed to fetch results for {id}: {e}");
+                        tracing::warn!("Failed to fetch results for {}: {e}", &id);
                     }
                 }
             }
             std::thread::sleep(interval);
-        })
-        .await
-        .unwrap();
+        }
     }
 }

--- a/rust/openvasd/src/crypt.rs
+++ b/rust/openvasd/src/crypt.rs
@@ -1,0 +1,225 @@
+use std::fmt::Display;
+
+use async_trait::async_trait;
+use chacha20::cipher::{KeyIvInit, StreamCipher};
+use chacha20::ChaCha20;
+use generic_array::typenum::U32;
+use generic_array::GenericArray;
+use pbkdf2::pbkdf2_hmac;
+use rand::{self, RngCore};
+use sha2::Sha256;
+
+#[derive(Clone, Debug)]
+pub struct Key(GenericArray<u8, U32>);
+
+impl Default for Key {
+    fn default() -> Self {
+        let mut key = [0u8; 32];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut key);
+        Key(key.into())
+    }
+}
+
+impl From<&str> for Key {
+    fn from(s: &str) -> Self {
+        let mut key = [0u8; 32];
+        // we currently don't need a salt as we only have one key
+        let salt = [0u8; 8];
+        pbkdf2_hmac::<Sha256>(s.as_bytes(), &salt, 8000, &mut key);
+        Key(key.into())
+    }
+}
+
+impl From<String> for Key {
+    fn from(s: String) -> Self {
+        Key::from(s.as_str())
+    }
+}
+
+#[async_trait]
+pub trait Crypt {
+    async fn encrypt(&self, data: Vec<u8>) -> Encrypted;
+    fn encrypt_sync(&self, data: Vec<u8>) -> Encrypted;
+
+    async fn decrypt(&self, encrypted: Encrypted) -> Vec<u8>;
+    fn decrypt_sync(&self, encrypted: &Encrypted) -> Vec<u8>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ChaCha20Crypt {
+    key: Key,
+}
+
+impl ChaCha20Crypt {
+    fn encrypt_sync(key: &Key, mut data: Vec<u8>) -> Encrypted {
+        let mut nonce = [0u8; 12];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut nonce);
+        let Key(key) = key;
+        let mut cipher = ChaCha20::new(key, &nonce.into());
+        cipher.apply_keystream(&mut data);
+        Encrypted { nonce, data }
+    }
+
+    fn decrypt_sync(key: &Key, encrypted: &Encrypted) -> Vec<u8> {
+        let mut data = encrypted.data.clone();
+        let Key(key) = key;
+        let mut cipher = ChaCha20::new(key, &encrypted.nonce.into());
+        cipher.apply_keystream(&mut data);
+        data
+    }
+}
+
+#[async_trait]
+impl Crypt for ChaCha20Crypt {
+    async fn encrypt(&self, data: Vec<u8>) -> Encrypted {
+        let key = self.key.clone();
+        tokio::task::spawn_blocking(move || Self::encrypt_sync(&key, data))
+            .await
+            .unwrap()
+    }
+
+    fn encrypt_sync(&self, data: Vec<u8>) -> Encrypted {
+        Self::encrypt_sync(&self.key, data)
+    }
+
+    async fn decrypt(&self, encrypted: Encrypted) -> Vec<u8> {
+        let key = self.key.clone();
+        tokio::task::spawn_blocking(move || Self::decrypt_sync(&key, &encrypted))
+            .await
+            .unwrap()
+    }
+
+    fn decrypt_sync(&self, encrypted: &Encrypted) -> Vec<u8> {
+        Self::decrypt_sync(&self.key, encrypted)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Encrypted {
+    nonce: [u8; 12],
+    data: Vec<u8>,
+}
+
+impl Display for Encrypted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use base64::{display::Base64Display, engine::general_purpose::STANDARD};
+
+        let nonce = Base64Display::new(&self.nonce, &STANDARD);
+        let data = Base64Display::new(&self.data, &STANDARD);
+        write!(f, "{} {}", nonce, data)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    MissingNonce,
+    MissingData,
+    InvalidNonce,
+    InvalidData,
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ParseError::*;
+        match self {
+            MissingNonce => write!(f, "missing nonce"),
+            MissingData => write!(f, "missing data"),
+            InvalidNonce => write!(f, "invalid nonce"),
+            InvalidData => write!(f, "invalid data"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl TryFrom<&str> for Encrypted {
+    type Error = ParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        use base64::{engine::general_purpose, Engine as _};
+        let mut parts = s.split_whitespace();
+        let decode = |s: &str, e: ParseError| {
+            general_purpose::STANDARD
+                .decode(s.as_bytes())
+                .map_err(|_| e)
+        };
+        let nonce = parts
+            .next()
+            .map(|nonce| decode(nonce, ParseError::InvalidNonce))
+            .ok_or(ParseError::MissingNonce)??;
+        let data = parts
+            .next()
+            .map(|nonce| decode(nonce, ParseError::InvalidData))
+            .ok_or(ParseError::MissingData)??;
+        Ok(Encrypted {
+            nonce: nonce.try_into().map_err(|_| ParseError::InvalidNonce)?,
+            data,
+        })
+    }
+}
+
+impl TryFrom<String> for Encrypted {
+    type Error = ParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Encrypted::try_from(s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn chacha20_encrypt_decrypt() {
+        let data = b"Hello, world!".to_vec();
+        let encryptor = ChaCha20Crypt::default();
+        let encrypted = encryptor.encrypt(data.clone()).await;
+        let decrypted = encryptor.decrypt(encrypted).await;
+        assert_eq!(data, decrypted.as_slice());
+    }
+
+    #[test]
+    fn encrypted_string_handling() {
+        let encrypted = Encrypted {
+            nonce: [0u8; 12],
+            data: b"Hello, world!".to_vec(),
+        };
+        let encrypted = encrypted.to_string();
+        assert_eq!(encrypted, "AAAAAAAAAAAAAAAA SGVsbG8sIHdvcmxkIQ==");
+        let encrypted = Encrypted::try_from(encrypted).unwrap();
+        assert_eq!(encrypted.nonce, [0u8; 12]);
+        assert_eq!(encrypted.data, b"Hello, world!".to_vec());
+    }
+
+    #[test]
+    fn encrypted_string_handling_missing_data() {
+        let encrypted = "AAAAAAAAAAAAAAAASGVsbG8sIHdvcmxkIQ==".to_string();
+        let encrypted = Encrypted::try_from(encrypted);
+        assert_eq!(encrypted.unwrap_err(), ParseError::MissingData);
+    }
+    #[test]
+    fn encrypted_string_handling_missing_nonce() {
+        let encrypted = "".to_string();
+        let encrypted = Encrypted::try_from(encrypted);
+        assert_eq!(encrypted.unwrap_err(), ParseError::MissingNonce);
+    }
+    #[test]
+    fn encrypted_string_handling_invalid_none() {
+        let encrypted = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA SGVsbG8sIHdvcmxkIQ==".to_string();
+        let encrypted = Encrypted::try_from(encrypted);
+        assert_eq!(encrypted.unwrap_err(), ParseError::InvalidNonce);
+        let encrypted = "AAA^AAAAAAAAAAAA SGVsbG8sIHdvcmxkIQ==".to_string();
+        let encrypted = Encrypted::try_from(encrypted);
+        assert_eq!(encrypted.unwrap_err(), ParseError::InvalidNonce);
+    }
+
+    #[test]
+    fn encrypted_string_handling_invalid_data() {
+        let encrypted = "AAAAAAAAAAAAAAAA SGVsbG8s%HdvcmxkIQ==".to_string();
+        let encrypted = Encrypted::try_from(encrypted);
+        assert_eq!(encrypted.unwrap_err(), ParseError::InvalidData);
+    }
+}

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -4,10 +4,12 @@
 
 mod config;
 mod controller;
+mod crypt;
 mod feed;
 mod request;
 mod response;
 mod scan;
+mod storage;
 mod tls;
 
 #[tokio::main]

--- a/rust/openvasd/src/response.rs
+++ b/rust/openvasd/src/response.rs
@@ -206,17 +206,6 @@ impl Response {
         self.empty(hyper::StatusCode::INTERNAL_SERVER_ERROR)
     }
 
-    pub fn service_unavailable<'a>(&self, source: &'a str, reason: &'a str) -> Result {
-        #[derive(Serialize, Debug)]
-        struct Unavailable<'a> {
-            source: &'a str,
-            reason: &'a str,
-        }
-        let value = Unavailable { source, reason };
-        tracing::error!("Service {} unavailable: {}", source, reason);
-        self.create(hyper::StatusCode::SERVICE_UNAVAILABLE, &value)
-    }
-
     pub fn not_found<'a>(&self, class: &'a str, id: &'a str) -> Result {
         #[derive(Serialize, Debug)]
         struct NotFound<'a> {

--- a/rust/openvasd/src/storage.rs
+++ b/rust/openvasd/src/storage.rs
@@ -1,0 +1,371 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::{crypt, scan::FetchResult};
+
+#[derive(Debug)]
+pub enum Error {
+    SerializationError,
+    NotFound,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        match self {
+            NotFound => write!(f, "not found"),
+            SerializationError => write!(f, "serialization error"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<serde_json::Error> for Error {
+    fn from(_: serde_json::Error) -> Self {
+        Self::SerializationError
+    }
+}
+
+impl From<crypt::ParseError> for Error {
+    fn from(_: crypt::ParseError) -> Self {
+        Self::SerializationError
+    }
+}
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(_: std::string::FromUtf8Error) -> Self {
+        Self::SerializationError
+    }
+}
+
+#[async_trait]
+/// A trait for getting the progress of a scan, the scan itself with decrypted credentials and
+/// encrypted as well as results.
+///
+/// The main usage of this trait is in the controller and when transforming a scan to a osp
+pub trait ProgressGetter {
+    /// Returns the scan.
+    async fn get_scan(&self, id: &str) -> Result<(models::Scan, models::Status), Error>;
+    /// Returns the scan with dcecrypted passwords.
+    ///
+    /// This method should only be used when the password is required. E.g.
+    /// when transforming a scan to a osp command.
+    async fn get_decrypted_scan(&self, id: &str) -> Result<(models::Scan, models::Status), Error>;
+    /// Returns all scans.
+    async fn get_scans(&self) -> Result<Vec<(models::Scan, models::Status)>, Error>;
+    /// Returns the status of a scan.
+    async fn get_status(&self, id: &str) -> Result<models::Status, Error>;
+    /// Returns the results of a scan as json bytes.
+    ///
+    /// OpenVASD just stores to results without processing them therefore we
+    /// can just return the json bytes.
+    async fn get_results(
+        &self,
+        id: &str,
+        from: Option<usize>,
+        to: Option<usize>,
+    ) -> Result<Vec<Vec<u8>>, Error>;
+}
+
+#[async_trait]
+/// A trait for storing scans.
+///
+/// The main usage of this trait is in the controller and when a user inserts or removes a scan.
+pub trait ScanStorer {
+    /// Inserts a scan.
+    async fn insert_scan(&self, t: models::Scan) -> Result<Option<models::Scan>, Error>;
+    /// Removes a scan.
+    async fn remove_scan(&self, id: &str) -> Result<Option<(models::Scan, models::Status)>, Error>;
+    /// Updates a status of a scan.
+    ///
+    /// This is required when a scan is started or stopped.
+    async fn update_status(&self, id: &str, status: models::Status) -> Result<(), Error>;
+}
+
+#[async_trait]
+/// A trait for appending results from a different source.
+///
+/// This is used when a scan is started and the results are fetched from ospd.
+pub trait AppendFetchResult {
+    async fn append_fetch_result(&self, id: &str, results: FetchResult) -> Result<(), Error>;
+}
+
+#[async_trait]
+/// Combines the traits `ProgressGetter`, `ScanStorer` and `AppendFetchResult`.
+pub trait Storage: ProgressGetter + ScanStorer + AppendFetchResult {}
+
+#[async_trait]
+impl<T> Storage for T where T: ProgressGetter + ScanStorer + AppendFetchResult {}
+
+#[derive(Clone, Debug, Default)]
+struct Progress {
+    /// The scan that is being tracked. The credentials passwords are encrypted.
+    scan: models::Scan,
+    /// The status of the scan. Does not need to be encrypted.
+    status: models::Status,
+    /// The results of the scan as encrypted json.
+    ///
+    /// The reason that it is json is that we don't need it unless it is requested by the user.
+    results: Vec<crypt::Encrypted>,
+}
+
+#[derive(Debug)]
+pub struct InMemoryStorage<E> {
+    scans: RwLock<HashMap<String, Progress>>,
+    crypter: E,
+}
+
+impl<E> InMemoryStorage<E>
+where
+    E: crate::crypt::Crypt + Send + Sync + 'static,
+{
+    pub fn new(crypter: E) -> Self {
+        Self {
+            scans: RwLock::new(HashMap::new()),
+            crypter,
+        }
+    }
+
+    async fn new_progress(&self, mut scan: models::Scan) -> Result<Progress, Error> {
+        let credentials = scan
+            .target
+            .credentials
+            .into_iter()
+            .map(move |c| {
+                let c = c.map_password::<_, Error>(|p| {
+                    Ok(self.crypter.encrypt_sync(p.as_bytes().to_vec()).to_string())
+                });
+                c.unwrap()
+            })
+            .collect::<Vec<_>>();
+        scan.target.credentials = credentials;
+
+        Ok(Progress {
+            scan,
+            status: models::Status::default(),
+            results: Vec::new(),
+        })
+    }
+}
+
+impl Default for InMemoryStorage<crate::crypt::ChaCha20Crypt> {
+    fn default() -> Self {
+        Self::new(crate::crypt::ChaCha20Crypt::default())
+    }
+}
+
+#[async_trait]
+impl<E> ScanStorer for InMemoryStorage<E>
+where
+    E: crate::crypt::Crypt + Send + Sync + 'static,
+{
+    async fn insert_scan(&self, sp: models::Scan) -> Result<Option<models::Scan>, Error> {
+        let id = sp.scan_id.clone().unwrap_or_default();
+        let mut scans = self.scans.write().await;
+        if let Some(prgs) = scans.get_mut(&id) {
+            let old = prgs.scan.clone();
+            prgs.scan = sp;
+            Ok(Some(old))
+        } else {
+            let progress = self.new_progress(sp).await?;
+            let old = scans.insert(id.clone(), progress);
+            Ok(old.map(|p| p.scan))
+        }
+    }
+
+    async fn remove_scan(&self, id: &str) -> Result<Option<(models::Scan, models::Status)>, Error> {
+        let mut scans = self.scans.write().await;
+        Ok(scans.remove(id).map(|p| (p.scan, p.status)))
+    }
+
+    async fn update_status(&self, id: &str, status: models::Status) -> Result<(), Error> {
+        let mut scans = self.scans.write().await;
+        let progress = scans.get_mut(id).ok_or(Error::NotFound)?;
+        progress.status = status;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<E> AppendFetchResult for InMemoryStorage<E>
+where
+    E: crate::crypt::Crypt + Send + Sync + 'static,
+{
+    async fn append_fetch_result(
+        &self,
+        id: &str,
+        (status, results): FetchResult,
+    ) -> Result<(), Error> {
+        let mut scans = self.scans.write().await;
+        let progress = scans.get_mut(id).ok_or(Error::NotFound)?;
+        progress.status = status;
+        for result in &results {
+            let bytes = serde_json::to_vec(result)?;
+            progress.results.push(self.crypter.encrypt_sync(bytes));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<E> ProgressGetter for InMemoryStorage<E>
+where
+    E: crate::crypt::Crypt + Send + Sync + 'static,
+{
+    async fn get_scans(&self) -> Result<Vec<(models::Scan, models::Status)>, Error> {
+        let scans = self.scans.read().await;
+        let mut result = Vec::with_capacity(scans.len());
+        for (_, progress) in scans.iter() {
+            result.push((progress.scan.clone(), progress.status.clone()));
+        }
+        Ok(result)
+    }
+
+    async fn get_scan(&self, id: &str) -> Result<(models::Scan, models::Status), Error> {
+        let scans = self.scans.read().await;
+        let progress = scans.get(id).ok_or(Error::NotFound)?;
+        Ok((progress.scan.clone(), progress.status.clone()))
+    }
+    async fn get_decrypted_scan(&self, id: &str) -> Result<(models::Scan, models::Status), Error> {
+        let (mut scan, status) = self.get_scan(id).await?;
+        let mut decrypted_credentials = Vec::with_capacity(scan.target.credentials.len());
+        for c in scan.target.credentials.into_iter() {
+            let c = c.map_password::<_, Error>(|p| {
+                let enc = p.try_into()?;
+                let dec = self.crypter.decrypt_sync(&enc);
+                Ok(String::from_utf8(dec)?)
+            })?;
+            decrypted_credentials.push(c);
+        }
+        scan.target.credentials = decrypted_credentials;
+
+        Ok((scan, status))
+    }
+    async fn get_status(&self, id: &str) -> Result<models::Status, Error> {
+        let scans = self.scans.read().await;
+        let progress = scans.get(id).ok_or(Error::NotFound)?;
+        Ok(progress.status.clone())
+    }
+    async fn get_results(
+        &self,
+        id: &str,
+        from: Option<usize>,
+        to: Option<usize>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        let scans = self.scans.read().await;
+        let progress = scans.get(id).ok_or(Error::NotFound)?;
+        let from = from.unwrap_or(0);
+        let to = to.unwrap_or(progress.results.len());
+        let to = to.min(progress.results.len());
+        if from > to || from > progress.results.len() {
+            return Ok(Vec::new());
+        }
+        let mut results = Vec::with_capacity(to - from);
+        for result in &progress.results[from..to] {
+            results.push(self.crypter.decrypt_sync(result));
+        }
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use models::Scan;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn store_delete_scan() {
+        let storage = InMemoryStorage::default();
+        let scan = Scan::default();
+        let id = scan.scan_id.clone().unwrap_or_default();
+        let inserted = storage.insert_scan(scan).await.unwrap();
+        assert!(inserted.is_none());
+        let (retrieved, _) = storage.get_scan(&id).await.unwrap();
+        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        let (removed, _) = storage.remove_scan(&id).await.unwrap().unwrap();
+        assert_eq!(removed.scan_id.unwrap_or_default(), id);
+    }
+
+    #[tokio::test]
+    async fn encrypt_decrypt_passwords() {
+        let storage = InMemoryStorage::default();
+        let mut scan = Scan::default();
+        let mut pw = models::Credential::default();
+        pw.credential_type = models::CredentialType::UP {
+            username: "test".to_string(),
+            password: "test".to_string(),
+        };
+
+        scan.target.credentials = vec![pw];
+
+        let id = scan.scan_id.clone().unwrap_or_default();
+        storage.insert_scan(scan).await.unwrap();
+        let (retrieved, _) = storage.get_scan(&id).await.unwrap();
+        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        assert_ne!(retrieved.target.credentials[0].password(), "test");
+
+        let (retrieved, _) = storage.get_decrypted_scan(&id).await.unwrap();
+        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        assert_eq!(retrieved.target.credentials[0].password(), "test");
+    }
+
+    async fn store_scan(storage: &InMemoryStorage<crypt::ChaCha20Crypt>) -> String {
+        let mut scan = Scan::default();
+        let id = uuid::Uuid::new_v4().to_string();
+        scan.scan_id = Some(id.clone());
+        let inserted = storage.insert_scan(scan).await.unwrap();
+        assert!(inserted.is_none());
+        id
+    }
+
+    #[tokio::test]
+    async fn get_scans() {
+        let storage = InMemoryStorage::default();
+        for _ in 0..10 {
+            store_scan(&storage).await;
+        }
+        let scans = storage.get_scans().await.unwrap();
+        assert_eq!(scans.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn append_results() {
+        let storage = InMemoryStorage::default();
+        let scan = Scan::default();
+        let id = scan.scan_id.clone().unwrap_or_default();
+        let inserted = storage.insert_scan(scan).await.unwrap();
+        assert!(inserted.is_none());
+        let fetch_result = (models::Status::default(), vec![models::Result::default()]);
+        storage
+            .append_fetch_result(&id, fetch_result)
+            .await
+            .unwrap();
+        let results = storage.get_results(&id, None, None).await.unwrap();
+        assert_eq!(results.len(), 1);
+        let result: models::Result = serde_json::from_slice(&results[0]).unwrap();
+        assert_eq!(result, models::Result::default());
+        let results = storage.get_results(&id, Some(23), Some(1)).await.unwrap();
+        assert_eq!(results.len(), 0);
+        let results = storage.get_results(&id, Some(0), Some(0)).await.unwrap();
+        assert_eq!(results.len(), 0);
+        let results = storage.get_results(&id, Some(0), Some(5)).await.unwrap();
+        assert_eq!(results.len(), 1);
+        let results = storage.get_results(&id, Some(0), None).await.unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn update_status() {
+        let storage = InMemoryStorage::default();
+        let id = store_scan(&storage).await;
+        let (_, mut status) = storage.get_scan(&id).await.unwrap();
+        assert_eq!(status.status, models::Phase::Stored);
+        status.status = models::Phase::Requested;
+        storage.update_status(&id, status).await.unwrap();
+        let (_, status) = storage.get_scan(&id).await.unwrap();
+        assert_eq!(status.status, models::Phase::Requested);
+    }
+}

--- a/rust/osp/src/connection.rs
+++ b/rust/osp/src/connection.rs
@@ -25,8 +25,11 @@ pub fn send_command<T: AsRef<Path>>(address: T, cmd: ScanCommand) -> Result<Resp
 }
 
 /// Returns the scan information from OSPD
-pub fn get_scan<T: AsRef<Path>>(address: T, scan_id: &ScanID) -> Result<response::Scan, Error> {
-    let cmd = ScanCommand::Get(scan_id);
+pub fn get_scan<T: AsRef<Path>, I: AsRef<str>>(
+    address: T,
+    scan_id: I,
+) -> Result<response::Scan, Error> {
+    let cmd = ScanCommand::Get(scan_id.as_ref());
     let response = send_command(address, cmd)?;
     match response {
         Response::GetScans {
@@ -38,11 +41,11 @@ pub fn get_scan<T: AsRef<Path>>(address: T, scan_id: &ScanID) -> Result<response
 }
 
 /// Returns the scan information from OSPD and deletes the results from it
-pub fn get_delete_scan_results<T: AsRef<Path>>(
+pub fn get_delete_scan_results<T: AsRef<Path>, I: AsRef<str>>(
     address: T,
-    scan_id: &str,
+    scan_id: I,
 ) -> Result<response::Scan, Error> {
-    let cmd = ScanCommand::GetDelete(scan_id);
+    let cmd = ScanCommand::GetDelete(scan_id.as_ref());
     let response = send_command(address, cmd)?;
     match response {
         Response::GetScans {
@@ -67,8 +70,8 @@ pub fn start_scan<T: AsRef<Path>>(address: T, scan: &models::Scan) -> Result<Sca
 }
 
 /// Stops a scan
-pub fn stop_scan<T: AsRef<Path>>(address: T, scan_id: &ScanID) -> Result<(), Error> {
-    let cmd = ScanCommand::Stop(scan_id);
+pub fn stop_scan<T: AsRef<Path>, I: AsRef<str>>(address: T, scan_id: I) -> Result<(), Error> {
+    let cmd = ScanCommand::Stop(scan_id.as_ref());
     let response = send_command(address, cmd)?;
     match response {
         Response::StopScan { status: _ } => Ok(()),
@@ -77,8 +80,8 @@ pub fn stop_scan<T: AsRef<Path>>(address: T, scan_id: &ScanID) -> Result<(), Err
 }
 
 /// Deletes a scan
-pub fn delete_scan<T: AsRef<Path>>(address: T, scan_id: &ScanID) -> Result<(), Error> {
-    let cmd = ScanCommand::Delete(scan_id);
+pub fn delete_scan<T: AsRef<Path>, I: AsRef<str>>(address: T, scan_id: I) -> Result<(), Error> {
+    let cmd = ScanCommand::Delete(scan_id.as_ref());
     let response = send_command(address, cmd)?;
     match response {
         Response::DeleteScan { status: _ } => Ok(()),


### PR DESCRIPTION
To allow easier handling of sensitive data the direct usage of a hash
map is replaced with a storage interface and field encryption is added.

This is done by introducing interfaces:
- to get the progress of a scan
- store scans
- append results

instead of using a hashmap of a progress struct. This allows us to
exchange the storage from inmemory to something like a relational
database.

Additionally a crypt interface with a chacha20 implementation is
introduces to enable encryption of sensitive fields like passwords or
results.

[SC-900](https://jira.greenbone.net/browse/SC-900)