### PR TITLE
Add: notus only mode

### DIFF
--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -1,3 +1,9 @@
+# openvasd contains several modes to control the behaviour of it.
+# Service enables nasl and notus feed observations all endpoints.
+# mode = "service"
+# Notus disables /scan endpoints and just observes the notus feed.
+# mode = "service_notus"
+
 [feed]
 # path to the openvas feed. This is required for the /vts endpoint.
 path = "/var/lib/openvas/plugins"

--- a/rust/nasl-syntax/src/loader.rs
+++ b/rust/nasl-syntax/src/loader.rs
@@ -128,6 +128,11 @@ where
     pub fn new(root: P) -> Self {
         Self { root }
     }
+
+    /// Returns the used path
+    pub fn root(&self) -> &Path {
+        self.root.as_ref()
+    }
 }
 
 impl<P> AsBufReader<File> for FSPluginLoader<P>

--- a/rust/notus/src/notus.rs
+++ b/rust/notus/src/notus.rs
@@ -47,8 +47,8 @@ where
 
     fn load_new_product(&self, os: &str) -> Result<(Product, FeedStamp), Error> {
         tracing::debug!(
-            "Loading notus product from {:?}",
-            self.loader.get_root_dir()
+            root=?self.loader.get_root_dir(),
+            "Loading notus product",
         );
         let (product, stamp) = self.loader.load_product(os)?;
 

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -30,6 +30,7 @@ pub struct ContextBuilder<S, DB, T> {
     response: response::Response,
     notus: Option<NotusWrapper>,
     scheduler_config: Option<config::Scheduler>,
+    mode: config::Mode,
 }
 
 impl<S>
@@ -47,11 +48,17 @@ impl<S>
             response: response::Response::default(),
             notus: None,
             scheduler_config: None,
+            mode: config::Mode::default(),
         }
     }
 }
 
 impl<S, DB, T> ContextBuilder<S, DB, T> {
+    /// Sets the mode.
+    pub fn mode(mut self, mode: config::Mode) -> Self {
+        self.mode = mode;
+        self
+    }
     /// Sets the feed config.
     pub fn feed_config(mut self, config: config::Feed) -> Self {
         self.feed_config = Some(config);
@@ -104,6 +111,7 @@ impl<S, DB, T> ContextBuilder<S, DB, T> {
             response,
             notus,
             scheduler_config,
+            mode,
         } = self;
         ContextBuilder {
             scanner,
@@ -115,6 +123,7 @@ impl<S, DB, T> ContextBuilder<S, DB, T> {
             response,
             notus,
             scheduler_config,
+            mode,
         }
     }
 }
@@ -139,6 +148,7 @@ impl<S, DB> ContextBuilder<S, DB, NoScanner> {
             storage,
             notus,
             scheduler_config,
+            mode,
         } = self;
         ContextBuilder {
             scanner: Scanner(scanner),
@@ -150,6 +160,7 @@ impl<S, DB> ContextBuilder<S, DB, NoScanner> {
             response,
             notus,
             scheduler_config,
+            mode,
         }
     }
 }
@@ -169,6 +180,7 @@ impl<S, DB> ContextBuilder<S, DB, Scanner<S>> {
             api_key: self.api_key,
             enable_get_scans: self.enable_get_scans,
             notus: self.notus,
+            mode: self.mode,
         }
     }
 }
@@ -186,6 +198,7 @@ pub struct Context<S, DB> {
     pub api_key: Option<String>,
     /// Whether to enable the GET /scans endpoint
     pub enable_get_scans: bool,
+    pub mode: config::Mode,
     /// Aborts the background loops
     pub abort: RwLock<bool>,
     /// Notus Scanner

--- a/rust/openvasd/src/controller/feed.rs
+++ b/rust/openvasd/src/controller/feed.rs
@@ -6,9 +6,45 @@ use std::sync::Arc;
 
 use models::scanner::Scanner;
 
-use crate::{feed::FeedIdentifier, storage::NVTStorer as _};
+use crate::{
+    feed::FeedIdentifier,
+    storage::{FeedHash, NVTStorer as _},
+};
 
 use super::context::Context;
+
+async fn changed_hash(signature_check: bool, feeds: &[FeedHash]) -> Result<Vec<FeedHash>, ()> {
+    let mut result = Vec::with_capacity(feeds.len());
+    for h in feeds {
+        if signature_check {
+            if let Err(err) = feed::verify::check_signature(&h.path) {
+                tracing::warn!(
+                    sumsfile=%h.path.display(),
+                    error=%err,
+                    "Signature is incorrect, skipping",
+                );
+                return Err(());
+            }
+        }
+
+        let path = h.path.clone();
+        let hash = tokio::task::spawn_blocking(move || match FeedIdentifier::sumfile_hash(path) {
+            Ok(h) => h,
+            Err(e) => {
+                tracing::warn!(%e, "Failed to compute sumfile hash");
+                "".to_string()
+            }
+        })
+        .await
+        .unwrap();
+        if hash != h.hash {
+            let mut nh = h.clone();
+            nh.hash = hash;
+            result.push(nh);
+        }
+    }
+    Ok(result)
+}
 
 pub async fn fetch<S, DB>(ctx: Arc<Context<S, DB>>)
 where
@@ -20,38 +56,19 @@ where
         let interval = cfg.check_interval;
         let signature_check = cfg.signature_check;
         loop {
-            let path = cfg.path.clone();
             if *ctx.abort.read().unwrap() {
                 tracing::trace!("aborting");
                 break;
             };
             let last_hash = ctx.scheduler.feed_hash().await;
-            if signature_check {
-                if let Err(err) = feed::verify::check_signature(&path) {
-                    tracing::warn!(
-                        "Signature of {} is not corredct, skipping: {}",
-                        path.display(),
-                        err
-                    );
+            if let Ok(nh) = changed_hash(signature_check, &last_hash).await {
+                if !nh.is_empty() {
+                    if let Err(err) = ctx.scheduler.synchronize_feeds(nh).await {
+                        tracing::warn!(%err, "Unable to sync feed")
+                    }
                 }
             }
 
-            let hash =
-                tokio::task::spawn_blocking(move || match FeedIdentifier::sumfile_hash(path) {
-                    Ok(h) => h,
-                    Err(e) => {
-                        tracing::warn!("Failed to compute sumfile hash: {e:?}");
-                        "".to_string()
-                    }
-                })
-                .await
-                .unwrap();
-            if last_hash.is_empty() || last_hash != hash {
-                match ctx.scheduler.synchronize_feeds(hash).await {
-                    Ok(_) => {}
-                    Err(e) => tracing::warn!("Unable to sync feed: {e}"),
-                }
-            }
             tokio::time::sleep(interval).await;
         }
     }


### PR DESCRIPTION
Introduces modes to control openvasd.

Currently it has the modes:
- service - enables all endpoints and the whole functionality (default)
- service_notus - disables /scan endpoint and nasl feed

The configuration is described within rust/examples/openvasd/config.example.toml
and there is the possibility to set `OPENVASD_MOD` environment variable.

For an example to start openvasd in the notus mode you can it from the
examples dir:

```
FEED_PATH=feed/nasl NOTUS_ADVISORIES=feed/notus/advisories/ OPENVASD_LOG=debug OPENVASD_MODE=service_notus ../target/release/openvasd
```

and try to call `localhost:3000/scans`.
