### PR TITLE
Fix: set status to Stopped if the scan was successfully stopped

### DIFF
--- a/rust/openvasd/src/scheduling.rs
+++ b/rust/openvasd/src/scheduling.rs
@@ -285,6 +285,9 @@ where
                 if let Some(idx) = running.iter().position(|x| x == &cid) {
                     running.swap_remove(idx);
                 }
+                let mut current_status = self.db.get_status(&cid).await?;
+                current_status.status = Phase::Stopped;
+                self.db.update_status(&cid, current_status).await?;
                 Ok(())
             }
             Err(e) => Err(e),


### PR DESCRIPTION
**What**:
Fix: set status to Stopped if the scan was successfully stopped
Jira: SC-1035
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Openvas doesn't have a `stopped` status. It has `finished ` even when it was intentionally stopped.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
