### PR TITLE
Fix: Set scan status to failed, if scan cannot be started

### DIFF
--- a/rust/openvasd/src/scheduling.rs
+++ b/rust/openvasd/src/scheduling.rs
@@ -199,7 +199,18 @@ where
                         queued.push(scan_id);
                     }
                     Err(e) => {
-                        tracing::warn!(%scan_id, %e, "unable to start, removing from queue. Verify that scan using the API");
+                        tracing::warn!(%scan_id, %e, "unable to start, removing from queue and set status to failed. Verify that scan using the API");
+                        self.db
+                            .update_status(
+                                &scan_id,
+                                models::Status {
+                                    start_time: None,
+                                    end_time: None,
+                                    status: Phase::Failed,
+                                    host_info: None,
+                                },
+                            )
+                            .await?;
                     }
                 };
             } else {


### PR DESCRIPTION
In cases the scan cannot be started, the scan is removed from the queue, but the scan status was still requested. This fixes the issue, by setting the scan status to failed.