### PR TITLE
Fix: nasl-interpreter: string handling in operation

### DIFF
--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -115,8 +115,7 @@ where
                 NaslValue::Data(x) => {
                     let right: String = b.map(|x| x.to_string()).unwrap_or_default();
                     let x: String = x.into_iter().map(|b| b as char).collect();
-                    // TODO: wrong return value, should be data
-                    Ok(NaslValue::String(format!("{x}{right}")))
+                    Ok(NaslValue::Data(format!("{x}{right}").into()))
                 }
                 // on plus only we need to cast to string when right is a string
                 left => match b {
@@ -134,7 +133,7 @@ where
                 NaslValue::Data(x) => {
                     let right: String = b.map(|x| x.to_string()).unwrap_or_default();
                     let x: String = x.into_iter().map(|b| b as char).collect();
-                    Ok(NaslValue::String(x.replacen(&right, "", 1)))
+                    Ok(NaslValue::Data(x.replacen(&right, "", 1).into()))
                 }
                 left => match b {
                     Some(NaslValue::String(_)) => {
@@ -276,8 +275,8 @@ mod tests {
         cast_to_string_minus: "11-\"1\";" => "1".into(),
         string_plus: "\"hello \" + \"world!\";" => "hello world!".into(),
         string_minus : "\"hello \" - 'o ';" => "hell".into(),
-        data_plus: "'hello ' + 'world!';" => "hello world!".into(),
-        data_minus: "'hello ' - 'o ';" => "hell".into(),
+        data_plus: "'hello ' + 'world!';" => "hello world!".as_bytes().into(),
+        data_minus: "'hello ' - 'o ';" => "hell".as_bytes().into(),
         numeric_minus : "1 - 2;" => NaslValue::Number(-1),
         multiplication: "1*2;" => 2.into(),
         division: "512/2;" => 256.into(),

--- a/rust/nasl-syntax/src/naslvalue.rs
+++ b/rust/nasl-syntax/src/naslvalue.rs
@@ -103,6 +103,12 @@ impl Display for NaslValue {
     }
 }
 
+impl From<&[u8]> for NaslValue {
+    fn from(value: &[u8]) -> Self {
+        value.to_vec().into()
+    }
+}
+
 impl From<Vec<u8>> for NaslValue {
     fn from(s: Vec<u8>) -> Self {
         Self::Data(s)

--- a/rust/nasl-syntax/src/naslvalue.rs
+++ b/rust/nasl-syntax/src/naslvalue.rs
@@ -157,6 +157,28 @@ impl From<HashMap<String, NaslValue>> for NaslValue {
     }
 }
 
+impl From<NaslValue> for Vec<u8> {
+    fn from(value: NaslValue) -> Self {
+        match value {
+            NaslValue::String(x) => x.into(),
+            NaslValue::Data(x) => x,
+            NaslValue::Array(x) => x
+                .iter()
+                .flat_map(<&NaslValue as Into<Vec<u8>>>::into)
+                .collect(),
+            NaslValue::Boolean(_) | NaslValue::Number(_) | NaslValue::Dict(_) => {
+                value.to_string().as_bytes().into()
+            }
+            NaslValue::AttackCategory(_)
+            | NaslValue::Null
+            | NaslValue::Return(_)
+            | NaslValue::Continue
+            | NaslValue::Break
+            | NaslValue::Exit(_) => vec![],
+        }
+    }
+}
+
 impl From<NaslValue> for bool {
     fn from(value: NaslValue) -> Self {
         match value {

--- a/rust/openvasd/src/main.rs
+++ b/rust/openvasd/src/main.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             let redis_url = openvas::cmd::get_redis_socket();
             if redis_url != config.storage.redis.url {
                 tracing::warn!(openvas_redis=&redis_url, openvasd_redis=&config.storage.redis.url, "openvas and openvasd use different redis connection. Overriding openvasd#storage.redis.url");
-                config.storage.redis.url = redis_url.clone();
+                config.storage.redis.url.clone_from(&redis_url);
             }
             run(
                 openvas::Scanner::new(


### PR DESCRIPTION
When a string is added to a number, the number should be casted to a
string and not the string to number.

For example: 1 + "" + 3 should return "13" and not 5.

SC-1083