### PR TITLE
Fix underlink curl

### DIFF
--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -188,7 +188,7 @@ set_target_properties (openvas_nasl_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 set_target_properties (openvas_nasl_shared PROPERTIES SOVERSION "${PROJECT_VERSION_MAJOR}")
 set_target_properties (openvas_nasl_shared PROPERTIES VERSION "${PROJECT_VERSION_STRING}")
 # line below is needed so it also works with no-undefined which is e.g. used by Mandriva
-target_link_libraries (openvas_nasl_shared openvas_misc_shared pcap ${GLIB_LDFLAGS}
+target_link_libraries (openvas_nasl_shared openvas_misc_shared curl pcap ${GLIB_LDFLAGS}
                          ${LIBOPENVAS_MISC_LDFLAGS}
                          ${GLIB_JSON_LDFLAGS} 
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m

--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -172,7 +172,7 @@ add_definitions (-DOPENVAS_GPG_BASE_DIR="${OPENVAS_GPG_BASE_DIR}")
 
 include_directories (${GLIB_INCLUDE_DIRS}
                      ${LIBOPENVAS_MISC_INCLUDE_DIRS}
-                     ${GLIB_JSON_INCLUDE_DIRS} 
+                     ${GLIB_JSON_INCLUDE_DIRS}
                      ${GPGME_INCLUDE_DIRS}
                      ${LIBSSH_INCLUDE_DIRS}
                      ${LIBGVM_BASE_INCLUDE_DIRS}
@@ -181,7 +181,7 @@ include_directories (${GLIB_INCLUDE_DIRS}
                      ${GCRYPT_INCLUDE_DIRS})
 
 
-# Build shared 
+# Build shared
 add_library (openvas_nasl_shared SHARED ${FILES})
 set_target_properties (openvas_nasl_shared PROPERTIES OUTPUT_NAME "openvas_nasl")
 set_target_properties (openvas_nasl_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
@@ -190,7 +190,7 @@ set_target_properties (openvas_nasl_shared PROPERTIES VERSION "${PROJECT_VERSION
 # line below is needed so it also works with no-undefined which is e.g. used by Mandriva
 target_link_libraries (openvas_nasl_shared openvas_misc_shared curl pcap ${GLIB_LDFLAGS}
                          ${LIBOPENVAS_MISC_LDFLAGS}
-                         ${GLIB_JSON_LDFLAGS} 
+                         ${GLIB_JSON_LDFLAGS}
                          ${GCRYPT_LDFLAGS} ${GPGME_LDFLAGS} m
                          ${LIBGVM_BASE_LDFLAGS}
                          ${LIBGVM_UTIL_LDFLAGS}
@@ -219,5 +219,5 @@ install (FILES ${CMAKE_SOURCE_DIR}/doc/man/openvas-nasl.1
          DESTINATION ${DATADIR}/man/man1 )
 
 install (FILES ${CMAKE_SOURCE_DIR}/doc/man/openvas-nasl-lint.1
-         DESTINATION ${DATADIR}/man/man1 )   
+         DESTINATION ${DATADIR}/man/man1 )
 ## End


### PR DESCRIPTION
**What**:

Link curl in openvas_nasl_shared

**Why**:

building openvas-scanner with clang as compiler and lld as a linker, and setting --no-allow-shlib-undefined in LDFLAGS fails with the following error:
```
[72/88] : && /usr/lib/llvm/17/bin/clang -O2 -march=native -D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1                                 -std=c11                                 -Wall                                 -Wextra                                                                  -Wpedantic                                 -Wmissing-prototypes                                 -Wshadow                                 -Wsequence-point                                 -D_BSD_SOURCE                                 -D_ISOC11_SOURCE                                 -D_SVID_SOURCE                                 -D_DEFAULT_SOURCE -Wall -Wextra -fno-strict-aliasing -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -fuse-ld=lld -Wl,--no-allow-shlib-undefined    -rdynamic nasl/CMakeFiles/openvas-nasl.dir/nasl.c.o -o nasl/openvas-nasl  -Wl,-rpath,/var/tmp/portage/net-analyzer/openvas-scanner-23.3.0/work/openvas-scanner-23.3.0_build/nasl:/var/tmp/portage/net-analyzer/openvas-scanner-23.3.0/work/openvas-scanner-23.3.0_build/misc:  nasl/libopenvas_nasl.so.23.3.0  misc/libopenvas_misc.so.23.3.0  -L/usr/lib64  -lgnutls  -L/usr/lib64  -lssh  -lpcap  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lgcrypt -lgpg-error  -lgpgme  -lm  -lgvm_base  -lgvm_util  -lgnutls  -lssh  -lksba  -lgpg-error  -L/usr/lib64 -lnetsnmp -lm -lssl -lssl -lcrypto  -Wl,-z,relro -Wl,-z,now && :
FAILED: nasl/openvas-nasl 
: && /usr/lib/llvm/17/bin/clang -O2 -march=native -D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1                                 -std=c11                                 -Wall                                 -Wextra                                                                  -Wpedantic                                 -Wmissing-prototypes                                 -Wshadow                                 -Wsequence-point                                 -D_BSD_SOURCE                                 -D_ISOC11_SOURCE                                 -D_SVID_SOURCE                                 -D_DEFAULT_SOURCE -Wall -Wextra -fno-strict-aliasing -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -fuse-ld=lld -Wl,--no-allow-shlib-undefined    -rdynamic nasl/CMakeFiles/openvas-nasl.dir/nasl.c.o -o nasl/openvas-nasl  -Wl,-rpath,/var/tmp/portage/net-analyzer/openvas-scanner-23.3.0/work/openvas-scanner-23.3.0_build/nasl:/var/tmp/portage/net-analyzer/openvas-scanner-23.3.0/work/openvas-scanner-23.3.0_build/misc:  nasl/libopenvas_nasl.so.23.3.0  misc/libopenvas_misc.so.23.3.0  -L/usr/lib64  -lgnutls  -L/usr/lib64  -lssh  -lpcap  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lglib-2.0  -ljson-glib-1.0  -lgio-2.0  -lgobject-2.0  -lgcrypt -lgpg-error  -lgpgme  -lm  -lgvm_base  -lgvm_util  -lgnutls  -lssh  -lksba  -lgpg-error  -L/usr/lib64 -lnetsnmp -lm -lssl -lssl -lcrypto  -Wl,-z,relro -Wl,-z,now && :
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_init
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_cleanup
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_slist_append
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_setopt
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_reset
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_perform
>>> referenced by nasl/libopenvas_nasl.so.23.3.0

ld.lld: error: undefined reference due to --no-allow-shlib-undefined: curl_easy_getinfo
>>> referenced by nasl/libopenvas_nasl.so.23.3.0
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
I tested this to comply with
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/-Wl,-z,defs_and_-Wl,--no-allow-shlib-undefined
