### PR TITLE
Add: notus support for windows

### DIFF
--- a/rust/models/src/product.rs
+++ b/rust/models/src/product.rs
@@ -27,6 +27,8 @@ pub enum PackageType {
     RPM,
     #[cfg_attr(feature = "serde_support", serde(rename = "slack"))]
     SLACK,
+    #[cfg_attr(feature = "serde_support", serde(rename = "msp"))]
+    MSP,
 }
 
 /// Representing a single Vulnerability Test entry

--- a/rust/notus/src/notus.rs
+++ b/rust/notus/src/notus.rs
@@ -170,6 +170,7 @@ where
             Product::EBuild(adv) => Self::parse_and_compare(packages, adv)?,
             Product::Rpm(adv) => Self::parse_and_compare(packages, adv)?,
             Product::Slack(adv) => Self::parse_and_compare(packages, adv)?,
+            Product::Windows(adv) => Self::parse_and_compare(packages, adv)?,
         };
 
         Ok(results)

--- a/rust/notus/src/packages/mod.rs
+++ b/rust/notus/src/packages/mod.rs
@@ -6,6 +6,7 @@ pub mod deb;
 pub mod ebuild;
 pub mod rpm;
 pub mod slack;
+pub mod windows;
 
 use lazy_regex::{lazy_regex, Lazy, Regex};
 use std::cmp::{max, Ordering};

--- a/rust/notus/src/packages/windows.rs
+++ b/rust/notus/src/packages/windows.rs
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2023 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use super::{Package, PackageVersion};
+use std::cmp::Ordering;
+
+/// Represent a based Windows package
+#[derive(Debug, PartialEq, Clone)]
+pub struct Windows {
+    full_name: String,
+    build: String,
+    revision: PackageVersion,
+}
+
+impl PartialOrd for Windows {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self.build != other.build {
+            return None;
+        }
+
+        if self.full_name == other.full_name {
+            return Some(Ordering::Equal);
+        }
+
+        self.revision.partial_cmp(&other.revision)
+    }
+}
+
+impl Package for Windows {
+    fn from_full_name(full_name: &str) -> Option<Self> {
+        if full_name.is_empty() {
+            return None;
+        }
+        let full_name = full_name.trim();
+
+        // Get all fields
+        let (build, revision) = match full_name.rsplit_once('.') {
+            Some((b, r)) => (b, r),
+            None => {
+                return None;
+            }
+        };
+        Some(Windows {
+            full_name: full_name.to_string(),
+            build: build.to_string(),
+            revision: PackageVersion(revision.to_string()),
+        })
+    }
+
+    fn from_name_and_full_version(name: &str, full_version: &str) -> Option<Self> {
+        if name.is_empty() || full_version.is_empty() {
+            return None;
+        }
+
+        let name = name.trim();
+        let revision = full_version.trim();
+
+        // Get all fields
+        let mut full_name = name.to_string();
+        full_name.push('.');
+        full_name.push_str(full_version);
+
+        Some(Windows {
+            full_name,
+            build: name.to_string(),
+            revision: PackageVersion(revision.to_string()),
+        })
+    }
+
+    fn get_name(&self) -> String {
+        self.build.clone()
+    }
+
+    fn get_version(&self) -> String {
+        self.revision.0.clone()
+    }
+}
+
+#[cfg(test)]
+mod slack_tests {
+    use super::Package;
+    use super::Windows;
+    use crate::packages::PackageVersion;
+
+    #[test]
+    pub fn test_compare_gt() {
+        let package1 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3447".to_string(),
+            revision: PackageVersion("3447".to_string()),
+        };
+        let package2 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3449".to_string(),
+            revision: PackageVersion("3449".to_string()),
+        };
+        assert!(package2 > package1);
+    }
+
+    #[test]
+    pub fn test_compare_gt_different_name() {
+        let package1 = Windows {
+            build: "11.0.22631".to_string(),
+            full_name: "10.0.22631.3447".to_string(),
+            revision: PackageVersion("3447".to_string()),
+        };
+        let package2 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3449".to_string(),
+            revision: PackageVersion("3449".to_string()),
+        };
+
+        assert!(package2.partial_cmp(&package1).is_none());
+        assert!(package1.partial_cmp(&package2).is_none());
+    }
+
+    #[test]
+    pub fn test_compare_less() {
+        let package1 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3447".to_string(),
+            revision: PackageVersion("3447".to_string()),
+        };
+        let package2 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3449".to_string(),
+            revision: PackageVersion("3449".to_string()),
+        };
+        assert!(package1 < package2);
+    }
+
+    #[test]
+    pub fn test_compare_equal() {
+        let package1 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3447".to_string(),
+            revision: PackageVersion("3447".to_string()),
+        };
+        let package2 = Windows {
+            build: "10.0.22631".to_string(),
+            full_name: "10.0.22631.3447".to_string(),
+            revision: PackageVersion("3447".to_string()),
+        };
+        assert!(package1 == package2);
+    }
+
+    #[test]
+    pub fn test_from_full_name() {
+        assert!(Windows::from_full_name("").is_none());
+
+        let package = Windows::from_full_name("10.0.22631.3447").unwrap();
+        assert_eq!(package.build, "10.0.22631");
+        assert_eq!(package.full_name, "10.0.22631.3447");
+        assert_eq!(package.revision, PackageVersion("3447".to_string()));
+    }
+
+    #[test]
+    pub fn test_from_name_and_full_version() {
+        assert!(Windows::from_name_and_full_version("", "").is_none());
+
+        let package = Windows::from_name_and_full_version("10.0.22631", "3447").unwrap();
+        assert_eq!(package.build, "10.0.22631");
+        assert_eq!(package.full_name, "10.0.22631.3447");
+        assert_eq!(package.revision, PackageVersion("3447".to_string()));
+    }
+}

