### PR TITLE
 refactor: move scanner traits to model crate and introduce result struct

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1990,10 +1990,12 @@ dependencies = [
 name = "osp"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "models",
  "quick-xml",
  "serde",
  "serde_json",
+ "tokio",
  "urlencoding",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
 name = "models"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
 ]

--- a/rust/models/Cargo.toml
+++ b/rust/models/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-2.0-or-later"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.77"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]

--- a/rust/models/src/lib.rs
+++ b/rust/models/src/lib.rs
@@ -11,6 +11,7 @@ mod product;
 mod result;
 mod scan;
 mod scan_action;
+pub mod scanner;
 mod scanner_preference;
 mod status;
 mod target;

--- a/rust/models/src/scanner.rs
+++ b/rust/models/src/scanner.rs
@@ -1,0 +1,75 @@
+use async_trait::async_trait;
+
+use crate::{Scan, Status};
+
+/// Contains results of a scan as well as identification factors and statuses.
+///
+/// It is usually returned on fetch_results which gets all results of all running scans for further
+/// processing.
+#[derive(Debug, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct ScanResults {
+    pub id: String,
+    pub status: Status,
+    pub results: Vec<crate::Result>,
+}
+
+/// Starts a scan
+#[async_trait]
+pub trait ScanStarter {
+    /// Starts a scan
+    async fn start_scan(&self, scan: Scan) -> Result<(), Error>;
+}
+
+/// Stops a scan
+#[async_trait]
+pub trait ScanStopper {
+    /// Stops a scan
+    async fn stop_scan<I>(&self, id: I) -> Result<(), Error>
+    where
+        I: AsRef<str> + Send + 'static;
+}
+
+/// Deletes a scan
+#[async_trait]
+pub trait ScanDeleter {
+    async fn delete_scan<I>(&self, id: I) -> Result<(), Error>
+    where
+        I: AsRef<str> + Send + 'static;
+}
+
+#[async_trait]
+pub trait ScanResultFetcher {
+    /// Fetches the results of a scan and combines the results with response
+    async fn fetch_results<I>(&self, id: I) -> Result<ScanResults, Error>
+    where
+        I: AsRef<str> + Send + 'static;
+}
+
+/// Combines all traits needed for a scanner.
+#[async_trait]
+pub trait Scanner: ScanStarter + ScanStopper + ScanDeleter + ScanResultFetcher {}
+
+impl<T> Scanner for T where T: ScanStarter + ScanStopper + ScanDeleter + ScanResultFetcher {}
+
+#[derive(Debug)]
+pub enum Error {
+    Unexpected(String),
+    Connection(String),
+    Poisoned,
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unexpected(x) => write!(f, "Unexpecdted issue: {x}"),
+            Self::Connection(x) => write!(f, "Connection issue: {x}"),
+            _ => write!(f, "{:?}", self),
+        }
+    }
+}

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -270,7 +270,7 @@ impl ScanDeleter for NoOpScanner {
 
 #[async_trait]
 impl ScanResultFetcher for NoOpScanner {
-    async fn fetch_results<I>(&self, _: I) -> Result<crate::scan::FetchResult, Error>
+    async fn fetch_results<I>(&self, _: I) -> Result<crate::scan::ScanResults, Error>
     where
         I: AsRef<str> + Send,
     {

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -7,10 +7,10 @@ use std::{path::PathBuf, sync::RwLock};
 use async_trait::async_trait;
 use storage::DefaultDispatcher;
 
-use crate::{
-    notus::NotusWrapper,
-    response,
-    scan::{Error, ScanDeleter, ScanResultFetcher, ScanStarter, ScanStopper},
+use crate::{notus::NotusWrapper, response};
+
+use models::scanner::{
+    Error, ScanDeleter, ScanResultFetcher, ScanResults, ScanStarter, ScanStopper,
 };
 
 #[derive(Debug, Clone)]
@@ -166,7 +166,11 @@ where
     /// Sets the scanner. This is required.
     pub fn scanner(self, scanner: S) -> ContextBuilder<S, DB, Scanner<S>>
     where
-        S: super::Scanner + 'static + std::marker::Send + std::marker::Sync + std::fmt::Debug,
+        S: models::scanner::Scanner
+            + 'static
+            + std::marker::Send
+            + std::marker::Sync
+            + std::fmt::Debug,
     {
         let Self {
             result_config,
@@ -270,7 +274,7 @@ impl ScanDeleter for NoOpScanner {
 
 #[async_trait]
 impl ScanResultFetcher for NoOpScanner {
-    async fn fetch_results<I>(&self, _: I) -> Result<crate::scan::ScanResults, Error>
+    async fn fetch_results<I>(&self, _: I) -> Result<ScanResults, Error>
     where
         I: AsRef<str> + Send,
     {

--- a/rust/openvasd/src/controller/entry.rs
+++ b/rust/openvasd/src/controller/entry.rs
@@ -11,12 +11,10 @@ use std::{fmt::Display, marker::PhantomData, sync::Arc};
 use super::{context::Context, ClientIdentifier};
 
 use hyper::{Method, Request};
+use models::scanner::{ScanDeleter, ScanResultFetcher, ScanStarter, ScanStopper};
 
-use crate::{
-    controller::ClientHash,
-    notus::NotusScanner,
-    scan::{self, Error, ScanDeleter, ScanStarter, ScanStopper},
-};
+use crate::{controller::ClientHash, notus::NotusScanner};
+use models::scanner::*;
 
 enum HealthOpts {
     /// Ready
@@ -137,7 +135,7 @@ where
     S: ScanStarter
         + ScanStopper
         + ScanDeleter
-        + scan::ScanResultFetcher
+        + ScanResultFetcher
         + std::marker::Send
         + std::marker::Sync
         + 'static,

--- a/rust/openvasd/src/controller/feed.rs
+++ b/rust/openvasd/src/controller/feed.rs
@@ -4,13 +4,15 @@
 
 use std::sync::Arc;
 
+use models::scanner::Scanner;
+
 use crate::feed::FeedIdentifier;
 
 use super::context::Context;
 
 pub async fn fetch<S, DB>(ctx: Arc<Context<S, DB>>)
 where
-    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync,
+    S: Scanner + 'static + std::marker::Send + std::marker::Sync,
     DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync,
 {
     tracing::debug!("Starting VTS synchronization loop");

--- a/rust/openvasd/src/controller/mod.rs
+++ b/rust/openvasd/src/controller/mod.rs
@@ -159,7 +159,7 @@ mod tests {
     use super::context::Context;
     use crate::{
         controller::{ClientIdentifier, ContextBuilder, NoOpScanner},
-        scan::{ScanDeleter, ScanStarter, ScanStopper},
+        scan::{ScanDeleter, ScanResults, ScanStarter, ScanStopper},
         storage::file,
     };
     use async_trait::async_trait;
@@ -203,8 +203,8 @@ mod tests {
     impl crate::scan::ScanResultFetcher for FakeScanner {
         async fn fetch_results<I>(
             &self,
-            _id: I,
-        ) -> Result<crate::scan::FetchResult, crate::scan::Error>
+            id: I,
+        ) -> Result<crate::scan::ScanResults, crate::scan::Error>
         where
             I: AsRef<str> + Send,
         {
@@ -216,7 +216,11 @@ mod tests {
                         ..Default::default()
                     };
                     *count += 1;
-                    Ok((status, vec![]))
+                    Ok(ScanResults {
+                        id: id.as_ref().to_string(),
+                        status,
+                        results: vec![],
+                    })
                 }
                 1..=99 => {
                     let status = models::Status {
@@ -232,7 +236,11 @@ mod tests {
                         });
                     }
                     *count += 1;
-                    Ok((status, results))
+                    Ok(ScanResults {
+                        id: id.as_ref().to_string(),
+                        status,
+                        results,
+                    })
                 }
                 _ => {
                     *count += 1;
@@ -240,7 +248,11 @@ mod tests {
                         status: models::Phase::Succeeded,
                         ..Default::default()
                     };
-                    Ok((status, vec![]))
+                    Ok(ScanResults {
+                        id: id.as_ref().to_string(),
+                        status,
+                        results: vec![],
+                    })
                 }
             }
         }

--- a/rust/openvasd/src/controller/results.rs
+++ b/rust/openvasd/src/controller/results.rs
@@ -6,6 +6,8 @@
 //!
 //! This loop should be run as background task to fetch results from the scanner.
 
+use models::scanner::Scanner;
+
 use crate::controller::quit_on_poison;
 use std::sync::Arc;
 
@@ -16,7 +18,7 @@ use super::context::Context;
 /// This loop should be run as background task to fetch results from the scanner.
 pub async fn fetch<S, DB>(ctx: Arc<Context<S, DB>>)
 where
-    S: super::Scanner + 'static + std::marker::Send + std::marker::Sync,
+    S: Scanner + 'static + std::marker::Send + std::marker::Sync,
     DB: crate::storage::Storage + 'static + std::marker::Send + std::marker::Sync,
 {
     if let Some(cfg) = &ctx.result_config {
@@ -59,7 +61,7 @@ where
                                 // and need to escalate this.
                                 ctx.db.append_fetched_result(vec![fr]).await.unwrap();
                             }
-                            Err(crate::scan::Error::Poisoned) => {
+                            Err(models::scanner::Error::Poisoned) => {
                                 quit_on_poison::<()>();
                             }
                             Err(e) => {

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -12,15 +12,11 @@ pub mod feed;
 pub mod notus;
 pub mod request;
 pub mod response;
-pub mod scan;
 pub mod storage;
 pub mod tls;
 
-fn create_context<DB>(
-    db: DB,
-    config: &config::Config,
-) -> controller::Context<scan::OSPDWrapper, DB> {
-    let scanner = scan::OSPDWrapper::new(config.ospd.socket.clone(), config.ospd.read_timeout);
+fn create_context<DB>(db: DB, config: &config::Config) -> controller::Context<osp::Scanner, DB> {
+    let scanner = osp::Scanner::new(config.ospd.socket.clone(), config.ospd.read_timeout);
     let rc = config.ospd.result_check_interval;
     let fc = (
         config.feed.path.clone(),

--- a/rust/openvasd/src/storage/mod.rs
+++ b/rust/openvasd/src/storage/mod.rs
@@ -45,6 +45,11 @@ impl From<std::string::FromUtf8Error> for Error {
     }
 }
 
+impl From<crate::storage::Error> for models::scanner::Error {
+    fn from(value: crate::storage::Error) -> Self {
+        Self::Unexpected(format!("{value:?}"))
+    }
+}
 #[async_trait]
 pub trait ScanIDClientMapper {
     async fn add_scan_client_id(&self, scan_id: String, client_id: ClientHash)

--- a/rust/openvasd/src/storage/mod.rs
+++ b/rust/openvasd/src/storage/mod.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 
-use crate::{controller::ClientHash, crypt, scan::FetchResult};
+use crate::{controller::ClientHash, crypt, scan::ScanResults};
 
 #[derive(Debug)]
 pub enum Error {
@@ -150,7 +150,7 @@ pub trait ScanStorer {
 ///
 /// This is used when a scan is started and the results are fetched from ospd.
 pub trait AppendFetchResult {
-    async fn append_fetched_result(&self, id: &str, results: FetchResult) -> Result<(), Error>;
+    async fn append_fetched_result(&self, results: Vec<ScanResults>) -> Result<(), Error>;
 }
 
 #[async_trait]

--- a/rust/openvasd/src/storage/mod.rs
+++ b/rust/openvasd/src/storage/mod.rs
@@ -4,8 +4,9 @@ pub mod redis;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
+use models::scanner::ScanResults;
 
-use crate::{controller::ClientHash, crypt, scan::ScanResults};
+use crate::{controller::ClientHash, crypt};
 
 #[derive(Debug)]
 pub enum Error {

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -12,7 +12,8 @@ use redis_storage::{
 use storage::{item::PerItemDispatcher, Dispatcher, Field};
 use tokio::sync::RwLock;
 
-use crate::{controller::ClientHash, scan::ScanResults};
+use crate::controller::ClientHash;
+use models::scanner::ScanResults;
 
 use super::{AppendFetchResult, Error, NVTStorer, ProgressGetter, ScanIDClientMapper, ScanStorer};
 

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -12,7 +12,7 @@ use redis_storage::{
 use storage::{item::PerItemDispatcher, Dispatcher, Field};
 use tokio::sync::RwLock;
 
-use crate::{controller::ClientHash, scan::FetchResult};
+use crate::{controller::ClientHash, scan::ScanResults};
 
 use super::{AppendFetchResult, Error, NVTStorer, ProgressGetter, ScanIDClientMapper, ScanStorer};
 
@@ -282,7 +282,7 @@ impl<T> AppendFetchResult for Storage<T>
 where
     T: super::Storage + std::marker::Sync,
 {
-    async fn append_fetched_result(&self, id: &str, results: FetchResult) -> Result<(), Error> {
-        self.underlying.append_fetched_result(id, results).await
+    async fn append_fetched_result(&self, results: Vec<ScanResults>) -> Result<(), Error> {
+        self.underlying.append_fetched_result(results).await
     }
 }

--- a/rust/osp/Cargo.toml
+++ b/rust/osp/Cargo.toml
@@ -12,3 +12,5 @@ serde = { version = "1.0", features = ["derive"]}
 quick-xml = { version = "0.28.1", features = ["serialize"] }
 serde_json = "1.0"
 urlencoding = "2.1.2"
+async-trait = "0.1.77"
+tokio = { version = "1.36.0", features = [ "full" ] }

--- a/rust/osp/src/commands.rs
+++ b/rust/osp/src/commands.rs
@@ -342,6 +342,11 @@ pub enum Error {
     /// Invalid response from OSPD
     InvalidResponse(Status),
 }
+impl From<Error> for models::scanner::Error {
+    fn from(value: Error) -> Self {
+        Self::Unexpected(format!("{value:?}"))
+    }
+}
 
 impl From<quick_xml::de::DeError> for Error {
     fn from(value: quick_xml::de::DeError) -> Self {

--- a/rust/osp/src/lib.rs
+++ b/rust/osp/src/lib.rs
@@ -6,10 +6,12 @@
 mod commands;
 mod connection;
 mod response;
+mod scanner;
 pub use commands::Error;
 pub use commands::ScanCommand;
 pub use connection::*;
 pub use response::*;
+pub use scanner::Scanner;
 
 /// The id of a scan
 pub type ScanID = String;

--- a/rust/osp/src/response.rs
+++ b/rust/osp/src/response.rs
@@ -563,7 +563,7 @@ impl Default for Scan {
         }
     }
 }
-
+// TODO when traits moved to models create From for ScanResults
 impl From<Scan> for models::Status {
     fn from(value: Scan) -> Self {
         let phase: models::Phase = match value.status {


### PR DESCRIPTION
- Change: move osp specific Scanner implementation from openvasd into osp
- Change: move scanner trait to models library
- Change: remove FetchResult in favor of ScanResults