### PR TITLE
Fix: OpenAPI specification

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -312,7 +312,7 @@ components:
       type: "object"
       properties:
         target:
-            $ref: "#/components/schemas/Target"
+          $ref: "#/components/schemas/Target"
         scanner_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
@@ -410,15 +410,17 @@ components:
             - udp
             - tcp
         range:
-          description: "A list of ranges, start and end are inclusive."
-          type: "object"
-          properties:
-            start:
-              type: "number"
-              description: "The inclusive start port. When end is not set only the start port is used"
-            end:
-              type: "number"
-              description: "The inclusive end port."
+          type: "array"
+          description: "A list of ranges"
+          items:
+            type: "object"
+            properties:
+              start:
+                type: "number"
+                description: "The inclusive start port. When end is not set only the start port is used"
+              end:
+                type: "number"
+                description: "The inclusive end port."
       required:
         - range
 


### PR DESCRIPTION
There was an error in the Port Range specification for a scan Target, in which only a single range object instead of an array of ranges was specified.

To see the changes paste the raw openapi.yml file https://raw.githubusercontent.com/greenbone/openvas-scanner/c34130a97e101149ad97fdb1ecd5bc3d761da2c3/rust/doc/openapi.yml into the top field of https://greenbone.github.io/scanner-api/