### PR TITLE
CI: use GREENBONE_BOT_TOKEN instead of GITHUB_TOKEN for release

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -124,7 +124,7 @@ jobs:
       project: ${{ needs.init.outputs.release_project }}
       repository: ${{ github.repository }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GREENBONE_BOT_TOKEN }}
       name: ${{ secrets.GREENBONE_BOT }}
       email: ${{ secrets.GREENBONE_BOT_MAIL }}
       gpg_key: ${{ secrets.GPG_KEY }}


### PR DESCRIPTION
To circumvent protected branch rules use the GREENBONE_BOT_TOKEN instead
of the more flexible GITHUB_TOKEN.
