### PR TITLE
Fix: OpenVASD: add path on hashsum failure

### DIFF
--- a/rust/openvasd/src/controller/feed.rs
+++ b/rust/openvasd/src/controller/feed.rs
@@ -28,9 +28,11 @@ async fn changed_hash(signature_check: bool, feeds: &[FeedHash]) -> Result<Vec<F
         }
 
         let path = h.path.clone();
-        let hash = tokio::task::spawn_blocking(move || match FeedIdentifier::sumfile_hash(path) {
+        let hash = tokio::task::spawn_blocking(move || match FeedIdentifier::sumfile_hash(&path) {
             Ok(h) => h,
-            Err(e) => {
+            Err(mut e) => {
+                e.key = path.to_str().unwrap_or_default().to_string();
+
                 tracing::warn!(%e, "Failed to compute sumfile hash");
                 "".to_string()
             }


### PR DESCRIPTION
Adds the path to the erreor as a key when hash sum verification for
sha256sums fails.
