### PR TITLE
Adjust scanner preferences

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -415,10 +415,8 @@ components:
         target:
           $ref: "#/components/schemas/Target"
         scan_preferences:
-          description: "Overwrite the default settings of the Scanner."
-          type: "array"
-          items:
-            $ref: "#/components/schemas/ScanPreference"
+          description: "Overwrite the default settings for a scan. Setting are id-value pairs."
+          type: "object"
         vts:
           type: "array"
           description: "A collection of VTs, which are run for the given target."
@@ -947,11 +945,11 @@ components:
               "reverse_lookup_only": false,
             },
           "scan_preferences":
-            [
-              { "id": "target_port", "value": "443" },
-              { "id": "use_https", "value": "1" },
-              { "id": "profile", "value": "fast_scan" },
-            ],
+            {
+              "target_port": 443,
+              "use_https": true,
+              "cgi_path": "/cgi-bin:/scripts",
+            },
           "vts":
             [
               {

--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -414,11 +414,11 @@ components:
       properties:
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
-            $ref: "#/components/schemas/ScannerPreference"
+            $ref: "#/components/schemas/ScanPreference"
         vts:
           type: "array"
           description: "A collection of VTs, which are run for the given target."
@@ -445,11 +445,11 @@ components:
           $ref: "#/components/schemas/ScanID"
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
-            $ref: "#/components/schemas/ScannerPreference"
+            $ref: "#/components/schemas/ScanPreference"
         vts:
           type: "array"
           description: "A collection of VTs, which are run for the given target."
@@ -634,7 +634,7 @@ components:
             - aes
             - des
 
-    ScannerPreference:
+    ScanPreference:
       description: "Consists of a preference ID and its value."
       type: "object"
       properties:
@@ -897,10 +897,7 @@ components:
                   "2002::1234:abcd:ffff:c0a8:101/64",
                   "examplehost",
                 ],
-              "excluded_hosts":
-                [
-                  "192.168.0.14"
-                ],
+              "excluded_hosts": ["192.168.0.14"],
               "ports":
                 [
                   {
@@ -949,7 +946,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },
@@ -1030,7 +1027,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },

--- a/rust/doc/reverse-sensor-openapi.yml
+++ b/rust/doc/reverse-sensor-openapi.yml
@@ -152,22 +152,22 @@ paths:
       parameters:
         - $ref: "#/components/parameters/ScanID"
       requestBody:
-          description: "The new status"
-          content:
-            application/json:
+        description: "The new status"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Status"
+            examples:
               schema:
-                $ref: "#/components/schemas/Status"
-              examples:
-                schema:
-                  description: "Schema of a status response."
-                status of a stored scan:
-                  $ref: "#/components/examples/scan_status_stored"
-                status of a running scan:
-                  $ref: "#/components/examples/scan_status_running"
-                status of a succeeded scan:
-                  $ref: "#/components/examples/scan_status_success"
-                status of a failed scan:
-                  $ref: "#/components/examples/scan_status_fail"
+                description: "Schema of a status response."
+              status of a stored scan:
+                $ref: "#/components/examples/scan_status_stored"
+              status of a running scan:
+                $ref: "#/components/examples/scan_status_running"
+              status of a succeeded scan:
+                $ref: "#/components/examples/scan_status_success"
+              status of a failed scan:
+                $ref: "#/components/examples/scan_status_fail"
       responses:
         "204":
           description: "Status received"
@@ -228,11 +228,11 @@ components:
           $ref: "#/components/schemas/ScanID"
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
-            $ref: "#/components/schemas/ScannerPreference"
+            $ref: "#/components/schemas/ScanPreference"
         vts:
           type: "array"
           description: "A collection of VTs, which are run for the given target."
@@ -396,7 +396,7 @@ components:
             - aes
             - des
 
-    ScannerPreference:
+    ScanPreference:
       description: "Consists of a preference ID and its value."
       type: "object"
       properties:
@@ -573,14 +573,10 @@ components:
       items:
         $ref: "#/components/schemas/ScanAction"
 
-
   examples:
     sensor_simple:
       description: "A simple example for sensor."
-      value:
-        {
-          "sensor_id": "6c591f83-8f7b-452a-8c78-ba35779e682f"
-        }
+      value: { "sensor_id": "6c591f83-8f7b-452a-8c78-ba35779e682f" }
     scan_simple:
       description: "A simple example for creating a scan."
       value:
@@ -656,7 +652,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },
@@ -677,19 +673,20 @@ components:
       value: "6c591f83-8f7b-452a-8c78-ba35779e682f"
     scan_actions:
       description: "Actions to perform"
