### PR TITLE
Fix scan start responsen

### DIFF
--- a/rust/openvasd/src/controller/entry.rs
+++ b/rust/openvasd/src/controller/entry.rs
@@ -312,6 +312,9 @@ where
                                         "Queue is already full. Try again later.",
                                     ))
                                 }
+                                Err(scheduling::Error::UnsupportedResume) => {
+                                    Ok(ctx.response.not_implemented("Resuming task is currently not possible, please create a new scan excluding the finished hosts."))
+                                }
                                 Err(e) => Ok(ctx.response.internal_server_error(&e)),
                             }
                         }

--- a/rust/openvasd/src/response.rs
+++ b/rust/openvasd/src/response.rs
@@ -307,6 +307,13 @@ impl Response {
         self.create(hyper::StatusCode::BAD_REQUEST, &value)
     }
 
+    pub fn not_implemented<T>(&self, value: &T) -> Result
+    where
+        T: ?Sized + Serialize + std::fmt::Debug,
+    {
+        self.create(hyper::StatusCode::NOT_IMPLEMENTED, &value)
+    }
+
     pub fn service_unavailable<T>(&self, value: &T) -> Result
     where
         T: ?Sized + Serialize + std::fmt::Debug,


### PR DESCRIPTION

On scan start requests the internal data could get corrupted by updating the status of the scan, but might not be queued.
In addition we now sent a NOT IMPLEMENTED response when starting an stopped or failed scan.