### PR TITLE
Fix: scannerctl option name and redis-storage distaptcher

### DIFF
--- a/rust/scannerctl/src/notusupdate/scanner.rs
+++ b/rust/scannerctl/src/notusupdate/scanner.rs
@@ -27,7 +27,7 @@ pub fn extend_args(cmd: Command) -> Command {
                     .action(ArgAction::SetTrue),
             )
             .arg(
-                arg!(-l --pkg-list <STRING> "Comma separated list of packages.")
+                arg!(-l --"pkg-list" <STRING> "Comma separated list of packages.")
                     .required_unless_present("input"),
             )
             .arg(Arg::new("os").required(true).action(ArgAction::Append)),


### PR DESCRIPTION
**What**:
Fix: scannerctl option name and redis-storage distaptcher
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
scannerctl panic when running `feed update` becasue a wrong parameter name (debug build)
Redis CacheDispatcher release the selected namespace when does the namespace cleanup. It should only flush the db without releasing.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
