### PR TITLE
Fix: multiple verbose entries in nasl-cli

### DIFF
--- a/rust/nasl-cli/src/execute/mod.rs
+++ b/rust/nasl-cli/src/execute/mod.rs
@@ -20,21 +20,19 @@ pub fn run(root: &clap::ArgMatches) -> Option<Result<(), CliError>> {
     ))
 }
 pub fn extend_args(cmd: Command) -> Command {
-    crate::add_verbose(
-        cmd.subcommand(
-            Command::new("execute")
-                .about(
-                    "Executes a nasl-script.
+    cmd.subcommand(crate::add_verbose(
+        Command::new("execute")
+            .about(
+                "Executes a nasl-script.
 A script can either be a file to be executed or an ID.
 When ID is used than a valid feed path must be given within the path parameter.",
-                )
-                .arg(
-                    arg!(-p --path <FILE> "Path to the feed.")
-                        .required(false)
-                        .value_parser(value_parser!(PathBuf)),
-                )
-                .arg(Arg::new("script").required(true))
-                .arg(arg!(-t --target <HOST> "Target to scan").required(false)),
-        ),
-    )
+            )
+            .arg(
+                arg!(-p --path <FILE> "Path to the feed.")
+                    .required(false)
+                    .value_parser(value_parser!(PathBuf)),
+            )
+            .arg(Arg::new("script").required(true))
+            .arg(arg!(-t --target <HOST> "Target to scan").required(false)),
+    ))
 }

--- a/rust/nasl-cli/src/feed/mod.rs
+++ b/rust/nasl-cli/src/feed/mod.rs
@@ -11,8 +11,8 @@ use storage::StorageError;
 use crate::{get_path_from_openvas, notusupdate, read_openvas_config, CliError, CliErrorKind};
 
 pub fn extend_args(cmd: Command) -> Command {
-    crate::add_verbose(
     cmd.subcommand(
+    crate::add_verbose(
             Command::new("feed")
                 .about("Handles feed related tasks")
                 .subcommand_required(true)

--- a/rust/nasl-cli/src/scanconfig.rs
+++ b/rust/nasl-cli/src/scanconfig.rs
@@ -9,8 +9,7 @@ use std::collections::HashMap;
 use std::io::BufRead;
 
 pub fn extend_args(cmd: Command) -> Command {
-    crate::add_verbose(
-        cmd.subcommand(
+    cmd.subcommand( crate::add_verbose(
             Command::new("scan-config")
                 .about("Transforms a scan-config xml to a scan json for openvasd.
 When piping a scan json it is enriched with the scan-config xml and may the portlist otherwise it will print a scan json without target or credentials.")

--- a/rust/nasl-cli/src/syntax/mod.rs
+++ b/rust/nasl-cli/src/syntax/mod.rs
@@ -18,20 +18,18 @@ pub fn run(root: &clap::ArgMatches) -> Option<Result<(), CliError>> {
 }
 
 pub fn extend_args(cmd: Command) -> Command {
-    add_verbose(
-        cmd.subcommand(
-            Command::new("syntax")
-                .about("Verifies syntax of NASL files in given dir or file.")
-                .arg(
-                    Arg::new("path")
-                        .required(true)
-                        .value_parser(value_parser!(PathBuf)),
-                )
-                .arg(
-                    arg!(-q --quiet "Prints only error output and no progress.")
-                        .required(false)
-                        .action(ArgAction::SetTrue),
-                ),
-        ),
-    )
+    cmd.subcommand(add_verbose(
+        Command::new("syntax")
+            .about("Verifies syntax of NASL files in given dir or file.")
+            .arg(
+                Arg::new("path")
+                    .required(true)
+                    .value_parser(value_parser!(PathBuf)),
+            )
+            .arg(
+                arg!(-q --quiet "Prints only error output and no progress.")
+                    .required(false)
+                    .action(ArgAction::SetTrue),
+            ),
+    ))
 }


### PR DESCRIPTION
Verbose is set on the overall clap command although it should be set on
the subcommand itself. This leads to
```
debug_asserts.rs:86:13:
Command nasl-cli: Argument names must be unique, but 'verbose' is in use by more than one argument or group
```
when it is not build with --release.

This commit changes this behaviour by calling it on the newly build
subcommand rather than the given root command.