### PR TITLE
Fix: use edge instead of unstable as a default version

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=unstable
+ARG VERSION=edge
 
 FROM greenbone/gvm-libs:$VERSION
 LABEL deprecated="This image is deprecated and may be removed soon."

--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=unstable
+ARG VERSION=edge
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
 ARG GVM_LIBS_VERSION=oldstable

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=unstable
+ARG VERSION=edge
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
 ARG GVM_LIBS_VERSION=testing-edge

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=unstable
+ARG VERSION=edge
 # this allows to work on forked repository
 ARG REPOSITORY=greenbone/openvas-scanner
 


### PR DESCRIPTION
Unstable isn't used since a while therefore we should use edge when we
don't have version set.