-      value: [
+      value:
+        [
           {
             "scan_id": "6c591f83-8f7b-452a-8c78-ba35779e682f",
-            "action": "start"
+            "action": "start",
           },
           {
             "scan_id": "24591f83-8f7b-452a-8c78-ba35779e6816",
-            "action": "stop"
+            "action": "stop",
           },
           {
             "scan_id": "13591f83-8f74-45da-8c7d-ba35779e682a",
-            "action": "delete"
-          }
+            "action": "delete",
+          },
         ]
 
     scan_results:

--- a/rust/doc/reverse-sensor-openapi.yml
+++ b/rust/doc/reverse-sensor-openapi.yml
@@ -229,10 +229,8 @@ components:
         target:
           $ref: "#/components/schemas/Target"
         scan_preferences:
-          description: "Overwrite the default settings of the Scanner."
-          type: "array"
-          items:
-            $ref: "#/components/schemas/ScanPreference"
+          description: "Overwrite the default settings for a scan. Setting are id-value pairs."
+          type: "object"
         vts:
           type: "array"
           description: "A collection of VTs, which are run for the given target."
@@ -653,11 +651,11 @@ components:
               "reverse_lookup_only": false,
             },
           "scan_preferences":
-            [
-              { "id": "target_port", "value": "443" },
-              { "id": "use_https", "value": "1" },
-              { "id": "profile", "value": "fast_scan" },
-            ],
+            {
+              "target_port": 443,
+              "use_https": true,
+              "cgi_path": "/cgi-bin:/scripts",
+            },
           "vts":
             [
               {

--- a/rust/models/src/lib.rs
+++ b/rust/models/src/lib.rs
@@ -11,8 +11,8 @@ mod product;
 mod result;
 mod scan;
 mod scan_action;
+mod scan_preference;
 pub mod scanner;
-mod scanner_preference;
 mod status;
 mod target;
 mod vt;
@@ -26,7 +26,7 @@ pub use product::*;
 pub use result::*;
 pub use scan::*;
 pub use scan_action::*;
-pub use scanner_preference::*;
+pub use scan_preference::*;
 pub use status::*;
 pub use target::*;
 pub use vt::*;
@@ -137,7 +137,7 @@ mod tests {
     "reverse_lookup_unify": true,
     "reverse_lookup_only": false
   },
-  "scanner_preferences": [
+  "scan_preferences": [
     {
       "id": "target_port",
       "value": "443"

--- a/rust/models/src/lib.rs
+++ b/rust/models/src/lib.rs
@@ -137,20 +137,11 @@ mod tests {
     "reverse_lookup_unify": true,
     "reverse_lookup_only": false
   },
-  "scan_preferences": [
-    {
-      "id": "target_port",
-      "value": "443"
-    },
-    {
-      "id": "use_https",
-      "value": "1"
-    },
-    {
-      "id": "profile",
-      "value": "fast_scan"
-    }
-  ],
+  "scan_preferences": {
+    "target_port": 443,
+    "use_https": true,
+    "cgi_path": "/cgi-bin:/scripts"
+  },
   "vts": [
     {
       "oid": "1.3.6.1.4.1.25623.1.0.10662",

--- a/rust/models/src/scan.rs
+++ b/rust/models/src/scan.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use super::{scan_preference::ScanPreference, target::Target, vt::VT};
+use std::collections::HashMap;
+
+use super::{scan_preference::PreferenceValue, target::Target, vt::VT};
 
 /// Struct for creating and getting a scan
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -22,7 +24,7 @@ pub struct Scan {
         serde(default, alias = "scanner_preferences")
     )]
     /// Configuration options for the scanner
-    pub scan_preferences: Vec<ScanPreference>,
+    pub scan_preferences: HashMap<String, PreferenceValue>,
     /// List of VTs to execute for the target
     pub vts: Vec<VT>,
 }

--- a/rust/models/src/scan.rs
+++ b/rust/models/src/scan.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use super::{scanner_preference::ScannerPreference, target::Target, vt::VT};
+use super::{scan_preference::ScanPreference, target::Target, vt::VT};
 
 /// Struct for creating and getting a scan
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -17,9 +17,12 @@ pub struct Scan {
     pub scan_id: String,
     /// Information about the target to scan
     pub target: Target,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[cfg_attr(
+        feature = "serde_support",
+        serde(default, alias = "scanner_preferences")
+    )]
     /// Configuration options for the scanner
-    pub scanner_preferences: Vec<ScannerPreference>,
+    pub scan_preferences: Vec<ScanPreference>,
     /// List of VTs to execute for the target
     pub vts: Vec<VT>,
 }

--- a/rust/models/src/scan_preference.rs
+++ b/rust/models/src/scan_preference.rs
@@ -2,15 +2,33 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/// Configuration preference for the scanner
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+use std::fmt::Display;
+
+/// Preference value
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
+    derive(serde::Serialize, serde::Deserialize),
+    serde(untagged)
 )]
-pub struct ScanPreference {
-    /// The ID of the scanner preference.
-    pub id: String,
-    /// The value of the scanner preference.
-    pub value: String,
+pub enum PreferenceValue {
+    Bool(bool),
+    Int(i64),
+    String(String),
+}
+
+impl Default for PreferenceValue {
+    fn default() -> Self {
+        Self::Int(0)
+    }
+}
+
+impl Display for PreferenceValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PreferenceValue::Bool(v) => write!(f, "{v}"),
+            PreferenceValue::Int(v) => write!(f, "{v}"),
+            PreferenceValue::String(v) => write!(f, "{v}"),
+        }
+    }
 }

--- a/rust/models/src/scan_preference.rs
+++ b/rust/models/src/scan_preference.rs
@@ -8,7 +8,7 @@
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
 )]
