### PR TITLE
Fix: Spread log level over all crates

### DIFF
--- a/rust/notus/src/notus.rs
+++ b/rust/notus/src/notus.rs
@@ -104,7 +104,7 @@ where
     fn signature_check (&self) -> Result<(), Error> {
         if self.signature_check {
             match self.loader.verify_signature() {
-                Ok(_) => tracing::info!("Signature check succsessful"),
+                Ok(_) => tracing::debug!("Signature check succsessful"),
                 Err(feed::VerifyError::MissingKeyring) => {
                     tracing::warn!("Signature check enabled but missing keyring");
                     return Err(Error::SignatureCheckError(feed::VerifyError::MissingKeyring));

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -210,7 +210,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = config::Config::load();
     let filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing::metadata::LevelFilter::INFO.into())
-        .parse_lossy(format!("info,openvasd={}", &config.log.level));
+        .parse_lossy(format!("{},rustls=info", &config.log.level));
     tracing::debug!("config: {:?}", config);
     tracing_subscriber::fmt().with_env_filter(filter).init();
     if !config.ospd.socket.exists() {


### PR DESCRIPTION
**What**:
Fix: Spread log level over all crates
Code provided by @nichtsfrei Philipp Eder
Jira: SC-980
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently only openvasd shows debug messages, while other libraries only have the default INFO level.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
