### PR TITLE
Add: openvasctl crate for controling openvas scans

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1850,6 +1850,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvas"
+version = "0.1.0"
+dependencies = [
+ "models",
+]
+
+[[package]]
 name = "openvasd"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "feed-verifier",
   "models",
   "osp",
+  "openvasctl",
   "openvasd",
   "scanconfig",
   "infisto",

--- a/rust/openvasctl/Cargo.toml
+++ b/rust/openvasctl/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "openvas"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+models = { path = "../models" }

--- a/rust/openvasctl/README.md
+++ b/rust/openvasctl/README.md
@@ -1,0 +1,5 @@
+# OpenVAS Control
+
+Is a module for controlling scan instances using OpenVAS. It works similar to
+[ospd-openvas](https://github.com/greenbone/ospd-openvas), as it prepares the
+scan and invokes a OpenVAS instance to run the scan

--- a/rust/openvasctl/src/cmd.rs
+++ b/rust/openvasctl/src/cmd.rs
@@ -1,0 +1,53 @@
+use std::{
+    io::Result,
+    process::{Child, Command},
+};
+
+/// Check if it is possible to start openvas
+pub fn check() -> bool {
+    Command::new("openvas").spawn().is_ok()
+}
+
+/// Check if it is possible to start openvas with the sudo command
+pub fn check_sudo() -> bool {
+    Command::new("sudo").args(["-n", "openvas"]).spawn().is_ok()
+}
+
+/// Start a new scan with the openvas executable with the given string. Before a scan can be
+/// started all data needed for the scan must put into redis before.
+pub fn start(id: &str, sudo: bool, nice: Option<i8>) -> Result<Child> {
+    match nice {
+        Some(niceness) => match sudo {
+            true => Command::new("nice")
+                .args([
+                    "-n",
+                    &niceness.to_string(),
+                    "sudo",
+                    "-n",
+                    "openvas",
+                    "--start-scan",
+                    id,
+                ])
+                .spawn(),
+            false => Command::new("nice")
+                .args(["-n", &niceness.to_string(), "openvas", "--start-scan", id])
+                .spawn(),
+        },
+        None => match sudo {
+            true => Command::new("sudo")
+                .args(["-n", "openvas", "--start-scan", id])
+                .spawn(),
+            false => Command::new("openvas").args(["--start-scan", id]).spawn(),
+        },
+    }
+}
+
+/// Stops a running scan
+pub fn stop(id: &str, sudo: bool) -> Result<Child> {
+    match sudo {
+        true => Command::new("sudo")
+            .args(["-n", "openvas", "--stop-scan", id])
+            .spawn(),
+        false => Command::new("openvas").args(["--stop-scan", id]).spawn(),
+    }
+}

--- a/rust/openvasctl/src/ctl.rs
+++ b/rust/openvasctl/src/ctl.rs
@@ -1,0 +1,117 @@
+use std::{
+    collections::HashMap,
+    process::Child,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    cmd::{self, check_sudo},
+    error::OpenvasError,
+};
+
+#[derive(Default)]
+pub struct ScanContainer {
+    init: HashMap<String, ()>,
+    running: HashMap<String, Child>,
+}
+
+pub struct OpenvasController {
+    scans: Arc<Mutex<ScanContainer>>,
+    sudo: bool,
+}
+
+impl OpenvasController {
+    /// Create a new OpenvasController
+    pub fn new() -> Result<Self, OpenvasError> {
+        if !cmd::check() {
+            return Err(OpenvasError::MissingExec);
+        }
+
+        Ok(Self {
+            scans: Default::default(),
+            sudo: check_sudo(),
+        })
+    }
+
+    /// Add a scan into the init phase
+    fn add_init(&mut self, id: String) -> bool {
+        self.scans.lock().unwrap().init.insert(id, ()).is_none()
+    }
+
+    /// Remove a scan from the init phase
+    fn remove_init(&mut self, id: &String) -> bool {
+        self.scans.lock().unwrap().init.remove(id).is_some()
+    }
+
+    /// Removes a scan from init and add it to the list of running scans
+    fn add_running(&mut self, id: String) -> Result<bool, OpenvasError> {
+        let mut container = self.scans.lock().unwrap();
+        if container.init.remove(&id).is_none() {
+            return Ok(false);
+        }
+        let openvas =
+            cmd::start(&id, self.sudo, None).map_err(|_| OpenvasError::UnableToRunExec)?;
+        container.running.insert(id, openvas);
+        Ok(true)
+    }
+
+    /// Remove a scan from the list of running scans and returns the Child process
+    fn remove_running(&mut self, id: &String) -> Option<Child> {
+        self.scans.lock().unwrap().running.remove(id)
+    }
+
+    /// Stops a scan with given ID. This will set a key in redis and indirectly
+    /// sends SIGUSR1 to the running scan process by running openvas with the
+    /// --stop-scan option.
+    pub fn stop_scan(&mut self, id: &str) -> Result<(), OpenvasError> {
+        let scan_id = id.to_string();
+
+        // TODO: Set stop scan flag in redis?
+
+        if self.remove_init(&scan_id) {
+            return Ok(());
+        }
+
+        let mut scan = match self.remove_running(&scan_id) {
+            Some(scan) => scan,
+            None => return Err(OpenvasError::ScanNotFound),
+        };
+
+        cmd::stop(&scan_id, self.sudo)
+            .map_err(OpenvasError::CmdError)?
+            .wait()
+            .map_err(OpenvasError::CmdError)?;
+
+        scan.wait().map_err(OpenvasError::CmdError)?;
+
+        // TODO: Clean redis DB
+
+        Ok(())
+    }
+
+    /// Prepare scan and start it
+    pub fn start_scan(&mut self, scan: models::Scan) -> Result<(), OpenvasError> {
+        let scan_id = match scan.scan_id {
+            Some(id) => id,
+            None => return Err(OpenvasError::MissingID),
+        };
+        self.add_init(scan_id.clone());
+
+        // TODO: Create new DB for Scan
+        // TODO: Add Scan ID to DB
+        // TODO: Prepare Target (hosts, ports, credentials)
+        // TODO: Prepare Plugins
+        // TODO: Prepare main kbindex
+        // TODO: Prepare host options
+        // TODO: Prepare scan params
+        // TODO: Prepare reverse lookup option (maybe part of target)
+        // TODO: Prepare alive test option (maybe part of target)
+
+        if !self.add_running(scan_id)? {
+            return Ok(());
+        }
+
+        // TODO: Control loop (check for status and results)?
+        todo!();
+    }
+}

--- a/rust/openvasctl/src/error.rs
+++ b/rust/openvasctl/src/error.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+pub enum OpenvasError {
+    MissingID,
+    MissingExec,
+    UnableToRunExec,
+    ScanNotFound,
+    ScanAlreadyExists,
+    CmdError(io::Error),
+}

--- a/rust/openvasctl/src/lib.rs
+++ b/rust/openvasctl/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod cmd;
+pub mod ctl;
+pub mod error;


### PR DESCRIPTION
Intoduction of an OpenvasControler for ospd-openvas deprectation. This module is meant to Control, Prepare, Stop and Manage scans with OpenVAS.

This PR adds functionality to start and stop scans.

SC-1000
