### PR TITLE
Fix: ci: remove helm version upgrade

### DIFF
--- a/.github/workflows/helm-release-on-tag.yml
+++ b/.github/workflows/helm-release-on-tag.yml
@@ -17,22 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get version from tag
-        shell: bash
-        run: |
-          vtag='${{github.ref_name}}'
-          echo "TAG=${vtag:1}" >> $GITHUB_ENV
-
-      - name: Run helm version upgrade
-        uses: greenbone/actions/helm-version-upgrade@v3
-        with:
-          chart-path: ${{ github.workspace }}/charts/${{ matrix.chart }}
-          chart-version: ${{ env.TAG }}
-
-      - name: Print Chart.yaml
-        run: |
-          cat '${{ github.workspace }}/charts/${{ matrix.chart }}/Chart.yaml'
-
       - name: Upload to github registry
         uses: greenbone/actions/helm-build-push@v3
         with:


### PR DESCRIPTION
Our versioning scheme is image based and our helm charts contains
multiple images.

Currently versioning is based on the used values.yaml and the set tag
for each scanner component rather than a single source the concept of
a helm chart version upgrade  doesn't make sense and is removed.
