### PR TITLE
Change: set Scan ID of Scan Model to non-optional

### DIFF
--- a/rust/models/Cargo.toml
+++ b/rust/models/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-2.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1", features = ["derive"], optional = true}
+serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 default = ["serde_support"]

--- a/rust/models/src/scan.rs
+++ b/rust/models/src/scan.rs
@@ -14,7 +14,7 @@ use super::{scanner_preference::ScannerPreference, target::Target, vt::VT};
 pub struct Scan {
     #[cfg_attr(feature = "serde_support", serde(default))]
     /// Unique ID of a scan
-    pub scan_id: Option<String>,
+    pub scan_id: String,
     /// Information about the target to scan
     pub target: Target,
     #[cfg_attr(feature = "serde_support", serde(default))]

--- a/rust/openvasctl/src/ctl.rs
+++ b/rust/openvasctl/src/ctl.rs
@@ -91,11 +91,7 @@ impl OpenvasController {
 
     /// Prepare scan and start it
     pub fn start_scan(&mut self, scan: models::Scan) -> Result<(), OpenvasError> {
-        let scan_id = match scan.scan_id {
-            Some(id) => id,
-            None => return Err(OpenvasError::MissingID),
-        };
-        self.add_init(scan_id.clone());
+        self.add_init(scan.scan_id.clone());
 
         // TODO: Create new DB for Scan
         // TODO: Add Scan ID to DB
@@ -107,7 +103,7 @@ impl OpenvasController {
         // TODO: Prepare reverse lookup option (maybe part of target)
         // TODO: Prepare alive test option (maybe part of target)
 
-        if !self.add_running(scan_id)? {
+        if !self.add_running(scan.scan_id)? {
             return Ok(());
         }
 

--- a/rust/openvasctl/src/pref_handler.rs
+++ b/rust/openvasctl/src/pref_handler.rs
@@ -66,11 +66,7 @@ where
 
     fn prepare_main_kbindex_for_openvas(&mut self) -> RedisStorageResult<()> {
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             format!("ov_maindbid|||{}", self.redis_connector.kb_id()?),
         )?;
         Ok(())
@@ -78,17 +74,11 @@ where
 
     fn prepare_scan_id_for_openvas(&mut self) -> RedisStorageResult<()> {
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}",
-                &self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}", &self.scan_config.scan_id.clone()).as_str(),
             "new",
         )?;
-        self.redis_connector.push_kb_item(
-            "internal/scanid",
-            self.scan_config.scan_id.clone().expect("Missing scan ID"),
-        )?;
+        self.redis_connector
+            .push_kb_item("internal/scanid", self.scan_config.scan_id.clone())?;
 
         Ok(())
     }
@@ -143,11 +133,7 @@ where
 
         // prepare vts
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             format!("plugin_set|||{}", nvts.join(";")),
         )
     }
@@ -161,11 +147,7 @@ where
             .into_iter()
             .map(|(k, v)| items.push(format!("{}|||{}", k, v)));
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             items,
         )
     }
@@ -271,22 +253,14 @@ where
 
         if (1..=31).contains(&alive_test) {
             self.redis_connector.push_kb_item(
-                format!(
-                    "internal/{}/scanprefs",
-                    self.scan_config.scan_id.clone().expect("Missing scan ID")
-                )
-                .as_str(),
+                format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
                 format!("{BOREAS_ALIVE_TEST}|||{}", alive_test),
             )?;
         };
 
         if alive_test == ALIVE_TEST_SCAN_CONFIG_DEFAULT {
             self.redis_connector.push_kb_item(
-                format!(
-                    "internal/{}/scanprefs",
-                    self.scan_config.scan_id.clone().expect("Missing scan ID")
-                )
-                .as_str(),
+                format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
                 format!("{BOREAS_ALIVE_TEST}|||{}", AliveTestMethods::Icmp as u8),
             )?;
         }
@@ -294,11 +268,7 @@ where
         let alive_test_ports = self.scan_config.target.alive_test_ports.clone();
         if let Some(ports) = ports_to_openvas_port_list(alive_test_ports) {
             self.redis_connector.push_kb_item(
-                format!(
-                    "internal/{}/scanprefs",
-                    self.scan_config.scan_id.clone().expect("Missing scan ID")
-                )
-                .as_str(),
+                format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
                 format!("{BOREAS_ALIVE_TEST_PORTS}|||{}", ports),
             )?;
         };
@@ -326,11 +296,7 @@ where
         }
 
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             lookup_opts,
         )
     }
