### PR TITLE
Fix: escape char for data type

### DIFF
--- a/rust/nasl-syntax/src/token.rs
+++ b/rust/nasl-syntax/src/token.rs
@@ -599,15 +599,14 @@ impl<'a> Tokenizer<'a> {
         if self.cursor.is_eof() {
             Category::Unclosed(UnclosedCategory::Data)
         } else {
-            let raw = self.code[Range {
+            let mut raw_str = self.code[Range {
                 start,
                 end: self.cursor.len_consumed(),
             }]
-            .as_bytes()
-            .to_vec();
-
+            .to_owned();
+            raw_str = raw_str.replace(r#"\""#, "\"");
             self.cursor.advance();
-            Category::Data(raw)
+            Category::Data(raw_str.as_bytes().to_vec())
         }
     }
     fn may_parse_ipv4(&mut self, base: Base, start: usize) -> Option<Category> {
@@ -956,6 +955,14 @@ mod tests {
             [
                 r"[119, 101, 98, 97, 112, 112, 115, 92, 92, 97, 112, 112, 108, 105, 97, 110, 99, 101, 92, 92]",
             ]
+        );
+    }
+
+    #[test]
+    fn data_escape_quoting() {
+        verify_tokens!(
+            r#"'version=\"1.0\"'"#,
+            [r"[118, 101, 114, 115, 105, 111, 110, 61, 34, 49, 46, 48, 34]",]
         );
     }
 


### PR DESCRIPTION
**What**:
Fix: escape char for data type

`scannerctl` removes now the back slash for the following case. 

Jira: SC-1037
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
scannerctl must behave like openvas-nasl
<!-- Why are these changes necessary? -->

**How**:
Run `openvas-nasl -X test.nasl` and `scannerctl execute test.nasl`. Both should give the same output

```
d = 'aaaaa\"ddddd';
display(d);
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
