### PR TITLE
Fix:  typo in mktime.md. Linked issue: 1645

### DIFF
--- a/doc/manual/nasl/built-in-functions/misc/mktime.md
+++ b/doc/manual/nasl/built-in-functions/misc/mktime.md
@@ -13,18 +13,19 @@
 ## DESCRIPTION
 
 Takes:
+
 - `sec` - seconds 0-60
-- `min` - mintues 0-60
+- `min` - minutes 0-60
 - `hour` - hour 0-23
 - `mday` - day of the month 0-31
 - `mon` - month 1-12
-- `year` - year four digits 
+- `year` - year four digits
 - `isdst` A flag that indicates whether daylight saving time is in effect at the time described.
 
 Transforms those into the Unix time.
 
-
 ## RETURN VALUE
+
 Returns a Unix time (the number of seconds since 1970-01-01).
 
 ## Error


### PR DESCRIPTION
**What**:

Fixes typo in doc/manual/nasl/built-in-funtions/misc/mktime.md:17

**Why**:

I was scrapping data for inhouse project purposes and found this typo.

**How**:

Simple fix typo task

**Checklist**:
N/A
