### PR TITLE
Change: add a dummy item in the redis storage for backward compatibility

### DIFF
--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -291,9 +291,14 @@ pub trait RedisAddNvt: RedisWrapper {
         }
 
         // Stores the OID under the filename key. This key is currently used
-        // for the dependency autoload, where the filename is used to fetch the OID
+        // for the dependency autoload, where the filename is used to fetch the OID.
+        //
+        // TODO: since openvas get the oid by position and it is stored in the second position,
+        // for backward compatibility a dummy item (it is the plugin's upload timestamp)
+        // under the filename key is added.
+        // Once openvas is no longer used, the dummy item can be removed.
         let key_name = format!("filename:{filename}");
-        self.lpush(&key_name, &oid)?;
+        self.rpush(&key_name, &["1", &oid])?;
         Ok(())
     }
 }

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -583,9 +583,12 @@ mod tests {
                             );
                         }
                         "filename:test.nasl" => {
-                            let values = values.first().unwrap().clone();
-                            let oid = String::from_utf8(values);
+                            assert_eq!(values.len(), 2);
+                            let mut vals = values.clone();
+                            let oid = String::from_utf8(vals.pop().unwrap());
                             assert_eq!(Ok("0.0.0.0.0.0.0.0.0.1".to_owned()), oid);
+                            let dummy = vals.pop().unwrap();
+                            assert_eq!(Ok("1".to_owned()), String::from_utf8(dummy));
                         }
                         _ => panic!("{key} should not occur"),
                     }


### PR DESCRIPTION
**What**:
Change: add a dummy item in the redis storage for backward compatibility
Jira: SC-935
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Since openvas uses positional items and expects the plugin oid in the second position, add a dummy item under filename key

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
