### PR TITLE
Fix: rename scanner_preference to scan_preference

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -431,7 +431,7 @@ components:
       properties:
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
@@ -462,7 +462,7 @@ components:
           $ref: "#/components/schemas/ScanID"
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
@@ -990,7 +990,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },
@@ -1071,7 +1071,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },

--- a/rust/doc/reverse-sensor-openapi.yml
+++ b/rust/doc/reverse-sensor-openapi.yml
@@ -249,7 +249,7 @@ components:
           $ref: "#/components/schemas/ScanID"
         target:
           $ref: "#/components/schemas/Target"
-        scanner_preferences:
+        scan_preferences:
           description: "Overwrite the default settings of the Scanner."
           type: "array"
           items:
@@ -697,7 +697,7 @@ components:
               "reverse_lookup_unify": true,
               "reverse_lookup_only": false,
             },
-          "scanner_preferences":
+          "scan_preferences":
             [
               { "id": "target_port", "value": "443" },
               { "id": "use_https", "value": "1" },

--- a/rust/models/src/lib.rs
+++ b/rust/models/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
     "reverse_lookup_unify": true,
     "reverse_lookup_only": false
   },
-  "scanner_preferences": [
+  "scan_preferences": [
     {
       "id": "target_port",
       "value": "443"

--- a/rust/models/src/scan.rs
+++ b/rust/models/src/scan.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use super::{scanner_preference::ScannerPreference, target::Target, vt::VT};
+use super::{scanner_preference::ScanPreference, target::Target, vt::VT};
 
 /// Struct for creating and getting a scan
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -17,9 +17,12 @@ pub struct Scan {
     pub scan_id: String,
     /// Information about the target to scan
     pub target: Target,
-    #[cfg_attr(feature = "serde_support", serde(default))]
-    /// Configuration options for the scanner
-    pub scanner_preferences: Vec<ScannerPreference>,
+    #[cfg_attr(
+        feature = "serde_support",
+        serde(default, alias = "scanner_preferences")
+    )]
+    /// Configuration options for a scan
+    pub scan_preferences: Vec<ScanPreference>,
     /// List of VTs to execute for the target
     pub vts: Vec<VT>,
 }

--- a/rust/models/src/scanner_preference.rs
+++ b/rust/models/src/scanner_preference.rs
@@ -8,10 +8,10 @@
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
 )]
-pub struct ScannerPreference {
-    /// The ID of the scanner preference.
+pub struct ScanPreference {
+    /// The ID of a scan preference.
     pub id: String,
-    /// The value of the scanner preference.
+    /// The value of the scan preference.
     pub value: String,
 }
 

--- a/rust/openvas/src/pref_handler.rs
+++ b/rust/openvas/src/pref_handler.rs
@@ -339,7 +339,7 @@ where
     async fn prepare_scan_params_for_openvas(&mut self) -> RedisStorageResult<()> {
         let options = self
             .scan_config
-            .scanner_preferences
+            .scan_preferences
             .clone()
             .iter()
             .map(|x| format!("{}|||{}", x.id, x.value))

--- a/rust/osp/src/commands.rs
+++ b/rust/osp/src/commands.rs
@@ -185,7 +185,7 @@ fn write_vts(scan: &Scan, writer: &mut Writer) -> Result<()> {
 // it is called scanner parameters.
 fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     writer.write_event(Event::Start(BytesStart::new("scanner_params")))?;
-    for p in &scan.scanner_preferences {
+    for p in &scan.scan_preferences {
         writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
         writer.write_event(Event::Text(BytesText::new(&p.value)))?;
         writer.write_event(Event::End(BytesEnd::new(&p.id)))?;


### PR DESCRIPTION
As preferences are set per scan, this name is more convenient. For now the renaming is backwards compatible.

Jira: SC-1040