### PR TITLE
Add: support authenticated connection to MQTT broker

### DIFF
--- a/src/openvas.c
+++ b/src/openvas.c
@@ -443,7 +443,13 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
       mqtt_server_uri = prefs_get ("mqtt_server_uri");
       if (mqtt_server_uri)
         {
+#ifdef AUTH_MQTT
+          const char *mqtt_user = prefs_get ("mqtt_user");
+          const char *mqtt_pass = prefs_get ("mqtt_pass");
+          if ((mqtt_init_auth (mqtt_server_uri, mqtt_user, mqtt_pass)) != 0)
+#else
           if ((mqtt_init (mqtt_server_uri)) != 0)
+#endif
             {
               g_message ("%s: INIT MQTT: FAIL", __func__);
               send_message_to_client_and_finish_scan (


### PR DESCRIPTION
**What**:
If the scanner options `mqtt_user` and `mqtt_pass` are set, the connection will be authenticated.
For this to work, MQTT broker must be configured with valid user and pass

This is disable per default

SC-917

DEPENDS ON greenbone/gvm-libs#801

Closes #1486
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Improvement
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
