### PR TITLE
Fix: Set the right status when a scan fails because an invalid host list

### DIFF
--- a/rust/openvas/src/openvas.rs
+++ b/rust/openvas/src/openvas.rs
@@ -359,7 +359,7 @@ impl ScanResultFetcher for Scanner {
                     host_info: Some(hosts_info),
                 };
 
-                let scan_res = ScanResults {
+                let mut scan_res = ScanResults {
                     id: scan_id.to_string(),
                     status: st,
                     results: all_results
@@ -369,15 +369,24 @@ impl ScanResultFetcher for Scanner {
                         .collect(),
                 };
 
-                // If the scan finished, release
+                // If the scan finished, release. Openvas "finished" status is translated todo
+                // Succeeded. It is necessary to read the exit code to know if it failed.
                 if status == Phase::Succeeded {
                     let mut scan = match self.remove_running(scan_id) {
                         Some(scan) => scan.0,
                         None => return Err(OpenvasError::ScanNotFound(scan_id.to_string()).into()),
                     };
 
-                    scan.wait().map_err(OpenvasError::CmdError)?;
-
+                    // Read openvas scanner exit code and if failed, reset the status to Failed.
+                    let exit_status = scan.wait().map_err(OpenvasError::CmdError)?;
+                    if let Some(code) = exit_status.code() {
+                        if code != 0 {
+                            scan_res.status.status = Phase::Failed;
+                            scan_res.status.start_time = scan_res.status.end_time;
+                            scan_res.status.host_info = None;
+                        }
+                    }
+                        
                     redis_help
                         .release()
                         .map_err(|e| ScanError::Unexpected(e.to_string()))?;

--- a/rust/openvas/src/openvas.rs
+++ b/rust/openvas/src/openvas.rs
@@ -386,7 +386,7 @@ impl ScanResultFetcher for Scanner {
                             scan_res.status.host_info = None;
                         }
                     }
-                        
+
                     redis_help
                         .release()
                         .map_err(|e| ScanError::Unexpected(e.to_string()))?;

--- a/src/attack.h
+++ b/src/attack.h
@@ -17,7 +17,7 @@
 
 #include <gvm/util/kb.h>
 
-void
+int
 attack_network (struct scan_globals *);
 
 #endif

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -625,6 +625,7 @@ openvas (int argc, char *argv[], char *env[])
   /* openvas --scan-start */
   if (scan_id)
     {
+      int attack_error = 0;
       struct scan_globals *globals;
       set_scan_id (g_strdup (scan_id));
       globals = g_malloc0 (sizeof (struct scan_globals));
@@ -635,13 +636,19 @@ openvas (int argc, char *argv[], char *env[])
           destroy_scan_globals (globals);
           return EXIT_FAILURE;
         }
-      attack_network (globals);
+      attack_error = attack_network (globals);
 
       gvm_close_sentry ();
       destroy_scan_globals (globals);
 #ifdef LOG_REFERENCES_AVAILABLE
       free_log_reference ();
 #endif // LOG_REFERENCES_AVAILABLE
+
+      if (attack_error)
+        {
+          g_warning("Scan ending with FAILURE status");
+          return EXIT_FAILURE;
+        }
       return EXIT_SUCCESS;
     }
 

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -646,7 +646,7 @@ openvas (int argc, char *argv[], char *env[])
 
       if (attack_error)
         {
-          g_warning("Scan ending with FAILURE status");
+          g_warning ("Scan ending with FAILURE status");
           return EXIT_FAILURE;
         }
       return EXIT_SUCCESS;


### PR DESCRIPTION
**What**:
Fix: Set the right status when a scan fails because an invalid host list
Jira: SC-1089
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Running a scan with a host with unsupported chars (e.g. examplö.com) the openvas scanner finishes immediately but the status is set as Succeeded in openvasd. Also set a start scan timestamp and cleanups the host information.
<!-- Why are these changes necessary? -->

**How**:
start a scan via openvasd with a host with unsupported chars.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