@@ -338,11 +304,7 @@ where
     fn prepare_target_for_openvas(&mut self) -> RedisStorageResult<()> {
         let target = self.scan_config.target.hosts.join(",");
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             format!("TARGET|||{}", target),
         )
     }
@@ -351,11 +313,7 @@ where
         let ports = self.scan_config.target.ports.clone();
         if let Some(ports) = ports_to_openvas_port_list(ports) {
             self.redis_connector.push_kb_item(
-                format!(
-                    "internal/{}/scanprefs",
-                    self.scan_config.scan_id.clone().expect("Missing scan ID")
-                )
-                .as_str(),
+                format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
                 format!("PORTS|||{}", ports),
             )?;
         };
@@ -370,11 +328,7 @@ where
         }
 
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             format!("excluded_hosts|||{}", excluded_hosts),
         )
     }
@@ -393,11 +347,7 @@ where
         }
 
         self.redis_connector.push_kb_item(
-            format!(
-                "internal/{}/scanprefs",
-                self.scan_config.scan_id.clone().expect("Missing scan ID")
-            )
-            .as_str(),
+            format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
             options,
         )
     }
@@ -550,11 +500,7 @@ where
 
         if !credential_preferences.is_empty() {
             self.redis_connector.push_kb_item(
-                format!(
-                    "internal/{}/scanprefs",
-                    self.scan_config.scan_id.clone().expect("Missing scan ID")
-                )
-                .as_str(),
+                format!("internal/{}/scanprefs", self.scan_config.scan_id.clone()).as_str(),
                 credential_preferences,
             )?;
         }
