### PR TITLE
Add: client authorization on endpoints

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,4 @@
 target/
 libsrc/
+*.rsa
+*.cert

--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -1,6 +1,8 @@
 [feed]
 # path to the openvas feed. This is required for the /vts endpoint.
 path = "/var/lib/openvas/plugins"
+# disables or enables the signnature check
+signature_check = true
 
 [feed.check_interval]
 # how often the feed should be checked for updates

--- a/rust/infisto/src/base.rs
+++ b/rust/infisto/src/base.rs
@@ -282,6 +282,18 @@ impl IndexedFileStorer {
             .map_err(Error::Remove)?;
         Ok(())
     }
+
+    /// Removes base dir and all its content.
+    ///
+    /// # Safety
+    /// Does remove the whole base dir and its content.
+    /// Do not use carelessly.
+    pub unsafe fn remove_base(self) -> Result<(), Error> {
+        fs::remove_dir_all(self.base)
+            .map_err(|e| e.kind())
+            .map_err(Error::Remove)
+            .map(|_| ())
+    }
 }
 
 impl IndexedByteStorage for IndexedFileStorer {

--- a/rust/openvasd/Cargo.toml
+++ b/rust/openvasd/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0.96"
 serde = { version = "1.0.163", features = ["derive"] }
 uuid = {version = "1", features = ["v4", "fast-rng", "serde"]}
 hyper-rustls = "0.24.0"
-rustls = "0.21.1"
+rustls = {version = "0.21.1", features = ["dangerous_configuration"]}
 tokio-rustls = "0.24.0"
 futures-util = "0.3.28"
 rustls-pemfile = "1.0.2"

--- a/rust/openvasd/src/config.rs
+++ b/rust/openvasd/src/config.rs
@@ -188,8 +188,8 @@ impl Config {
     where
         P: AsRef<std::path::Path> + std::fmt::Display,
     {
-        let config = std::fs::read_to_string(path).unwrap_or_default();
-        toml::from_str(&config).unwrap_or_default()
+        let config = std::fs::read_to_string(path).unwrap();
+        toml::from_str(&config).unwrap()
     }
 
     pub fn load() -> Self {

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -100,7 +100,8 @@ impl<S, DB, T> ContextBuilder<S, DB, T> {
         if let Some(fp) = self.feed_config.as_ref() {
             let loader = nasl_interpreter::FSPluginLoader::new(fp.path.clone());
             let dispatcher: DefaultDispatcher<String> = DefaultDispatcher::default();
-            let version = feed::version(&loader, &dispatcher).unwrap();
+            let version =
+                feed::version(&loader, &dispatcher).unwrap_or_else(|_| String::from("UNDEFINED"));
             self.response.set_feed_version(&version);
         }
         self

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -2,23 +2,104 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-mod config;
-mod controller;
-mod crypt;
-mod feed;
-mod request;
-mod response;
-mod scan;
-mod storage;
-mod tls;
+use controller::ClientGossiper;
+use futures_util::ready;
 
-pub async fn run<'a, DB>(
+pub mod config;
+pub mod controller;
+pub mod crypt;
+pub mod feed;
+pub mod request;
+pub mod response;
+pub mod scan;
+pub mod storage;
+pub mod tls;
+
+struct AddrIncomingWrapper(hyper::server::conn::AddrIncoming);
+
+impl hyper::server::accept::Accept for AddrIncomingWrapper {
+    type Conn = AddrStreamWrapper;
+    type Error = std::io::Error;
+
+    fn poll_accept(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<Self::Conn, Self::Error>>> {
+        use core::task::Poll;
+        use std::pin::Pin;
+        let pin = self.get_mut();
+        match ready!(Pin::new(&mut pin.0).poll_accept(cx)) {
+            Some(Ok(sock)) => std::task::Poll::Ready(Some(Ok(AddrStreamWrapper::new(sock)))),
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+struct AddrStreamWrapper(
+    hyper::server::conn::AddrStream,
+    std::sync::Arc<std::sync::RwLock<controller::ClientIdentifier>>,
+);
+impl AddrStreamWrapper {
+    fn new(sock: hyper::server::conn::AddrStream) -> AddrStreamWrapper {
+        AddrStreamWrapper(
+            sock,
+            std::sync::Arc::new(std::sync::RwLock::new(
+                controller::ClientIdentifier::Unknown,
+            )),
+        )
+    }
+}
+
+impl ClientGossiper for AddrStreamWrapper {
+    fn client_identifier(
+        &self,
+    ) -> &std::sync::Arc<std::sync::RwLock<controller::ClientIdentifier>> {
+        &self.1
+    }
+}
+
+impl tokio::io::AsyncRead for AddrStreamWrapper {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let pin = self.get_mut();
+        std::pin::Pin::new(&mut pin.0).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for AddrStreamWrapper {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        let pin = self.get_mut();
+        std::pin::Pin::new(&mut pin.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let pin = self.get_mut();
+        std::pin::Pin::new(&mut pin.0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        let pin = self.get_mut();
+        std::pin::Pin::new(&mut pin.0).poll_shutdown(cx)
+    }
+}
+
+fn create_context<DB>(
     db: DB,
-    config: config::Config,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
-where
-    DB: crate::storage::Storage + std::marker::Send + 'static + std::marker::Sync,
-{
+    config: &config::Config,
+) -> controller::Context<scan::OSPDWrapper, DB> {
     let scanner = scan::OSPDWrapper::new(config.ospd.socket.clone(), config.ospd.read_timeout);
     let rc = config.ospd.result_check_interval;
     let fc = (
@@ -26,30 +107,81 @@ where
         config.feed.check_interval,
         config.feed.signature_check,
     );
-    let ctx = controller::ContextBuilder::new()
+    controller::ContextBuilder::new()
         .result_config(rc)
         .feed_config(fc)
         .scanner(scanner)
         .api_key(config.endpoints.key.clone())
         .enable_get_scans(config.endpoints.enable_get_scans)
         .storage(db)
-        .build();
+        .build()
+}
+
+async fn serve<'a, S, DB, I>(
+    ctx: controller::Context<S, DB>,
+    inc: I,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    S: scan::ScanStarter
+        + scan::ScanStopper
+        + scan::ScanDeleter
+        + scan::ScanResultFetcher
+        + std::marker::Send
+        + std::marker::Sync
+        + 'static,
+    I: hyper::server::accept::Accept,
+    I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    I::Conn: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + ClientGossiper + 'static,
+    DB: crate::storage::Storage + std::marker::Send + 'static + std::marker::Sync,
+{
     let controller = std::sync::Arc::new(ctx);
+    let make_svc = {
+        use std::sync::Arc;
+
+        tokio::spawn(crate::controller::results::fetch(Arc::clone(&controller)));
+        tokio::spawn(crate::controller::feed::fetch(Arc::clone(&controller)));
+
+        use hyper::service::{make_service_fn, service_fn};
+        make_service_fn(|conn| {
+            let controller = Arc::clone(&controller);
+            let conn = conn as &dyn ClientGossiper;
+            let cis = Arc::clone(conn.client_identifier());
+            async {
+                Ok::<_, crate::scan::Error>(service_fn(move |req| {
+                    controller::entrypoint(req, Arc::clone(&controller), cis.clone())
+                }))
+            }
+        })
+    };
+    let server = hyper::Server::builder(inc).serve(make_svc);
+    server.await?;
+    Ok(())
+}
+
+pub async fn run<'a, S, DB>(
+    ctx: controller::Context<S, DB>,
+    config: &config::Config,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    S: scan::ScanStarter
+        + scan::ScanStopper
+        + scan::ScanDeleter
+        + scan::ScanResultFetcher
+        + std::marker::Send
+        + std::marker::Sync
+        + 'static,
+    DB: crate::storage::Storage + std::marker::Send + 'static + std::marker::Sync,
+{
     let addr = config.listener.address;
     let incoming = hyper::server::conn::AddrIncoming::bind(&addr)?;
     let addr = incoming.local_addr();
-
-    if let Some(tlsc) = tls::tls_config(&config)? {
-        tracing::trace!("TLS enabled");
-        let make_svc = crate::controller::make_svc!(&controller);
-        let server = hyper::Server::builder(tls::TlsAcceptor::new(tlsc, incoming)).serve(make_svc);
+    if let Some((roots, certs, key)) = tls::tls_config(config)? {
         tracing::info!("listening on https://{}", addr);
-        server.await?;
+        let inc = tls::TlsAcceptor::new(roots, certs, key, incoming);
+        serve(ctx, inc).await?;
     } else {
-        let make_svc = crate::controller::make_svc!(&controller);
-        let server = hyper::Server::builder(incoming).serve(make_svc);
         tracing::info!("listening on http://{}", addr);
-        server.await?;
+        serve(ctx, AddrIncomingWrapper(incoming)).await?;
     }
     Ok(())
 }
@@ -59,7 +191,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = config::Config::load();
     let filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing::metadata::LevelFilter::INFO.into())
-        .parse_lossy(config.log.level.clone());
+        .parse_lossy(format!("info,openvasd={}", &config.log.level));
+    tracing::debug!("config: {:?}", config);
     tracing_subscriber::fmt().with_env_filter(filter).init();
     if !config.ospd.socket.exists() {
         tracing::warn!("OSPD socket {} does not exist. Some commands will not work until the socket is created!", config.ospd.socket.display());
@@ -67,23 +200,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match config.storage.storage_type {
         config::StorageType::InMemory => {
             tracing::info!("using in memory store. No sensitive data will be stored on disk.");
-            run(storage::inmemory::Storage::default(), config).await
+
+            let ctx = create_context(storage::inmemory::Storage::default(), &config);
+            run(ctx, &config).await
         }
         config::StorageType::FileSystem => {
             if let Some(key) = &config.storage.fs.key {
                 tracing::info!(
                     "using in file storage. Sensitive data will be encrypted stored on disk."
                 );
-                run(
+
+                let ctx = create_context(
                     storage::file::encrypted(&config.storage.fs.path, key)?,
-                    config,
-                )
-                .await
+                    &config,
+                );
+                run(ctx, &config).await
             } else {
                 tracing::warn!(
                     "using in file storage. Sensitive data will be stored on disk without any encryption."
                 );
-                run(storage::file::unencrypted(&config.storage.fs.path)?, config).await
+                let ctx = create_context(
+                    storage::file::unencrypted(&config.storage.fs.path)?,
+                    &config,
+                );
+                run(ctx, &config).await
             }
         }
     }


### PR DESCRIPTION
To prevent that a registered client can see results
or scan of another client a differentiation factor
is introduces.

The scans and results will now be stored as an u64->information and the
key is either calculated by the used client certificate or, when openvasd
is started without client certifactes, by the used API key.

When client certificates and the API key is configured than the client
certificates are getting used.

When neither is configured the scans endpoints are unreachable.

SC-949 SC-950