### PR TITLE
Fix: forks to often when reading same KB in different scripts

### DIFF
--- a/nasl/nasl.c
+++ b/nasl/nasl.c
@@ -386,12 +386,12 @@ main (int argc, char **argv)
 
           if (exec_nasl_script (script_infos, mode) < 0)
             err++;
+
+          if (process_id != getpid ())
+            exit (0);
         }
       g_free (script_infos->globals);
       g_free (script_infos);
-
-      if (process_id != getpid ())
-        exit (0);
 
       kb_delete (kb);
     }


### PR DESCRIPTION
**What**:
Fix: forks to often when reading same KB in different scripts
Jira: SC-1090
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It fork()s to much

<!-- Why are these changes necessary? -->

**How**:
Set values in redis with set_kb_item. Then, read it from different scripts with get_kb_items()

`openvas-nasl -X -d set_kb.nasl 1.nasl 2.nasl`

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
