### PR TITLE
Fix: panic when trying to append empty results

### DIFF
--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -277,7 +277,6 @@ mod tests {
             count: Arc::new(RwLock::new(0)),
         };
         let ns = std::time::Duration::from_nanos(10);
-        // let storage = file::encrypted("/tmp/aha", "key").unwrap();
         let storage = file::unencrypted("/tmp/aha").unwrap();
         let ctx = ContextBuilder::new()
             .result_config(ns)

--- a/rust/openvasd/src/controller/results.rs
+++ b/rust/openvasd/src/controller/results.rs
@@ -5,6 +5,7 @@
 //! Defines the result fetching loop.
 //!
 //! This loop should be run as background task to fetch results from the scanner.
+
 use crate::controller::quit_on_poison;
 use std::sync::Arc;
 


### PR DESCRIPTION
Under the condition that there is a status change
without any kind results infisto returned an error.

This changes the behavior of append-all to ignore
calls without any data.
