### PR TITLE
Fix undelinking pcap library in nasl

### DIFF
--- a/RELICENSE/GFoti.md
+++ b/RELICENSE/GFoti.md
@@ -1,0 +1,80 @@
+Thank you for your interest in the project openvas-scanner managed by Greenbone.
+In order for you to make Contributions now or in the future to this
+project, You agree to license your Contributions under the MIT-0 license (see below).
+Please note that You remain the copyright owner, and anyone receives the right to
+use your Contribution in proprietary and open source software without any
+attribution.
+ 
+..................
+ 
+MIT No Attribution (MIT-0)
+ 
+Copyright <YEAR> <COPYRIGHT HOLDER>
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+.........................
+ 
+Please note that You remain the copyright owner, and anyone receives the
+right to use your Contribution in proprietary and open source software
+without attribution. However, we will include your name as a Contributor
+in our CREDITS list as long as your Contribution is used in the project
+openvas-scanner.
+ 
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is submitted by you
+to Greenbone for inclusion in the project openvas-scanner.
+ 
+Greenbone requires that each Contribution you submit now or in the
+future to comply with the following commitments documented in the
+Developer Certificate of Origin (DCO) [https://developercertificate.org/]:
+ 
+........
+ 
+Developer Certificate of Origin
+ 
+Version 1.1
+ 
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+ 
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+ 
+Developer's Certificate of Origin 1.1
+ 
+By making a contribution to this project, I certify that:
+ 
+(a) The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+ 
+(b) The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+ 
+(c) The contribution was provided directly to me by some other
+   person who certified (a), (b) or (c) and I have not modified
+   it.
+ 
+(d) I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.
+ 
+.....

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -188,7 +188,7 @@ set_target_properties (openvas_nasl_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 set_target_properties (openvas_nasl_shared PROPERTIES SOVERSION "${PROJECT_VERSION_MAJOR}")
 set_target_properties (openvas_nasl_shared PROPERTIES VERSION "${PROJECT_VERSION_STRING}")
 # line below is needed so it also works with no-undefined which is e.g. used by Mandriva
-target_link_libraries (openvas_nasl_shared openvas_misc_shared ${GLIB_LDFLAGS}
+target_link_libraries (openvas_nasl_shared openvas_misc_shared pcap ${GLIB_LDFLAGS}
                          ${LIBOPENVAS_MISC_LDFLAGS}
                          ${GLIB_JSON_LDFLAGS} 
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m


### PR DESCRIPTION
**What**:
Link pcap in openvas_nasl_shared

**Why**:
building openvas-scanner with clang as compiler and lld as a linker, and setting  --no-allow-shlib-undefined in LDFLAGS fails with the following error:

```
[71/87] : && /usr/lib/llvm/17/bin/clang -O2 -march=native -D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1                                 -std=c11                                 -Wall                                 -Wextra                                                                  -Wpedantic                                 -Wmissing-prototypes                                 -Wshadow                                 -Wsequence-point                                 -D_BSD_SOURCE                                 -D_ISOC11_SOURCE                                 -D_SVID_SOURCE                                 -D_DEFAULT_SOURCE -Wall -Wextra -fno-strict-aliasing -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -Wl,--no-allow-shlib-undefined -fuse-ld=lld    -rdynamic nasl/CMakeFiles/openvas-nasl.dir/nasl.c.o -o nasl/openvas-nasl  -Wl,-rpath,/var/tmp/portage/net-analyzer/openvas-scanner-23.0.1/work/openvas-scanner-23.0.1_build/nasl:/var/tmp/portage/net-analyzer/openvas-scanner-23.0.1/work/openvas-scanner-23.0.1_build/misc:  nasl/libopenvas_nasl.so.23.0.1  misc/libopenvas_misc.so.23.0.1  -L/usr/lib64  -lgnutls  -L/usr/lib64  -lssh  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lgcrypt -lgpg-error  -lgpgme  -lm  -lgvm_base  -lgvm_util  -lgnutls  -lssh  -lksba  -lgpg-error  -L/usr/lib64 -lnetsnmp -lm -lssl -lssl -lcrypto  -Wl,-z,relro -Wl,-z,now && :
FAILED: nasl/openvas-nasl 
: && /usr/lib/llvm/17/bin/clang -O2 -march=native -D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1                                 -std=c11                                 -Wall                                 -Wextra                                                                  -Wpedantic                                 -Wmissing-prototypes                                 -Wshadow                                 -Wsequence-point                                 -D_BSD_SOURCE                                 -D_ISOC11_SOURCE                                 -D_SVID_SOURCE                                 -D_DEFAULT_SOURCE -Wall -Wextra -fno-strict-aliasing -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -Wl,--no-allow-shlib-undefined -fuse-ld=lld    -rdynamic nasl/CMakeFiles/openvas-nasl.dir/nasl.c.o -o nasl/openvas-nasl  -Wl,-rpath,/var/tmp/portage/net-analyzer/openvas-scanner-23.0.1/work/openvas-scanner-23.0.1_build/nasl:/var/tmp/portage/net-analyzer/openvas-scanner-23.0.1/work/openvas-scanner-23.0.1_build/misc:  nasl/libopenvas_nasl.so.23.0.1  misc/libopenvas_misc.so.23.0.1  -L/usr/lib64  -lgnutls  -L/usr/lib64  -lssh  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lgcrypt -lgpg-error  -lgpgme  -lm  -lgvm_base  -lgvm_util  -lgnutls  -lssh  -lksba  -lgpg-error  -L/usr/lib64 -lnetsnmp -lm -lssl -lssl -lcrypto  -Wl,-z,relro -Wl,-z,now && :
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: pcap_findalldevs
>>> referenced by nasl/libopenvas_nasl.so.23.0.1
```
I tested this to compy with
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/-Wl,-z,defs_and_-Wl,--no-allow-shlib-undefined