-pub struct ScannerPreference {
+pub struct ScanPreference {
     /// The ID of the scanner preference.
     pub id: String,
     /// The value of the scanner preference.

--- a/rust/openvas/src/pref_handler.rs
+++ b/rust/openvas/src/pref_handler.rs
@@ -342,7 +342,7 @@ where
             .scan_preferences
             .clone()
             .iter()
-            .map(|x| format!("{}|||{}", x.id, x.value))
+            .map(|x| format!("{}|||{}", x.0, x.1))
             .collect::<Vec<String>>();
 
         if options.is_empty() {

--- a/rust/openvas/src/pref_handler.rs
+++ b/rust/openvas/src/pref_handler.rs
@@ -339,7 +339,7 @@ where
     async fn prepare_scan_params_for_openvas(&mut self) -> RedisStorageResult<()> {
         let options = self
             .scan_config
-            .scanner_preferences
+            .scan_preferences
             .clone()
             .iter()
             .map(|x| format!("{}|||{}", x.id, x.value))

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -13,6 +13,7 @@ pub mod controller;
 pub mod crypt;
 pub mod feed;
 pub mod notus;
+pub mod preference;
 pub mod request;
 pub mod response;
 mod scheduling;

--- a/rust/osp/src/commands.rs
+++ b/rust/osp/src/commands.rs
@@ -181,14 +181,14 @@ fn write_vts(scan: &Scan, writer: &mut Writer) -> Result<()> {
     })
 }
 
-// In the openvasd API it is called scanner preferences while in the OSP side
+// In the openvasd API it is called scan preferences while in the OSP side
 // it is called scanner parameters.
 fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     writer.write_event(Event::Start(BytesStart::new("scanner_params")))?;
     for p in &scan.scan_preferences {
-        writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
-        writer.write_event(Event::Text(BytesText::new(&p.value)))?;
-        writer.write_event(Event::End(BytesEnd::new(&p.id)))?;
+        writer.write_event(Event::Start(BytesStart::new(p.0)))?;
+        writer.write_event(Event::Text(BytesText::new(p.1.to_string().as_str())))?;
+        writer.write_event(Event::End(BytesEnd::new(p.0)))?;
     }
 
     writer.write_event(Event::End(BytesEnd::new("scanner_params")))?;

--- a/rust/osp/src/commands.rs
+++ b/rust/osp/src/commands.rs
@@ -185,7 +185,7 @@ fn write_vts(scan: &Scan, writer: &mut Writer) -> Result<()> {
 // it is called scanner parameters.
 fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     writer.write_event(Event::Start(BytesStart::new("scanner_params")))?;
-    for p in &scan.scanner_preferences {
+    for p in &scan.scan_preferences {
         writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
         writer.write_event(Event::Text(BytesText::new(&p.value)))?;
         writer.write_event(Event::End(BytesEnd::new(&p.id)))?;


### PR DESCRIPTION
This PR contains two changes to the API:
1. Rename scanner_preferences to scan_preferences within the Scan json
2. Change the contents of scan_preferences to a json dict instead of an array of id-value pairs

This PR should be merged for the next major release.

Jira: SC-1040