### PR TITLE
Fix: use %zu instead of %lu when print size_t of count

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -1095,7 +1095,7 @@ apply_hosts_reverse_lookup_preferences (gvm_hosts_t *hosts)
       gvm_hosts_t *excluded;
 
       excluded = gvm_hosts_reverse_lookup_unify_excluded (hosts);
-      g_debug ("reverse_lookup_unify: Skipped %lu host(s).", excluded->count);
+      g_debug ("reverse_lookup_unify: Skipped %zu host(s).", excluded->count);
 
       // Get the amount of hosts which are excluded now for this option,
       // but they are already in the exclude list.
@@ -1111,7 +1111,7 @@ apply_hosts_reverse_lookup_preferences (gvm_hosts_t *hosts)
       gvm_hosts_t *excluded;
 
       excluded = gvm_hosts_reverse_lookup_only_excluded (hosts);
-      g_debug ("reverse_lookup_unify: Skipped %lu host(s).", excluded->count);
+      g_debug ("reverse_lookup_unify: Skipped %zu host(s).", excluded->count);
       // Get the amount of hosts which are excluded now for this option,
       // but they are already in the exclude list.
       // This is to avoid issues with the scan progress calculation, since


### PR DESCRIPTION
Some architectures don't use unsigned long therefore it is better to use
the specialized %z indicator when printing size_t.

Fixes 1520