@@ -574,7 +520,7 @@ mod tests {
     #[test]
     fn test_prefs() {
         let mut scan = Scan::default();
-        scan.scan_id = Some("123-456".to_string());
+        scan.scan_id = "123-456".to_string();
         scan.target.alive_test_methods = vec![AliveTestMethods::Icmp, AliveTestMethods::TcpSyn];
         scan.target.credentials = vec![Credential {
             service: models::Service::SSH,

--- a/rust/openvasd/Cargo.toml
+++ b/rust/openvasd/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 serde_json = "1.0.96"
 serde = { version = "1.0.163", features = ["derive"] }
 uuid = { version = "1", features = ["v4", "fast-rng", "serde"] }
-rustls = {version = "0.22"}
+rustls = { version = "0.22" }
 tokio-rustls = "0.25"
 futures-util = "0.3.28"
 rustls-pemfile = "1.0.2"
@@ -35,7 +35,7 @@ pbkdf2 = { version = "0.12.2", features = ["password-hash"] }
 sha2 = "0.10.7"
 generic-array = "0.14.7"
 base64 = "0.21.2"
-hyper-util = { version = "0", features = [ "tokio" ]}
+hyper-util = { version = "0", features = ["tokio"] }
 http-body-util = "0.1.0"
 http-body = "1"
 

--- a/rust/openvasd/src/controller/entry.rs
+++ b/rust/openvasd/src/controller/entry.rs
@@ -257,14 +257,14 @@ where
                     match crate::request::json_request::<models::Scan, _>(&ctx.response, req).await
                     {
                         Ok(mut scan) => {
-                            if scan.scan_id.is_some() {
+                            if !scan.scan_id.is_empty() {
                                 return Ok(ctx
                                     .response
                                     .bad_request("field scan_id is not allowed to be set."));
                             }
                             let id = uuid::Uuid::new_v4().to_string();
                             let resp = ctx.response.created(&id);
-                            scan.scan_id = Some(id.clone());
+                            scan.scan_id = id.clone();
                             ctx.db.insert_scan(scan).await?;
                             ctx.db.add_scan_client_id(id.clone(), cid).await?;
                             tracing::debug!("Scan with ID {} created", &id);

--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -361,7 +361,7 @@ mod tests {
     #[tokio::test]
     async fn add_scan_with_id_fails() {
         let scan: models::Scan = models::Scan {
-            scan_id: Some(String::new()),
+            scan_id: "test".to_string(),
             ..Default::default()
         };
         let ctx = Arc::new(Context::default());

--- a/rust/openvasd/src/storage/file.rs
+++ b/rust/openvasd/src/storage/file.rs
@@ -212,7 +212,7 @@ where
     S: infisto::base::IndexedByteStorage + std::marker::Sync + std::marker::Send + Clone + 'static,
 {
     async fn insert_scan(&self, scan: models::Scan) -> Result<(), Error> {
-        let id = scan.scan_id.clone().unwrap_or_default();
+        let id = scan.scan_id.clone();
         let key = format!("scan_{id}");
         let status_key = format!("status_{id}");
         let storage = Arc::clone(&self.storage);
@@ -553,7 +553,7 @@ mod tests {
 }
         "#;
         let mut scan: Scan = serde_json::from_str(jraw).unwrap();
-        scan.scan_id = Some("aha".to_string());
+        scan.scan_id = "aha".to_string();
         let storage =
             infisto::base::CachedIndexFileStorer::init("/tmp/openvasd/credential").unwrap();
         let nfp = "../../examples/feed/nasl";
@@ -606,7 +606,7 @@ mod tests {
         let mut scans = Vec::with_capacity(100);
         for i in 0..100 {
             let scan = Scan {
-                scan_id: Some(i.to_string()),
+                scan_id: i.to_string(),
                 ..Default::default()
             };
             scans.push(scan);
@@ -622,7 +622,7 @@ mod tests {
         }
 
         for s in scans.clone().into_iter() {
-            storage.get_scan(&s.scan_id.unwrap()).await.unwrap();
+            storage.get_scan(&s.scan_id).await.unwrap();
         }
         storage.remove_scan("5").await.unwrap();
         storage.insert_scan(scans[5].clone()).await.unwrap();
@@ -656,7 +656,7 @@ mod tests {
             .collect();
         assert_eq!(2, range.len());
         for s in scans {
-            let _ = storage.remove_scan(&s.scan_id.unwrap_or_default()).await;
+            let _ = storage.remove_scan(&s.scan_id).await;
         }
 
         let ids = storage.get_scan_ids().await.unwrap();

--- a/rust/openvasd/src/storage/inmemory.rs
+++ b/rust/openvasd/src/storage/inmemory.rs
@@ -184,7 +184,7 @@ where
     E: crate::crypt::Crypt + Send + Sync + 'static,
 {
     async fn insert_scan(&self, sp: models::Scan) -> Result<(), Error> {
-        let id = sp.scan_id.clone().unwrap_or_default();
+        let id = sp.scan_id.clone();
         let mut scans = self.scans.write().await;
         if let Some(prgs) = scans.get_mut(&id) {
             prgs.scan = sp;
@@ -243,9 +243,7 @@ where
         let scans = self.scans.read().await;
         let mut result = Vec::with_capacity(scans.len());
         for (_, progress) in scans.iter() {
-            if let Some(id) = progress.scan.scan_id.as_ref() {
-                result.push(id.clone());
-            }
+            result.push(progress.scan.scan_id.clone());
         }
         Ok(result)
     }
@@ -441,10 +439,10 @@ mod tests {
     async fn store_delete_scan() {
         let storage = Storage::default();
         let scan = Scan::default();
-        let id = scan.scan_id.clone().unwrap_or_default();
+        let id = scan.scan_id.clone();
         storage.insert_scan(scan).await.unwrap();
         let (retrieved, _) = storage.get_scan(&id).await.unwrap();
-        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        assert_eq!(retrieved.scan_id, id);
         storage.remove_scan(&id).await.unwrap();
     }
 
@@ -463,21 +461,21 @@ mod tests {
 
         scan.target.credentials = vec![pw];
 
-        let id = scan.scan_id.clone().unwrap_or_default();
+        let id = scan.scan_id.clone();
         storage.insert_scan(scan).await.unwrap();
         let (retrieved, _) = storage.get_scan(&id).await.unwrap();
-        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        assert_eq!(retrieved.scan_id, id);
         assert_ne!(retrieved.target.credentials[0].password(), "test");
 
         let (retrieved, _) = storage.get_decrypted_scan(&id).await.unwrap();
-        assert_eq!(retrieved.scan_id.unwrap_or_default(), id);
+        assert_eq!(retrieved.scan_id, id);
         assert_eq!(retrieved.target.credentials[0].password(), "test");
     }
 
     async fn store_scan(storage: &Storage<crypt::ChaCha20Crypt>) -> String {
         let mut scan = Scan::default();
         let id = uuid::Uuid::new_v4().to_string();
-        scan.scan_id = Some(id.clone());
+        scan.scan_id = id.clone();
         storage.insert_scan(scan).await.unwrap();
         id
     }
@@ -496,7 +494,7 @@ mod tests {
     async fn append_results() {
         let storage = Storage::default();
         let scan = Scan::default();
-        let id = scan.scan_id.clone().unwrap_or_default();
+        let id = scan.scan_id.clone();
         storage.insert_scan(scan).await.unwrap();
         let fetch_result = (models::Status::default(), vec![models::Result::default()]);
         storage


### PR DESCRIPTION
As the scan ID was set by the server and not by the client, it was set to Optional. This lead to many unnecessary checks, even though it was not possible, that this value is None.

SC-1021