### PR TITLE
Fix: docker: add libcurl3-gnutls

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libhdb9-heimdal \
   libpopt0 \
   libcurl4 \
+  libcurl3-gnutls \
   zlib1g \
   && rm -rf /var/lib/apt/lists/*
 COPY .docker/openvas.conf /etc/openvas/


### PR DESCRIPTION
Adds missing dependency libcurl3-gnutls.

Based on: https://packages.debian.org/search?searchon=contents&keywords=libcurl-gnutls.so.4&mode=exactfilename&suite=bookworm&arch=any

Relates to: [SC-989](https://jira.greenbone.net/browse/SC-989)
