### PR TITLE
Fix: infisto storage, create results file on scan init

### DIFF
--- a/rust/infisto/src/base.rs
+++ b/rust/infisto/src/base.rs
@@ -403,7 +403,10 @@ impl Range {
 
 impl CachedIndexFileStorer {
     /// Initializes the storage.
-    pub fn init(base: &str) -> Result<Self, Error> {
+    pub fn init<P>(base: P) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+    {
         let base = IndexedFileStorer::init(base)?;
         let cache = [None, None, None, None, None];
         Ok(Self { base, cache })

--- a/rust/models/src/result.rs
+++ b/rust/models/src/result.rs
@@ -12,6 +12,7 @@ use super::port::Protocol;
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
 )]
+#[cfg_attr(feature = "bincode_support", derive(bincode::Encode, bincode::Decode))]
 pub struct Result {
     /// Incremental ID of a result
     pub id: usize,
@@ -78,6 +79,7 @@ impl<T: Into<Result>> From<(usize, T)> for Result {
     derive(serde::Serialize, serde::Deserialize)
 )]
 #[cfg_attr(feature = "serde_support", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "bincode_support", derive(bincode::Encode, bincode::Decode))]
 pub enum ResultType {
     /// Vulnerability
     Alarm,


### PR DESCRIPTION
In case the storage for a new scan was initialized, the file for the results was missing Now creating a file for the results with an empty Vec

SC-928