### PR TITLE
Fix: openvasd endpoint /vts?information=1

### DIFF
--- a/rust/openvasd/src/scheduling.rs
+++ b/rust/openvasd/src/scheduling.rs
@@ -497,7 +497,7 @@ where
     async fn vts<'a>(
         &self,
     ) -> Result<Box<dyn Iterator<Item = storage::item::Nvt> + Send + 'a>, StorageError> {
-        self.vts().await
+        self.db.vts().await
     }
 
     async fn vt_by_oid(&self, oid: &str) -> Result<Option<storage::item::Nvt>, StorageError> {


### PR DESCRIPTION
Instead of getting VT information from the db, the function called itself which caused a stack overflow
Jira: SC-1051