### PR TITLE
Fix: openvas-nasl can not read KB when forking

### DIFF
--- a/misc/plugutils.c
+++ b/misc/plugutils.c
@@ -1207,6 +1207,12 @@ plug_get_key (struct script_infos *args, char *name, int *type, size_t *len,
       res = res->next;
     }
   kb_item_free (res_list);
+
+  // Allow to return to the main process if parent process is openvas-nasl.
+  // So, the main process can do e.g. a kb clean up
+  if (args->standalone)
+    return NULL;
+
   _exit (0);
 }
 

--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -330,6 +330,7 @@ main (int argc, char **argv)
       struct in6_addr ip6;
       kb_t kb;
       int rc;
+      int process_id;
 
       if (prefs_get_bool ("expand_vhosts"))
         gvm_host_add_reverse_lookup (host);
@@ -341,6 +342,8 @@ main (int argc, char **argv)
         exit (1);
 
       set_main_kb (kb);
+      process_id = getpid ();
+
       script_infos = init (&ip6, host->vhosts, kb);
       for (int i = 0; nasl_filenames[i] != NULL; i++)
         {
@@ -386,6 +389,10 @@ main (int argc, char **argv)
         }
       g_free (script_infos->globals);
       g_free (script_infos);
+
+      if (process_id != getpid ())
+        exit (0);
+
       kb_delete (kb);
     }
 


### PR DESCRIPTION
**What**:
Fix: openvas-nasl can not read KB when forking
Jira: SC-1052

Allows the parent process to return to main function and perform a kb cleanup. All children processes return as well, but they can't cleanup the kb, since it could be still in use by other fork()ed child.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The first child process after forking, performs a clean up of the kb. This should not happen, and all children should access the kb.
The main process is the one which cleans the kb after all children finished.
<!-- Why are these changes necessary? -->

**How**:
For testing, write a nasl script which set a key with many items. Then, using `get_kb_item()` (it forks a new process for each iteam) check the results.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