--- a/rust/notus/src/vts.rs
+++ b/rust/notus/src/vts.rs
@@ -8,7 +8,7 @@ use models::{FixedPackage, FixedVersion, Specifier};
 
 use crate::{
     error::Error,
-    packages::{deb::Deb, ebuild::EBuild, rpm::Rpm, slack::Slack, Package},
+    packages::{deb::Deb, ebuild::EBuild, rpm::Rpm, slack::Slack, windows::Windows, Package},
 };
 
 /// VulnerabilityTests is a collection of Tests to detect vulnerabilities, in case of notus these
@@ -23,6 +23,7 @@ pub enum Product {
     EBuild(VulnerabilityTests<EBuild>),
     Rpm(VulnerabilityTests<Rpm>),
     Slack(VulnerabilityTests<Slack>),
+    Windows(VulnerabilityTests<Windows>),
 }
 
 impl Product {
@@ -82,6 +83,10 @@ impl TryFrom<models::Product> for Product {
             models::PackageType::SLACK => {
                 let vts = Self::transform(value.vulnerability_tests)?;
                 Ok(Self::Slack(vts))
+            }
+            models::PackageType::MSP => {
+                let vts = Self::transform(value.vulnerability_tests)?;
+                Ok(Self::Windows(vts))
             }
         }
     }


### PR DESCRIPTION
**What**:
Add: notus support for windows
Jira: SC-1066

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Create notus product and advisory files for windows. 
Add the sha256 sum to the file. You have to set the signature check to `false`.

Reload the feed and check if windows is supported. 
`curl --verbose --insecure --request GET https://127.0.0.1:3000/notus -H "X-API-KEY: changeme" |jq . |grep win `

Test notus with (build numbers are examples which match with the products and advisories I used for testing):
```curl --verbose --insecure --request POST https://127.0.0.1:3000/notus/windows_11_home -H "X-API-KEY: changeme" -d '["11.0.22632.3446", "11.0.22631.233"]' |jq .```




<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
