### PR TITLE
Change: toggle smoketest

### DIFF
--- a/.github/workflows/rustification.yaml
+++ b/.github/workflows/rustification.yaml
@@ -24,8 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt update && sudo apt-get install -y libpcap-dev
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} || rustup default ${{ matrix.toolchain }}
-      # Run unittests and integration test, but excludes the smoketest since it depends on a running openvasd server.
-      - run: cargo test --lib --tests --workspace --exclude smoketest
+      - run: cargo test --lib --tests --workspace
   clippy:
     runs-on: ubuntu-latest
     defaults:
@@ -94,7 +93,7 @@ jobs:
     needs: [rs-build-binaries]
     container:
       # maybe better to use builder, build openvas to have
-      # the version of this checkout rather than a dataed official one?
+      # the version of this checkout rather than a dated official one?
       image: greenbone/openvas-scanner:unstable
       options: --privileged
     services:

--- a/rust/smoketest/Cargo.toml
+++ b/rust/smoketest/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1"
 [features]
 default = ["serde_support"]
 serde_support = ["serde"]
+smoketest = []
 
 [dev-dependencies]
 serde_json = "1"

--- a/rust/smoketest/Makefile
+++ b/rust/smoketest/Makefile
@@ -35,7 +35,7 @@ build: prepare-scan
 	${CARGO} build
 
 run:
-	cargo test --tests
+	${CARGO} test --tests --features=smoketest
 
 prepare-scan:
 	sed -i 's|<username>|'$(TARGET_USERNAME)'|' configs/simple_scan_ssh_only.json

--- a/rust/smoketest/README.md
+++ b/rust/smoketest/README.md
@@ -11,8 +11,6 @@ Usage of api-key is optional. For details on how to configure it, see the [openv
 
 In case of running the test against a mTLS enabled `openvasd`, you need to configure the client key and cert as well in the smoke test environment. For details on how to configure it, see the [openvasd documentation](../openvasd/README.md).
 
-WARNING: Don't use the provided key/cert pair for production. This smoketest includes client cert/key example files which work with the provided one in the helm charts.
-
 For creation of the key/cert pair for mTLS authentication, see the tls section in the [openvasd documentation](../openvasd/README.md). Also, you find certificate generators in the [examples](../examples/tls)
 
 For authenticated scans, you can set a custom target (default is 127.0.0.1), username and password.

--- a/rust/smoketest/tests/tests.rs
+++ b/rust/smoketest/tests/tests.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+#[cfg(feature = "smoketest")]
 pub mod tests {
     use models::Phase;
     use smoketest::*;


### PR DESCRIPTION
Instead of having to run a smoke test for each cargo test we just run it
when explicitely set. This is done by introducing a feature called
`smoketest` that is toggling if the `smoketest/tests/tests.rs` is run.

To run the smoke tests execute:

```
cargo test --features=smoketest
```

this is also reflected within the Makefile.
