### PR TITLE
Refactor: remove generic K in favor of enum

### DIFF
--- a/rust/feed/README.md
+++ b/rust/feed/README.md
@@ -39,7 +39,7 @@ Is [implemented](./src/update/mod.rs) as a Iterator over String and [UpdateError
 ```no_run
 use nasl_interpreter::{Interpreter, FSPluginLoader, Register};
 use storage::DefaultDispatcher;
-let storage: DefaultDispatcher<String> = DefaultDispatcher::new(false);
+let storage: DefaultDispatcher = DefaultDispatcher::new(false);
 let path = "/var/lib/openvas/plugins/";
 let loader = FSPluginLoader::new(path);
 let verifier = feed::HashSumNameLoader::sha256(&loader).expect("sha256sums");

--- a/rust/feed/README.md
+++ b/rust/feed/README.md
@@ -45,7 +45,7 @@ let loader = FSPluginLoader::new(path);
 let verifier = feed::HashSumNameLoader::sha256(&loader).expect("sha256sums");
 let max_retries = 5;
 let openvas_version = "1";
-let updater = feed::Update::init(openvas_version, max_retries, loader.clone(), storage, verifier);
+let updater = feed::Update::init(openvas_version, max_retries, &loader, &storage, verifier);
 
 for s in updater {
     println!("updated {s:?}");

--- a/rust/feed/tests/update.rs
+++ b/rust/feed/tests/update.rs
@@ -54,7 +54,7 @@ mod test {
             Err(x) => panic!("expected to contain current_exe: {x:?}"),
         };
         let loader = FSPluginLoader::new(&root);
-        let storage: DefaultDispatcher<String> = DefaultDispatcher::new(true);
+        let storage: DefaultDispatcher = DefaultDispatcher::new(true);
         let verifier = HashSumNameLoader::sha256(&loader).expect("sha256sums should be available");
         let updater = Update::init("1", 1, loader.clone(), storage, verifier);
         let files = updater.filter_map(|x| x.ok()).collect::<Vec<String>>();

--- a/rust/feed/tests/update.rs
+++ b/rust/feed/tests/update.rs
@@ -56,7 +56,7 @@ mod test {
         let loader = FSPluginLoader::new(&root);
         let storage: DefaultDispatcher = DefaultDispatcher::new(true);
         let verifier = HashSumNameLoader::sha256(&loader).expect("sha256sums should be available");
-        let updater = Update::init("1", 1, loader.clone(), storage, verifier);
+        let updater = Update::init("1", 1, &loader, &storage, verifier);
         let files = updater.filter_map(|x| x.ok()).collect::<Vec<String>>();
         // feed version and filename of script
         assert_eq!(

--- a/rust/json-storage/README.md
+++ b/rust/json-storage/README.md
@@ -76,7 +76,7 @@ To create a single json element per dispatch you can use the ItemDispatcher with
 
 ```
 let mut buf = Vec::with_capacity(1208);
-let dispatcher = json_storage::ItemDispatcher::as_dispatcher::<String>(&mut buf);
+let dispatcher = json_storage::ItemDispatcher::as_dispatcher(&mut buf);
 ```
 
 ### Array
@@ -86,7 +86,7 @@ To create an array for elements per dispatch call:
 ```
 let mut buf = Vec::with_capacity(1208);
 let mut ja = json_storage::ArrayWrapper::new(&mut buf);
-let dispatcher = json_storage::ItemDispatcher::as_dispatcher::<String>(&mut ja);
+let dispatcher = json_storage::ItemDispatcher::as_dispatcher(&mut ja);
 // do your work
 ja.end();
 ```

--- a/rust/json-storage/src/lib.rs
+++ b/rust/json-storage/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use storage::{self, item::PerItemDispatcher, Kb, NotusAdvisory, StorageError};
+use storage::{self, item::PerItemDispatcher, ContextKey, Kb, NotusAdvisory, StorageError};
 
 /// Wraps write calls of json elements to be as list.
 ///
@@ -87,10 +87,7 @@ where
     }
 
     /// Returns a new instance as a Dispatcher
-    pub fn as_dispatcher<K>(w: S) -> PerItemDispatcher<Self, K>
-    where
-        K: AsRef<str>,
-    {
+    pub fn as_dispatcher(w: S) -> PerItemDispatcher<Self> {
         PerItemDispatcher::new(Self::new(w))
     }
 
@@ -102,7 +99,7 @@ where
     }
 }
 
-impl<S, K> storage::item::ItemDispatcher<K> for ItemDispatcher<S>
+impl<S> storage::item::ItemDispatcher for ItemDispatcher<S>
 where
     S: Write,
 {
@@ -115,7 +112,7 @@ where
         Ok(())
     }
 
-    fn dispatch_kb(&self, _: &K, kb: Kb) -> Result<(), StorageError> {
+    fn dispatch_kb(&self, _: &ContextKey, kb: Kb) -> Result<(), StorageError> {
         let mut kbs = self.kbs.lock().map_err(StorageError::from)?;
         let mut context = self.w.lock().map_err(StorageError::from)?;
         serde_json::to_vec(&kb)
@@ -135,14 +132,13 @@ where
     }
 }
 
-impl<S, K> storage::Retriever<K> for ItemDispatcher<S>
+impl<S> storage::Retriever for ItemDispatcher<S>
 where
     S: Write,
-    K: 'static,
 {
     fn retrieve(
         &self,
-        _: &K,
+        _: &ContextKey,
         scope: storage::Retrieve,
     ) -> Result<Box<dyn Iterator<Item = storage::Field>>, StorageError> {
         Ok(match scope {
@@ -164,7 +160,7 @@ where
         &self,
         _: storage::Field,
         _: storage::Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, storage::Field)>>, StorageError> {
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, storage::Field)>>, StorageError> {
         Ok(Box::new([].into_iter()))
     }
 }

--- a/rust/models/src/scanner.rs
+++ b/rust/models/src/scanner.rs
@@ -87,7 +87,7 @@ impl Default for Lambda {
     }
 }
 
-/// Builds a Lambda scanenr implementation.
+/// Builds a Lambda scanner implementation.
 ///
 /// Usage:
 /// ```

--- a/rust/nasl-builtin-cryptographic/src/aes_cbc.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_cbc.rs
@@ -74,10 +74,7 @@ where
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes128_cbc_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_cbc_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes128>(register, Crypt::Encrypt)
 }
 
@@ -89,10 +86,7 @@ fn aes128_cbc_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes128_cbc_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_cbc_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes128>(register, Crypt::Decrypt)
 }
 
@@ -103,10 +97,7 @@ fn aes128_cbc_decrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes192_cbc_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_cbc_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes192>(register, Crypt::Encrypt)
 }
 
@@ -118,10 +109,7 @@ fn aes192_cbc_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes192_cbc_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_cbc_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes192>(register, Crypt::Decrypt)
 }
 
@@ -132,10 +120,7 @@ fn aes192_cbc_decrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes256_cbc_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_cbc_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes256>(register, Crypt::Encrypt)
 }
 
@@ -147,14 +132,11 @@ fn aes256_cbc_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes
-fn aes256_cbc_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_cbc_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Aes256>(register, Crypt::Decrypt)
 }
 
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes128_cbc_encrypt" => Some(aes128_cbc_encrypt),
         "aes128_cbc_decrypt" => Some(aes128_cbc_decrypt),

--- a/rust/nasl-builtin-cryptographic/src/aes_ccm.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_ccm.rs
@@ -72,10 +72,7 @@ where
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_ccm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes128>(register, Crypt::Encrypt, false)
 }
 
@@ -86,9 +83,9 @@ fn aes128_ccm_encrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_encrypt_auth<K>(
+fn aes128_ccm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes128>(register, Crypt::Encrypt, true)
 }
@@ -100,10 +97,7 @@ fn aes128_ccm_encrypt_auth<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_ccm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes128>(register, Crypt::Decrypt, false)
 }
 
@@ -114,9 +108,9 @@ fn aes128_ccm_decrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes128_ccm_decrypt_auth<K>(
+fn aes128_ccm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes128>(register, Crypt::Decrypt, true)
 }
@@ -128,10 +122,7 @@ fn aes128_ccm_decrypt_auth<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_ccm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes192>(register, Crypt::Encrypt, false)
 }
 
@@ -142,9 +133,9 @@ fn aes192_ccm_encrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_encrypt_auth<K>(
+fn aes192_ccm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes192>(register, Crypt::Encrypt, true)
 }
@@ -156,10 +147,7 @@ fn aes192_ccm_encrypt_auth<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_ccm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes192>(register, Crypt::Decrypt, false)
 }
 
@@ -170,9 +158,9 @@ fn aes192_ccm_decrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes192_ccm_decrypt_auth<K>(
+fn aes192_ccm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes192>(register, Crypt::Decrypt, true)
 }
@@ -184,10 +172,7 @@ fn aes192_ccm_decrypt_auth<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_ccm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes256>(register, Crypt::Encrypt, false)
 }
 
@@ -198,9 +183,9 @@ fn aes256_ccm_encrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_encrypt_auth<K>(
+fn aes256_ccm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes256>(register, Crypt::Encrypt, true)
 }
@@ -212,10 +197,7 @@ fn aes256_ccm_encrypt_auth<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_ccm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes256>(register, Crypt::Decrypt, false)
 }
 
@@ -226,14 +208,14 @@ fn aes256_ccm_decrypt<K>(
 /// - The length of the key should be 16 bytes long
 /// - The iv must have a length of 7-13 bytes
 /// - The tag_size default is 16, it can be set to either 4, 6, 8, 10, 12, 14 or 16
-fn aes256_ccm_decrypt_auth<K>(
+fn aes256_ccm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     ccm::<Aes256>(register, Crypt::Decrypt, true)
 }
 
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes128_ccm_encrypt" => Some(aes128_ccm_encrypt),
         "aes128_ccm_encrypt_auth" => Some(aes128_ccm_encrypt_auth),

--- a/rust/nasl-builtin-cryptographic/src/aes_cmac.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_cmac.rs
@@ -15,7 +15,7 @@ use crate::{get_data, get_key, NaslFunction};
 /// This function expects 2 named arguments key and data either in a string or data type.
 /// It is important to notice, that internally the CMAC algorithm is used and not, as the name
 /// suggests, CBC-MAC.
-fn aes_cmac<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn aes_cmac(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let key = get_key(register)?;
     let data = get_data(register)?;
 
@@ -26,7 +26,7 @@ fn aes_cmac<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Functio
     Ok(mac.finalize().into_bytes().to_vec().into())
 }
 
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes_mac_cbc" => Some(aes_cmac),
         "aes_cmac" => Some(aes_cmac),

--- a/rust/nasl-builtin-cryptographic/src/aes_ctr.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_ctr.rs
@@ -59,10 +59,7 @@ where
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes128_ctr_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_ctr_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes128>(register, Crypt::Encrypt)
 }
 
@@ -74,10 +71,7 @@ fn aes128_ctr_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes128_ctr_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_ctr_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes128>(register, Crypt::Decrypt)
 }
 
@@ -88,10 +82,7 @@ fn aes128_ctr_decrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes192_ctr_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_ctr_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes192>(register, Crypt::Encrypt)
 }
 
@@ -103,10 +94,7 @@ fn aes192_ctr_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes192_ctr_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_ctr_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes192>(register, Crypt::Decrypt)
 }
 
@@ -117,10 +105,7 @@ fn aes192_ctr_decrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes256_ctr_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_ctr_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes256>(register, Crypt::Encrypt)
 }
 
@@ -132,14 +117,11 @@ fn aes256_ctr_encrypt<K>(
 ///   Currently the data is filled with zeroes. Therefore the length of the encrypted data must be
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
-fn aes256_ctr_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_ctr_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     ctr::<Aes256>(register, Crypt::Decrypt)
 }
 
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes128_ctr_encrypt" => Some(aes128_ctr_encrypt),
         "aes128_ctr_decrypt" => Some(aes128_ctr_decrypt),

--- a/rust/nasl-builtin-cryptographic/src/aes_gcm.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_gcm.rs
@@ -81,10 +81,7 @@ where
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes128_gcm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_gcm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes128>(register, Crypt::Encrypt, false)
 }
 
@@ -97,9 +94,9 @@ fn aes128_gcm_encrypt<K>(
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes128_gcm_encrypt_auth<K>(
+fn aes128_gcm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes128>(register, Crypt::Encrypt, true)
 }
@@ -113,10 +110,7 @@ fn aes128_gcm_encrypt_auth<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes128_gcm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes128_gcm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes128>(register, Crypt::Decrypt, false)
 }
 
@@ -129,9 +123,9 @@ fn aes128_gcm_decrypt<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes128_gcm_decrypt_auth<K>(
+fn aes128_gcm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes128>(register, Crypt::Decrypt, true)
 }
@@ -145,10 +139,7 @@ fn aes128_gcm_decrypt_auth<K>(
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes192_gcm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_gcm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes192>(register, Crypt::Encrypt, false)
 }
 
@@ -161,9 +152,9 @@ fn aes192_gcm_encrypt<K>(
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes192_gcm_encrypt_auth<K>(
+fn aes192_gcm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes192>(register, Crypt::Encrypt, true)
 }
@@ -177,10 +168,7 @@ fn aes192_gcm_encrypt_auth<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes192_gcm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes192_gcm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes192>(register, Crypt::Decrypt, false)
 }
 
@@ -193,9 +181,9 @@ fn aes192_gcm_decrypt<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes192_gcm_decrypt_auth<K>(
+fn aes192_gcm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes192>(register, Crypt::Decrypt, true)
 }
@@ -209,10 +197,7 @@ fn aes192_gcm_decrypt_auth<K>(
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes256_gcm_encrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_gcm_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes256>(register, Crypt::Encrypt, false)
 }
 
@@ -225,9 +210,9 @@ fn aes256_gcm_encrypt<K>(
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The result contains the ciphertext and the calculated tag in a single data type.
 /// - The tag has a size of 16 Bytes.
-fn aes256_gcm_encrypt_auth<K>(
+fn aes256_gcm_encrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes256>(register, Crypt::Encrypt, true)
 }
@@ -241,10 +226,7 @@ fn aes256_gcm_encrypt_auth<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes256_gcm_decrypt<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn aes256_gcm_decrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes256>(register, Crypt::Decrypt, false)
 }
 
@@ -257,14 +239,14 @@ fn aes256_gcm_decrypt<K>(
 ///   known for decryption. If no length is given, the last block is decrypted as a whole.
 /// - The iv must have a length of 16 bytes. It is used as the initial counter.
 /// - The tag is needed as a postfix in the given data in order to decrypt successfully.
-fn aes256_gcm_decrypt_auth<K>(
+fn aes256_gcm_decrypt_auth(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     gcm::<Aes256>(register, Crypt::Decrypt, true)
 }
 
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes128_gcm_encrypt" => Some(aes128_gcm_encrypt),
         "aes128_gcm_encrypt_auth" => Some(aes128_gcm_encrypt_auth),

--- a/rust/nasl-builtin-cryptographic/src/aes_gmac.rs
+++ b/rust/nasl-builtin-cryptographic/src/aes_gmac.rs
@@ -8,9 +8,9 @@ use crate::NaslFunction;
 ///
 /// This function expects 3 named arguments key, data and iv either in a string or data type.
 #[cfg(feature = "nasl-c-lib")]
-fn aes_gmac<K>(
+fn aes_gmac(
     register: &nasl_builtin_utils::Register,
-    _: &nasl_builtin_utils::Context<K>,
+    _: &nasl_builtin_utils::Context,
 ) -> Result<nasl_syntax::NaslValue, nasl_builtin_utils::FunctionErrorKind> {
     use crate::{get_data, get_iv, get_key};
     use nasl_c_lib::cryptographic::mac::aes_gmac;
@@ -31,7 +31,7 @@ fn aes_gmac<K>(
 }
 
 #[cfg(feature = "nasl-c-lib")]
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "aes_mac_gcm" => Some(aes_gmac),
         "aes_gmac" => Some(aes_gmac),
@@ -40,6 +40,6 @@ pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
 }
 
 #[cfg(not(feature = "nasl-c-lib"))]
-pub fn lookup<K>(_: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(_: &str) -> Option<NaslFunction> {
     None
 }

--- a/rust/nasl-builtin-cryptographic/src/des.rs
+++ b/rust/nasl-builtin-cryptographic/src/des.rs
@@ -7,9 +7,9 @@ use ccm::KeyInit;
 use des::cipher::generic_array::GenericArray;
 use nasl_builtin_utils::{Context, FunctionErrorKind, NaslFunction, Register};
 
-fn encrypt_des<K>(
+fn encrypt_des(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<nasl_syntax::NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.len() != 2 {
@@ -43,7 +43,7 @@ fn encrypt_des<K>(
     des_cipher.encrypt_block(&mut data);
     Ok(data.to_vec().into())
 }
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "DES" => Some(encrypt_des),
         _ => None,

--- a/rust/nasl-builtin-cryptographic/src/hash.rs
+++ b/rust/nasl-builtin-cryptographic/src/hash.rs
@@ -37,45 +37,42 @@ where
 }
 
 /// NASL function to get MD2 hash
-pub fn hash_md2<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_md2(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Md2>(register)
 }
 
 /// NASL function to get MD4 hash
-pub fn hash_md4<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_md4(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Md4>(register)
 }
 
 /// NASL function to get MD5 hash
-pub fn hash_md5<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_md5(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Md5>(register)
 }
 
 /// NASL function to get SHA1 hash
-pub fn hash_sha1<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_sha1(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Sha1>(register)
 }
 
 /// NASL function to get SHA256 hash
-pub fn hash_sha256<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_sha256(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Sha256>(register)
 }
 
 /// NASL function to get SHA512 hash
-pub fn hash_sha512<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_sha512(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Sha512>(register)
 }
 
 /// NASL function to get RIPemd160 hash
-pub fn hash_ripemd160<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hash_ripemd160(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_hash::<Ripemd160>(register)
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "MD2" => Some(hash_md2),
         "MD4" => Some(hash_md4),

--- a/rust/nasl-builtin-cryptographic/src/hmac.rs
+++ b/rust/nasl-builtin-cryptographic/src/hmac.rs
@@ -55,45 +55,42 @@ where
 }
 
 /// NASL function to get HMAC MD2 string
-pub fn hmac_md2<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_md2(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Md2>(register)
 }
 
 /// NASL function to get HMAC MD5 string
-pub fn hmac_md5<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_md5(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Md5>(register)
 }
 
 /// NASL function to get HMAC RIPEMD160 string
-pub fn hmac_ripemd160<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_ripemd160(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Ripemd160>(register)
 }
 
 /// NASL function to get HMAC SHA1 string
-pub fn hmac_sha1<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_sha1(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Sha1>(register)
 }
 
 /// NASL function to get HMAC SHA256 string
-pub fn hmac_sha256<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_sha256(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Sha256>(register)
 }
 
 /// NASL function to get HMAC SHA384 string
-pub fn hmac_sha384<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_sha384(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Sha384>(register)
 }
 
 /// NASL function to get HMAC SHA512 string
-pub fn hmac_sha512<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+pub fn hmac_sha512(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     hmac::<Sha512>(register)
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "HMAC_MD2" => Some(hmac_md2),
         "HMAC_MD5" => Some(hmac_md5),

--- a/rust/nasl-builtin-cryptographic/src/lib.rs
+++ b/rust/nasl-builtin-cryptographic/src/lib.rs
@@ -26,10 +26,7 @@ enum Crypt {
 /// Decodes given string as hex and returns the result as a byte array
 // TODO only used in tests, move tests to its own module and define there
 
-pub(crate) fn lookup<K>(function_name: &str) -> Option<NaslFunction<K>>
-where
-    K: AsRef<str>,
-{
+pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
     aes_ccm::lookup(function_name)
         .or_else(|| hmac::lookup(function_name))
         .or_else(|| aes_cbc::lookup(function_name))
@@ -43,18 +40,18 @@ where
 
 pub struct Cryptographic;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Cryptographic {
+impl nasl_builtin_utils::NaslFunctionExecuter for Cryptographic {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<K>(name).is_some()
+        lookup(name).is_some()
     }
 }
 /// Get named argument of Type Data or String from the register with appropriate error handling.

--- a/rust/nasl-builtin-cryptographic/tests/aes_cbc.rs
+++ b/rust/nasl-builtin-cryptographic/tests/aes_cbc.rs
@@ -19,8 +19,8 @@ mod tests {
         aes128_cbc_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -49,8 +49,8 @@ mod tests {
         aes192_cbc_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -79,8 +79,8 @@ mod tests {
         aes256_cbc_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -110,8 +110,8 @@ mod tests {
         aes128_cbc_encrypt(key: key, data: data2, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/aes_ccm.rs
+++ b/rust/nasl-builtin-cryptographic/tests/aes_ccm.rs
@@ -19,8 +19,8 @@ mod tests {
         aes128_ccm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -50,8 +50,8 @@ mod tests {
         aes128_ccm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -81,8 +81,8 @@ mod tests {
         aes192_ccm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -112,8 +112,8 @@ mod tests {
         aes192_ccm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -143,8 +143,8 @@ mod tests {
         aes256_ccm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -174,8 +174,8 @@ mod tests {
         aes256_ccm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/aes_cmac.rs
+++ b/rust/nasl-builtin-cryptographic/tests/aes_cmac.rs
@@ -16,8 +16,8 @@ mod tests {
         crypt = aes_mac_cbc(key: key, data: data);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/aes_ctr.rs
+++ b/rust/nasl-builtin-cryptographic/tests/aes_ctr.rs
@@ -20,8 +20,8 @@ mod tests {
         aes128_ctr_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -50,8 +50,8 @@ mod tests {
         aes192_ctr_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -80,8 +80,8 @@ mod tests {
         aes256_ctr_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/aes_gcm.rs
+++ b/rust/nasl-builtin-cryptographic/tests/aes_gcm.rs
@@ -19,8 +19,8 @@ mod tests {
         aes128_gcm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -51,8 +51,8 @@ mod tests {
         aes128_gcm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -83,8 +83,8 @@ mod tests {
         aes192_gcm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -115,8 +115,8 @@ mod tests {
         aes192_gcm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -147,8 +147,8 @@ mod tests {
         aes256_gcm_decrypt(key: key, data: crypt, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -179,8 +179,8 @@ mod tests {
         aes256_gcm_decrypt_auth(key: key, data: crypt, iv: iv, aad: aad);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -212,8 +212,8 @@ mod tests {
         aes128_gcm_encrypt(key: key, data: data2, iv: iv);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/des.rs
+++ b/rust/nasl-builtin-cryptographic/tests/des.rs
@@ -17,8 +17,8 @@ mod tests {
         DES(data,key);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();

--- a/rust/nasl-builtin-cryptographic/tests/hash.rs
+++ b/rust/nasl-builtin-cryptographic/tests/hash.rs
@@ -16,8 +16,8 @@ mod tests {
         a = MD5();
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -40,8 +40,8 @@ mod tests {
         MD4("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -58,8 +58,8 @@ mod tests {
         MD2("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -75,8 +75,8 @@ mod tests {
         SHA1("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -96,8 +96,8 @@ mod tests {
         SHA256("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -117,8 +117,8 @@ mod tests {
         SHA512("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -140,8 +140,8 @@ mod tests {
         RIPEMD160("hola mundo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),

--- a/rust/nasl-builtin-cryptographic/tests/hmac.rs
+++ b/rust/nasl-builtin-cryptographic/tests/hmac.rs
@@ -13,8 +13,8 @@ mod tests {
         HMAC_MD2(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -28,8 +28,8 @@ mod tests {
         HMAC_MD5(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -43,8 +43,8 @@ mod tests {
         HMAC_RIPEMD160(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -58,8 +58,8 @@ mod tests {
         HMAC_SHA1(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -73,8 +73,8 @@ mod tests {
         HMAC_SHA256(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -90,8 +90,8 @@ mod tests {
         HMAC_SHA384(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -105,8 +105,8 @@ mod tests {
         HMAC_SHA512(key: "my_shared?key", data: "so much wow");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),

--- a/rust/nasl-builtin-description/src/lib.rs
+++ b/rust/nasl-builtin-description/src/lib.rs
@@ -6,7 +6,10 @@ use std::str::FromStr;
 
 use nasl_builtin_utils::{Context, FunctionErrorKind, Register};
 
-use storage::item::{NVTField, NvtPreference, NvtRef, PreferenceType, TagKey, TagValue};
+use storage::{
+    item::{NVTField, NvtPreference, NvtRef, PreferenceType, TagKey, TagValue},
+    ContextKey,
+};
 
 use nasl_builtin_utils::{get_named_parameter, NaslFunction};
 use nasl_syntax::NaslValue;
@@ -54,10 +57,10 @@ macro_rules! make_storage_function {
         )?
         ///
         /// Returns NaslValue::Null on success.
-        pub fn $name<K>(
+        pub fn $name(
             registrat: &Register,
-            ctxconfigs: &Context<K>,
-        ) -> Result<NaslValue, FunctionErrorKind> where K: AsRef<str> {
+            ctxconfigs: &Context,
+        ) -> Result<NaslValue, FunctionErrorKind> {
             let mut variables = vec![];
             $(
             let positional = registrat.positional();
@@ -92,7 +95,7 @@ macro_rules! make_storage_function {
         }
         )*
         /// Returns found function for key or None when not found
-        pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> where K: AsRef<str> {
+        pub fn lookup(key: &str) -> Option<NaslFunction> {
             match key {
                 $(
                 stringify!($name) => Some($name),
@@ -105,7 +108,7 @@ macro_rules! make_storage_function {
 
 type Transform = Result<Vec<NVTField>, FunctionErrorKind>;
 
-fn as_timeout_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_timeout_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     Ok(vec![NVTField::Preference(NvtPreference {
         id: Some(0),
         name: "timeout".to_owned(),
@@ -114,46 +117,43 @@ fn as_timeout_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
     })])
 }
 
-fn as_category_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_category_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     match arguments[0] {
         NaslValue::AttackCategory(cat) => Ok(vec![NVTField::Category(*cat)]),
         a => Err(("AttackCategory", a).into()),
     }
 }
 
-fn as_name_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_name_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     Ok(vec![NVTField::Name(arguments[0].to_string())])
 }
 
-fn as_oid_field<K>(key: &K, arguments: &[&NaslValue]) -> Transform
-where
-    K: AsRef<str>,
-{
+fn as_oid_field(key: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     Ok(vec![
         NVTField::Oid(arguments[0].to_string()),
-        NVTField::FileName(key.as_ref().to_owned()),
+        NVTField::FileName(key.value()),
     ])
 }
 
-fn as_family_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_family_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     Ok(vec![NVTField::Family(arguments[0].to_string())])
 }
 
-fn as_noop<K>(_: &K, _arguments: &[&NaslValue]) -> Transform {
+fn as_noop(_: &ContextKey, _arguments: &[&NaslValue]) -> Transform {
     Ok(vec![NVTField::NoOp])
 }
 
-fn as_dependencies_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_dependencies_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     Ok(vec![NVTField::Dependencies(values)])
 }
 
-fn as_exclude_keys_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_exclude_keys_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     Ok(vec![NVTField::ExcludedKeys(values)])
 }
 
-fn as_mandatory_keys_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_mandatory_keys_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     match values.clone().last().and_then(|x| x.rsplit_once('=')) {
         Some((remove, _)) => {
@@ -167,22 +167,22 @@ fn as_mandatory_keys_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
     }
 }
 
-fn as_require_ports_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_require_ports_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     Ok(vec![NVTField::RequiredPorts(values)])
 }
 
-fn as_require_udp_ports_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_require_udp_ports_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     Ok(vec![NVTField::RequiredUdpPorts(values)])
 }
 
-fn as_require_keys_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_require_keys_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let values: Vec<String> = arguments.iter().map(|x| x.to_string()).collect();
     Ok(vec![NVTField::RequiredKeys(values)])
 }
 
-fn as_cve_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_cve_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let result = arguments
         .iter()
         .map(|x| ("cve", x.to_string()).into())
@@ -190,7 +190,7 @@ fn as_cve_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
     Ok(vec![NVTField::Reference(result)])
 }
 
-fn as_tag_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_tag_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     let key: TagKey = arguments[0].to_string().parse()?;
     Ok(vec![match TagValue::parse(key, arguments[1])? {
         TagValue::Null => NVTField::NoOp,
@@ -198,7 +198,7 @@ fn as_tag_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
     }])
 }
 
-fn as_xref_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_xref_field(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     if arguments.len() != 2 {
         return Err(FunctionErrorKind::MissingArguments(vec![
             "name".to_owned(),
@@ -211,7 +211,7 @@ fn as_xref_field<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
     }])])
 }
 
-fn as_preference<K>(_: &K, arguments: &[&NaslValue]) -> Transform {
+fn as_preference(_: &ContextKey, arguments: &[&NaslValue]) -> Transform {
     if arguments.len() < 3 {
         return Err(FunctionErrorKind::MissingArguments(vec![
             "type".to_owned(),
@@ -264,17 +264,17 @@ make_storage_function! {
 /// The description builtin function
 pub struct Description;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Description {
+impl nasl_builtin_utils::NaslFunctionExecuter for Description {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<K>(name).is_some()
+        lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-host/src/lib.rs
+++ b/rust/nasl-builtin-host/src/lib.rs
@@ -37,7 +37,7 @@ fn resolve_hostname(register: &Register) -> Result<String, FunctionErrorKind> {
 ///
 /// As of now (2023-01-20) there is no vhost handling.
 /// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
-fn get_host_names<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn get_host_names(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     resolve_hostname(register).map(|x| NaslValue::Array(vec![NaslValue::String(x)]))
 }
 
@@ -45,12 +45,12 @@ fn get_host_names<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, F
 ///
 /// As of now (2023-01-20) there is no vhost handling.
 /// Therefore this function does load the registered TARGET and if it is an IP Address resolves it via DNS instead.
-fn get_host_name<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn get_host_name(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     resolve_hostname(register).map(NaslValue::String)
 }
 
 /// Return the target's IP address as IpAddr.
-pub fn get_host_ip<K>(context: &Context<K>) -> Result<IpAddr, FunctionErrorKind> {
+pub fn get_host_ip(context: &Context) -> Result<IpAddr, FunctionErrorKind> {
     let default_ip = "127.0.0.1";
     let r_sock_addr = match context.target() {
         x if !x.is_empty() => IpAddr::from_str(x),
@@ -64,16 +64,16 @@ pub fn get_host_ip<K>(context: &Context<K>) -> Result<IpAddr, FunctionErrorKind>
 }
 
 /// Return the target's IP address or 127.0.0.1 if not set.
-fn nasl_get_host_ip<K>(
+fn nasl_get_host_ip(
     _register: &Register,
-    context: &Context<K>,
+    context: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let ip = get_host_ip(context)?;
     Ok(NaslValue::String(ip.to_string()))
 }
 
 /// Returns found function for key or None when not found
-fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "get_host_name" => Some(get_host_name),
         "get_host_names" => Some(get_host_names),
@@ -85,17 +85,17 @@ fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
 /// The description builtin function
 pub struct Host;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Host {
+impl nasl_builtin_utils::NaslFunctionExecuter for Host {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<K>(name).is_some()
+        lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-host/tests/hostname.rs
+++ b/rust/nasl-builtin-host/tests/hostname.rs
@@ -12,8 +12,8 @@ mod tests {
         get_host_names();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert!(matches!(parser.next(), Some(Ok(NaslValue::String(_)))));
         assert!(matches!(parser.next(), Some(Ok(NaslValue::Array(_)))));

--- a/rust/nasl-builtin-knowledge-base/src/lib.rs
+++ b/rust/nasl-builtin-knowledge-base/src/lib.rs
@@ -11,7 +11,7 @@ use nasl_builtin_utils::{Context, Register};
 use nasl_syntax::NaslValue;
 
 /// NASL function to set a knowledge base
-fn set_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn set_kb_item(register: &Register, c: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let name = get_named_parameter(register, "name", true)?;
     let value = get_named_parameter(register, "value", true)?;
     let expires = match get_named_parameter(register, "expires", false) {
@@ -46,7 +46,7 @@ fn set_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, Func
 }
 
 /// NASL function to get a knowledge base
-fn get_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn get_kb_item(register: &Register, c: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match register.positional() {
         [x] => c
             .retriever()
@@ -69,7 +69,7 @@ fn get_kb_item<K>(register: &Register, c: &Context<K>) -> Result<NaslValue, Func
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "set_kb_item" => Some(set_kb_item),
         "get_kb_item" => Some(get_kb_item),
@@ -79,17 +79,17 @@ pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
 
 pub struct KnowledgeBase;
 
-impl<K> nasl_builtin_utils::NaslFunctionExecuter<K> for KnowledgeBase {
+impl nasl_builtin_utils::NaslFunctionExecuter for KnowledgeBase {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<&str>(name).is_some()
+        lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-knowledge-base/tests/kb.rs
+++ b/rust/nasl-builtin-knowledge-base/tests/kb.rs
@@ -14,8 +14,8 @@ mod tests {
         set_kb_item(value: 1);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert!(matches!(parser.next(), Some(Err(_))));
@@ -29,8 +29,8 @@ mod tests {
         get_kb_item("test", 1);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(1))));

--- a/rust/nasl-builtin-misc/src/lib.rs
+++ b/rust/nasl-builtin-misc/src/lib.rs
@@ -35,17 +35,17 @@ pub fn random_impl() -> Result<i64, FunctionErrorKind> {
 }
 
 /// NASL function to get random number
-fn rand<K>(_: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn rand(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     random_impl().map(NaslValue::Number)
 }
 
 /// NASL function to get host byte order
-fn get_byte_order<K>(_: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn get_byte_order(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     Ok(NaslValue::Boolean(cfg!(target_endian = "little")))
 }
 
 /// NASL function to convert given number to string
-fn dec2str<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn dec2str(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match register.named("num") {
         Some(ContextType::Value(NaslValue::Number(x))) => Ok(NaslValue::String(x.to_string())),
         x => Err(("0", "numeric", x).into()),
@@ -53,7 +53,7 @@ fn dec2str<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Function
 }
 
 /// takes an integer and sleeps the amount of seconds
-fn sleep<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn sleep(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     match positional[0] {
         NaslValue::Number(x) => {
@@ -65,7 +65,7 @@ fn sleep<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionEr
 }
 
 /// takes an integer and sleeps the amount of microseconds
-fn usleep<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn usleep(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     match positional[0] {
         NaslValue::Number(x) => {
@@ -78,7 +78,7 @@ fn usleep<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 
 /// Returns the type of given unnamed argument.
 // typeof is a reserved keyword, therefore it is prefixed with "nasl_"
-fn nasl_typeof<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_typeof(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Ok(NaslValue::Null);
@@ -96,7 +96,7 @@ fn nasl_typeof<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Func
 }
 
 /// Returns true when the given unnamed argument is null.
-fn isnull<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn isnull(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Err(FunctionErrorKind::MissingPositionalArguments {
@@ -111,7 +111,7 @@ fn isnull<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 }
 
 /// Returns the seconds counted from 1st January 1970 as an integer.
-fn unixtime<K>(_: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn unixtime(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match std::time::SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(t) => Ok(NaslValue::Number(t.as_secs() as i64)),
         Err(_) => Err(("0", "numeric").into()),
@@ -119,7 +119,7 @@ fn unixtime<K>(_: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorK
 }
 
 /// Compress given data with gzip, when headformat is set to 'gzip' it uses gzipheader.
-fn gzip<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn gzip(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let data = match register.named("data") {
         Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
         Some(ContextType::Value(x)) => Vec::<u8>::from(x),
@@ -155,7 +155,7 @@ fn gzip<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErr
 }
 
 /// uncompress given data with gzip, when headformat is set to 'gzip' it uses gzipheader.
-fn gunzip<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn gunzip(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let data = match register.named("data") {
         Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
         Some(ContextType::Value(x)) => Vec::<u8>::from(x),
@@ -178,7 +178,7 @@ fn gunzip<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
     }
 }
 /// Takes seven named arguments sec, min, hour, mday, mon, year, isdst and returns the Unix time.
-fn mktime<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn mktime(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let sec = match register.named("sec") {
         Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
         _ => 0,
@@ -242,7 +242,7 @@ where
 }
 
 /// Returns an dict(mday, mon, min, wday, sec, yday, isdst, year, hour) based on optional given time in seconds and optional flag if utc or not.
-fn localtime<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn localtime(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let utc_flag = match register.named("utc") {
         Some(ContextType::Value(NaslValue::Number(x))) => *x != 0,
         Some(ContextType::Value(NaslValue::Boolean(x))) => *x,
@@ -279,10 +279,7 @@ fn localtime<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Functi
 /// Uses the first positional argument to verify if a function is defined.
 /// This argument must be a string everything else will return False per default.
 /// Returns NaslValue::Boolean(true) when defined NaslValue::Boolean(false) otherwise.
-fn defined_func<K>(register: &Register, ctx: &Context<K>) -> Result<NaslValue, FunctionErrorKind>
-where
-    K: AsRef<str>,
-{
+fn defined_func(register: &Register, ctx: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
 
     Ok(match positional.first() {
@@ -298,10 +295,7 @@ where
 /// containing the seconds separated by a `.` followed by the microseconds.
 ///
 /// For example: “1067352015.030757” means 1067352015 seconds and 30757 microseconds.
-fn gettimeofday<K>(_: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind>
-where
-    K: AsRef<str>,
-{
+fn gettimeofday(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH) {
         Ok(time) => {
             let time = time.as_micros();
@@ -317,19 +311,13 @@ where
 
 /// Is a debug function to print the keys available within the called context. It does not take any
 /// nor returns any arguments.
-fn dump_ctxt<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind>
-where
-    K: AsRef<str>,
-{
+fn dump_ctxt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     register.dump(register.index() - 1);
     Ok(NaslValue::Null)
 }
 
 /// Returns found function for key or None when not found
-fn lookup<K>(key: &str) -> Option<NaslFunction<K>>
-where
-    K: AsRef<str>,
-{
+fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "rand" => Some(rand),
         "get_byte_order" => Some(get_byte_order),
@@ -353,17 +341,17 @@ where
 /// The description builtin function
 pub struct Misc;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Misc {
+impl nasl_builtin_utils::NaslFunctionExecuter for Misc {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<K>(name).is_some()
+        lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-misc/tests/misc.rs
+++ b/rust/nasl-builtin-misc/tests/misc.rs
@@ -7,7 +7,7 @@ mod tests {
     use chrono::Offset;
 
     use nasl_builtin_utils::Register;
-    use nasl_interpreter::{CodeInterpreter, ContextBuilder};
+    use nasl_interpreter::{CodeInterpreter, ContextFactory};
     use nasl_syntax::NaslValue;
     use std::time::Instant;
 
@@ -18,8 +18,8 @@ mod tests {
         rand();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         let first = parser.next();
         let second = parser.next();
@@ -34,8 +34,8 @@ mod tests {
         get_byte_order();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert!(matches!(parser.next(), Some(Ok(NaslValue::Boolean(_)))));
     }
@@ -46,8 +46,8 @@ mod tests {
         dec2str(num: 23);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok("23".into())));
     }
@@ -66,8 +66,8 @@ mod tests {
         typeof(23,76);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::String("string".into()))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::String("int".into()))));
@@ -87,8 +87,8 @@ mod tests {
         isnull(Null);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Boolean(false))));
         assert_eq!(parser.next(), Some(Ok(NaslValue::Boolean(true))));
@@ -100,8 +100,8 @@ mod tests {
         unixtime();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert!(matches!(parser.next(), Some(Ok(NaslValue::Number(_)))));
     }
@@ -113,8 +113,8 @@ mod tests {
         gzip(data: 'z');
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -144,8 +144,8 @@ mod tests {
         gunzip(data: ngz);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(parser.next(), Some(Ok(NaslValue::String("z".into()))));
@@ -164,8 +164,8 @@ mod tests {
         d = localtime(utc: FALSE);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
 
         let offset = chrono::Local::now().offset().fix().local_minus_utc();
@@ -235,8 +235,8 @@ mod tests {
         mktime(sec: 01, min: 02, hour: 03, mday: 01, mon: 01, year: 1970);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         let offset = chrono::Local::now().offset().fix().local_minus_utc();
         assert_eq!(
@@ -251,8 +251,8 @@ mod tests {
         sleep(1);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         let now = Instant::now();
         parser.next();
@@ -265,8 +265,8 @@ mod tests {
         usleep(1000);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         let now = Instant::now();
         parser.next();
@@ -284,8 +284,8 @@ mod tests {
         defined_func(a);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null))); // defining function b
         assert_eq!(parser.next(), Some(Ok(true.into()))); // is b defined

--- a/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
@@ -347,9 +347,9 @@ fn send_frame(
 ///  
 /// It takes the following argument:
 /// - cap_timeout: time to wait for answer in seconds, 5 by default
-fn nasl_send_arp_request<K>(
+fn nasl_send_arp_request(
     register: &Register,
-    context: &Context<K>,
+    context: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let timeout = match register.named("pcap_timeout") {
         Some(ContextType::Value(NaslValue::Number(x))) => *x as i32 * 1000i32, // to milliseconds
@@ -390,9 +390,9 @@ fn nasl_send_arp_request<K>(
 
 /// Get the MAC address of a local IP address.
 /// The first positional argument is a local IP address as string.
-fn nasl_get_local_mac_address_from_ip<K>(
+fn nasl_get_local_mac_address_from_ip(
     register: &Register,
-    _: &Context<K>,
+    _: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
@@ -425,10 +425,7 @@ fn nasl_get_local_mac_address_from_ip<K>(
 /// - dst_haddr: is a string containing the destination MAC address
 /// -ether_proto: is an int containing the ethernet type (normally given as hexadecimal). It is optional and its default value is 0x0800. A list of Types can be e.g. looked up here.
 /// -payload: is any data, which is then attached as payload to the frame.
-fn nasl_forge_frame<K>(
-    register: &Register,
-    _: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_forge_frame(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let src_haddr = validate_mac_address(register.named("src_haddr"))?;
     let dst_haddr = validate_mac_address(register.named("dst_haddr"))?;
     let ether_proto = match register.named("ether_proto") {
@@ -456,10 +453,7 @@ fn nasl_forge_frame<K>(
 /// - pcap_active: option to capture the answer, default is TRUE
 /// - pcap_filter: filter for the answer
 /// - pcap_timeout: time to wait for the answer in seconds, default 5
-fn nasl_send_frame<K>(
-    register: &Register,
-    context: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_send_frame(register: &Register, context: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let frame = match register.named("frame") {
         Some(ContextType::Value(NaslValue::Data(x))) => x,
         _ => return Err(("Data", "Invalid data type").into()),
@@ -498,10 +492,7 @@ fn nasl_send_frame<K>(
 /// Print a datalink layer frame in its hexadecimal representation.
 /// The named argument frame is a string representing the datalink layer frame. A frame can be created with forge_frame(3).
 /// This function is meant to be used for debugging.
-fn nasl_dump_frame<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_dump_frame(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let frame: Frame = match register.named("frame") {
         Some(ContextType::Value(NaslValue::Data(x))) => (x as &[u8]).try_into()?,
         _ => return Err(("Data", "Invalid data type").into()),
@@ -512,7 +503,7 @@ fn nasl_dump_frame<K>(
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "send_frame" => Some(nasl_send_frame),
         "dump_frame" => Some(nasl_dump_frame),

--- a/rust/nasl-builtin-raw-ip/src/lib.rs
+++ b/rust/nasl-builtin-raw-ip/src/lib.rs
@@ -9,12 +9,12 @@ use nasl_builtin_utils::{Context, NaslVars, Register};
 
 pub struct RawIp;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for RawIp {
+impl nasl_builtin_utils::NaslFunctionExecuter for RawIp {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         frame_forgery::lookup(name)
             .map(|x| x(register, context))
@@ -22,8 +22,8 @@ impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for RawIp {
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        frame_forgery::lookup::<K>(name)
-            .or_else(|| packet_forgery::lookup::<K>(name))
+        frame_forgery::lookup(name)
+            .or_else(|| packet_forgery::lookup(name))
             .is_some()
     }
 }

--- a/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
@@ -119,10 +119,7 @@ fn safe_copy_from_slice(
 /// - ip_v is: the IP version. 4 by default.
 ///
 /// Returns the IP datagram or NULL on error.
-fn forge_ip_packet<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn forge_ip_packet(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let dst_addr = get_host_ip(configs)?;
 
     if dst_addr.is_ipv6() {
@@ -269,9 +266,9 @@ fn forge_ip_packet<K>(
 /// - ip_v: IP version, 4 by default
 ///  
 /// Returns the modified IP datagram
-fn set_ip_elements<K>(
+fn set_ip_elements(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let mut buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -369,10 +366,7 @@ fn set_ip_elements<K>(
 /// - ip_sum
 /// - ip_src
 /// - ip_dst
-fn get_ip_element<K>(
-    register: &Register,
-    _configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn get_ip_element(register: &Register, _configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
         _ => {
@@ -407,10 +401,7 @@ fn get_ip_element<K>(
 }
 
 /// Receive a list of IP packets and print them in a readable format in the screen.
-fn dump_ip_packet<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn dump_ip_packet(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Err(FunctionErrorKind::MissingPositionalArguments {
@@ -498,9 +489,9 @@ fn dump_ip_packet<K>(
 /// - code: is the identifier of the option to add
 /// - length: is the length of the option data
 /// - value: is the option data
-fn insert_ip_options<K>(
+fn insert_ip_options(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -595,9 +586,9 @@ fn insert_ip_options<K>(
 /// - update_ip_len: is a flag (TRUE by default). If set, NASL will recompute the size field of the IP datagram.
 ///  
 /// The modified IP datagram or NULL on error.
-fn forge_tcp_packet<K>(
+fn forge_tcp_packet(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let mut ip_buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -718,9 +709,9 @@ fn forge_tcp_packet<K>(
 /// - data
 ///  
 /// Returns an TCP element from a IP datagram.
-fn get_tcp_element<K>(
+fn get_tcp_element(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("tcp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -766,10 +757,7 @@ fn get_tcp_element<K>(
 /// - 8: TCPOPT_TIMESTAMP, 8 bytes value for timestamp and echo timestamp, 4 bytes each one.
 ///  
 /// The returned option depends on the given *option* parameter. It is either an int for option 2, 3 and 4 or an array containing the two values for option 8.
-fn get_tcp_option<K>(
-    register: &Register,
-    _configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn get_tcp_option(register: &Register, _configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("tcp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
         _ => {
@@ -847,9 +835,9 @@ fn get_tcp_option<K>(
 /// - th_win: is the TCP window size. NASL will convert it into network order if necessary. 0 by default.
 /// - th_x2: is a reserved field and should probably be left unchanged. 0 by default.
 /// - update_ip_len: is a flag (TRUE by default). If set, NASL will recompute the size field of the IP datagram.
-fn set_tcp_elements<K>(
+fn set_tcp_elements(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("tcp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -992,9 +980,9 @@ fn set_tcp_elements<K>(
 /// - 3: TCPOPT_WINDOW, with values between 0 and 14
 /// - 4: TCPOPT_SACK_PERMITTED, no value required.
 /// - 8: TCPOPT_TIMESTAMP, 8 bytes value for timestamp and echo timestamp, 4 bytes each one.
-fn insert_tcp_options<K>(
+fn insert_tcp_options(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("tcp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1177,10 +1165,7 @@ fn insert_tcp_options<K>(
 }
 
 /// Receive a list of IPv4 datagrams and print their TCP part in a readable format in the screen.
-fn dump_tcp_packet<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn dump_tcp_packet(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Err(FunctionErrorKind::Dirty(
@@ -1342,9 +1327,9 @@ fn dump_tcp_packet<K>(
 /// - update_ip_len: is a flag (TRUE by default). If set, NASL will recompute the size field of the IP datagram.
 
 /// Returns the modified IP datagram or NULL on error.
-fn forge_udp_packet<K>(
+fn forge_udp_packet(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let mut ip_buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1428,9 +1413,9 @@ fn forge_udp_packet<K>(
 /// - uh_sport: is the source port. NASL will convert it into network order if necessary. 0 by default.
 /// - uh_sum: is the UDP checksum. Although it is not compulsory, the right value is computed by default.
 /// - uh_ulen: is the data length. By default it is set to the length the data argument plus the size of the UDP header.
-fn set_udp_elements<K>(
+fn set_udp_elements(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("udp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1538,10 +1523,7 @@ fn set_udp_elements<K>(
 }
 
 /// Receive a list of IPv4 datagrams and print their UDP part in a readable format in the screen.
-fn dump_udp_packet<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn dump_udp_packet(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Err(FunctionErrorKind::Dirty(
@@ -1606,9 +1588,9 @@ fn dump_udp_packet<K>(
 /// - uh_ulen
 /// - uh_sum
 /// - data
-fn get_udp_element<K>(
+fn get_udp_element(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("udp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1646,9 +1628,9 @@ fn get_udp_element<K>(
 /// - *icmp_seq*: ICMP sequence number.
 /// - *icmp_type*: ICMP type. 0 by default.
 /// - *update_ip_len*: If this flag is set, NASL will recompute the size field of the IP datagram. Default: True.
-fn forge_icmp_packet<K>(
+fn forge_icmp_packet(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let mut ip_buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1744,9 +1726,9 @@ fn forge_icmp_packet<K>(
 /// - icmp_seq
 /// - icmp_chsum
 /// - icmp_data
-fn get_icmp_element<K>(
+fn get_icmp_element(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let buf = match register.named("icmp") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -1805,9 +1787,9 @@ fn get_icmp_element<K>(
 }
 
 /// Receive a list of IPv4 ICMP packets and print them in a readable format in the screen.
-fn dump_icmp_packet<K>(
+fn dump_icmp_packet(
     register: &Register,
-    configs: &Context<K>,
+    configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
@@ -1947,9 +1929,9 @@ pub mod igmp {
 /// - group: IGMP group
 /// - type: IGMP type. 0 by default.
 /// - update_ip_len: If this flag is set, NASL will recompute the size field of the IP datagram. Default: True.
-fn forge_igmp_packet<K>(
+fn forge_igmp_packet(
     register: &Register,
-    _configs: &Context<K>,
+    _configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let mut ip_buf = match register.named("ip") {
         Some(ContextType::Value(NaslValue::Data(d))) => d.clone(),
@@ -2055,10 +2037,7 @@ fn new_raw_socket() -> Result<Socket, FunctionErrorKind> {
 ///  
 /// Its argument is:
 /// - port: port for the ping
-fn nasl_tcp_ping<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_tcp_ping(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let rnd_tcp_port = || -> u16 { (random_impl().unwrap_or(0) % 65535 + 1024) as u16 };
 
     let sports_ori: Vec<u16> = vec![
@@ -2194,9 +2173,9 @@ fn nasl_tcp_ping<K>(
 /// - pcap_filter: BPF filter used for the answers
 /// - pcap_timeout: time to wait for the answers in seconds, 5 by default
 /// - allow_broadcast: default FALSE
-fn nasl_send_packet<K>(
+fn nasl_send_packet(
     register: &Register,
-    configs: &Context<K>,
+    configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let use_pcap = match register.named("pcap_active") {
         Some(ContextType::Value(NaslValue::Boolean(x))) => *x,
@@ -2324,10 +2303,7 @@ fn nasl_send_packet<K>(
 /// - interface: network interface name, by default NASL will try to find the best one
 /// - pcap_filter: BPF filter, by default it listens to everything
 /// - timeout: timeout in seconds, 5 by default
-fn nasl_pcap_next<K>(
-    register: &Register,
-    configs: &Context<K>,
-) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_pcap_next(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     nasl_send_capture(register, configs)
 }
 
@@ -2336,9 +2312,9 @@ fn nasl_pcap_next<K>(
 /// - interface: network interface name, by default NASL will try to find the best one
 /// - pcap_filter: BPF filter, by default it listens to everything
 /// - timeout: timeout in seconds, 5 by default
-fn nasl_send_capture<K>(
+fn nasl_send_capture(
     register: &Register,
-    configs: &Context<K>,
+    configs: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let interface = match register.named("interface") {
         Some(ContextType::Value(NaslValue::String(x))) => x.to_string(),
@@ -2445,7 +2421,7 @@ pub fn expose_vars() -> NaslVars<'static> {
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "forge_ip_packet" => Some(forge_ip_packet),
         "set_ip_elements" => Some(set_ip_elements),

--- a/rust/nasl-builtin-raw-ip/tests/frame_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/tests/frame_forgery.rs
@@ -8,7 +8,7 @@ mod tests {
 
     //use super::convert_vec_into_mac_address;
 
-    use nasl_builtin_std::ContextBuilder;
+    use nasl_builtin_std::ContextFactory;
     use nasl_builtin_utils::Register;
     use nasl_interpreter::CodeInterpreter;
     use nasl_syntax::NaslValue;
@@ -21,9 +21,9 @@ mod tests {
         get_local_mac_address_from_ip("::1");
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -49,10 +49,10 @@ mod tests {
         dump_frame(frame:a);
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -78,9 +78,9 @@ mod tests {
         send_frame(frame: a, pcap_active: TRUE);
         send_frame(frame: a, pcap_active: TRUE, filter: "arp", timeout: 2);
         "#;
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let register = Register::default();
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();

--- a/rust/nasl-builtin-raw-ip/tests/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/tests/packet_forgery.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 mod tests {
 
-    use nasl_builtin_std::ContextBuilder;
+    use nasl_builtin_std::ContextFactory;
     use nasl_builtin_utils::{error::FunctionErrorKind, Register};
     use nasl_interpreter::CodeInterpreter;
     use nasl_syntax::NaslValue;
@@ -64,10 +64,10 @@ mod tests {
                               th_urp:   0);
         "###;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -104,10 +104,10 @@ mod tests {
         elem = get_ip_element(ip: ip_packet, element: "ip_ttl");
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(255))));
@@ -133,10 +133,10 @@ mod tests {
         opt = get_ip_element(ip: ip_packet, element: "ip_hl");
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -173,10 +173,10 @@ mod tests {
         opt = get_tcp_option(tcp: tcp_packet, option: 3);
         "###;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -206,10 +206,10 @@ mod tests {
                                       data: "1234");
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -248,10 +248,10 @@ mod tests {
                      data: "1234");
         "#;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(
@@ -284,10 +284,10 @@ mod tests {
                      );
         "###;
         let register = Register::default();
-        let mut binding = ContextBuilder::default();
+        let mut binding = ContextFactory::default();
         binding.functions.push_executer(nasl_builtin_raw_ip::RawIp);
 
-        let context = binding.build();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(

--- a/rust/nasl-builtin-ssh/src/lib.rs
+++ b/rust/nasl-builtin-ssh/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     time::Duration,
 };
 
-type NaslSSHFunction<K> = fn(&Ssh, &Register, &Context<K>) -> Result<NaslValue, FunctionErrorKind>;
+type NaslSSHFunction = fn(&Ssh, &Register, &Context) -> Result<NaslValue, FunctionErrorKind>;
 
 fn read_ssh_blocking(channel: &Channel, timeout: Duration, response: &mut String) -> i32 {
     let mut buf: [u8; 4096] = [0; 4096];
@@ -415,10 +415,10 @@ impl Ssh {
     /// seconds (defined by libssh internally) if not given.
     ///
     /// nasl return An integer to identify the ssh session. Zero on error.
-    fn nasl_ssh_connect<K>(
+    fn nasl_ssh_connect(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let sock: i64 = register
             .named("socket")
@@ -627,10 +627,10 @@ impl Ssh {
     ///
     /// nasl params
     /// - An SSH session id.  A value of 0 is allowed and acts as a NOP.
-    fn nasl_ssh_disconnect<K>(
+    fn nasl_ssh_disconnect(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -671,10 +671,10 @@ impl Ssh {
     ///
     /// return An integer with the corresponding ssh session id or 0 if
     ///          no session id is known for the given socket.
-    fn nasl_ssh_session_id_from_sock<K>(
+    fn nasl_ssh_session_id_from_sock(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -701,10 +701,10 @@ impl Ssh {
     /// - An SSH session id.
     ///  
     /// return An integer representing the socket or -1 on error.
-    fn nasl_ssh_get_sock<K>(
+    fn nasl_ssh_get_sock(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -740,10 +740,10 @@ impl Ssh {
     ///  
     /// nasl named params
     /// - login: A string with the login name (optional).
-    fn nasl_ssh_set_login<K>(
+    fn nasl_ssh_set_login(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -829,10 +829,10 @@ impl Ssh {
     /// - passphrase: A string with the passphrase used to unprotect privatekey.
     ///  
     /// return An integer as status value; 0 indicates success.
-    fn nasl_ssh_userauth<K>(
+    fn nasl_ssh_userauth(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1098,10 +1098,10 @@ impl Ssh {
     ///    description.
     ///
     /// return A data block on success or NULL on error.
-    fn nasl_ssh_request_exec<K>(
+    fn nasl_ssh_request_exec(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1198,10 +1198,10 @@ impl Ssh {
     /// - pty: To enable/disable the interactive shell. Default is 1 (interactive).
     ///
     /// @naslret An int on success or NULL on error.
-    fn nasl_ssh_shell_open<K>(
+    fn nasl_ssh_shell_open(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1274,10 +1274,10 @@ impl Ssh {
     /// bytes left to read.
     ///
     /// return A string on success or NULL on error.
-    fn nasl_ssh_shell_read<K>(
+    fn nasl_ssh_shell_read(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1350,10 +1350,10 @@ impl Ssh {
     /// - cmd: A string to write to shell.
     ///
     /// return An integer: 0 on success, -1 on failure.
-    fn nasl_ssh_shell_write<K>(
+    fn nasl_ssh_shell_write(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1419,10 +1419,10 @@ impl Ssh {
     ///
     /// nasl params
     /// - An SSH session id.
-    fn nasl_ssh_shell_close<K>(
+    fn nasl_ssh_shell_close(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1480,10 +1480,10 @@ impl Ssh {
     /// - login: A string with the login name.
     ///  
     /// return A data block on success or NULL on error.
-    fn nasl_ssh_login_interactive<K>(
+    fn nasl_ssh_login_interactive(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1607,10 +1607,10 @@ impl Ssh {
     ///
     /// return An integer as status value; 0 indicates success.
     ///
-    fn nasl_ssh_login_interactive_pass<K>(
+    fn nasl_ssh_login_interactive_pass(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1720,10 +1720,10 @@ impl Ssh {
     ///
     /// return A data block on success or NULL on error.
     ///
-    fn nasl_ssh_get_issue_banner<K>(
+    fn nasl_ssh_get_issue_banner(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1780,10 +1780,10 @@ impl Ssh {
     /// - An SSH session id.
     ///
     /// return A data block on success or NULL on error.
-    fn nasl_ssh_get_server_banner<K>(
+    fn nasl_ssh_get_server_banner(
         &self,
         register: &Register,
-        _: &Context<K>,
+        _: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1832,10 +1832,10 @@ impl Ssh {
     /// - An SSH session id.
     ///
     /// return A string on success or NULL on error.
-    fn nasl_ssh_get_auth_methods<K>(
+    fn nasl_ssh_get_auth_methods(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1908,10 +1908,10 @@ impl Ssh {
     /// - An SSH session id.
     ///
     /// @naslret A data block on success or NULL on error.
-    fn nasl_ssh_get_host_key<K>(
+    fn nasl_ssh_get_host_key(
         &self,
         register: &Register,
-        _: &Context<K>,
+        _: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -1962,10 +1962,10 @@ impl Ssh {
     /// return An integer: 0 on success, -1 (SSH_ERROR) on Channel request
     /// subsystem failure. Greater than 0 means an error during SFTP init. NULL
     /// indicates a failure during session id verification.
-    fn nasl_sftp_enabled_check<K>(
+    fn nasl_sftp_enabled_check(
         &self,
         register: &Register,
-        ctx: &Context<K>,
+        ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -2021,10 +2021,10 @@ impl Ssh {
     ///
     /// param[in] lexic Lexical context of NASL interpreter.
     /// return Session ID on success, NULL on failure.
-    fn nasl_ssh_execute_netconf_subsystem<K>(
+    fn nasl_ssh_execute_netconf_subsystem(
         &self,
         register: &Register,
-        _ctx: &Context<K>,
+        _ctx: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let positional = register.positional();
         if positional.is_empty() {
@@ -2091,7 +2091,7 @@ impl Ssh {
         }
     }
 
-    fn lookup<K>(key: &str) -> Option<NaslSSHFunction<K>> {
+    fn lookup(key: &str) -> Option<NaslSSHFunction> {
         match key {
             "ssh_connect" => Some(Ssh::nasl_ssh_connect),
             "ssh_disconnect" => Some(Ssh::nasl_ssh_disconnect),
@@ -2117,7 +2117,7 @@ impl Ssh {
     }
 }
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Ssh {
+impl nasl_builtin_utils::NaslFunctionExecuter for Ssh {
     fn nasl_fn_cache_clear(&self) -> Option<usize> {
         let mut data = Arc::as_ref(&self.sessions).lock().unwrap();
         if data.is_empty() {
@@ -2133,12 +2133,12 @@ impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for Ssh {
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         Ssh::lookup(name).map(|f| f(self, register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        Ssh::lookup::<K>(name).is_some()
+        Ssh::lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-std/README.md
+++ b/rust/nasl-builtin-std/README.md
@@ -15,7 +15,8 @@ and set all but the functions. This will use the DefaultDispatcher as well as an
 For production use cases it is recommended to use new method and include a key and a storage:
 
 ```
-let key = "test:localhost".to_string();
+use storage::ContextKey;
+let key = ContextKey::Scan("test:localhost".to_string());
 let cb = nasl_builtin_std::ContextBuilder::new(key, Box::new(storage::DefaultDispatcher::default()));
 ```
 
@@ -80,16 +81,16 @@ Afterwards you need to create two methods. One for when the library is not inclu
 
 ```
 #[cfg(not(feature = "nasl-builtin-ssh"))]
-fn add_ssh<K: AsRef<str>>(
-    builder: nasl_builtin_utils::NaslfunctionRegisterBuilder<K>,
-) -> nasl_builtin_utils::NaslfunctionRegisterBuilder<K> {
+fn add_ssh(
+    builder: nasl_builtin_utils::NaslfunctionRegisterBuilder,
+) -> nasl_builtin_utils::NaslfunctionRegisterBuilder {
     builder
 }
 
 #[cfg(feature = "nasl-builtin-ssh")]
-fn add_ssh<K: AsRef<str>>(
-    builder: nasl_builtin_utils::NaslfunctionRegisterBuilder<K>,
-) -> nasl_builtin_utils::NaslfunctionRegisterBuilder<K> {
+fn add_ssh(
+    builder: nasl_builtin_utils::NaslfunctionRegisterBuilder,
+) -> nasl_builtin_utils::NaslfunctionRegisterBuilder {
     builder.push_register(nasl_builtin_ssh::Ssh::default())
 }
 

--- a/rust/nasl-builtin-std/README.md
+++ b/rust/nasl-builtin-std/README.md
@@ -2,12 +2,12 @@
 
 Contains functions that are within the std library of nasl.
 
-To use the std functions it is recommended to use the defined [ContextBuilder] as it sets the function register to the one created in [nasl_std_functions] automatically.
+To use the std functions it is recommended to use the defined [ContextFactory] as it sets the function register to the one created in [nasl_std_functions] automatically.
 
 All you have todo as a user is to create the builder
 
 ```
-let cb = nasl_builtin_std::ContextBuilder::default();
+let cb = nasl_builtin_std::ContextFactory::default();
 ```
 
 and set all but the functions. This will use the DefaultDispatcher as well as an empty String as a key.
@@ -15,9 +15,11 @@ and set all but the functions. This will use the DefaultDispatcher as well as an
 For production use cases it is recommended to use new method and include a key and a storage:
 
 ```
-use storage::ContextKey;
-let key = ContextKey::Scan("test:localhost".to_string());
-let cb = nasl_builtin_std::ContextBuilder::new(key, Box::new(storage::DefaultDispatcher::default()));
+
+let loader = nasl_syntax::FSPluginLoader::new("/feed");
+let logger = nasl_syntax::logger::DefaultLogger::default();
+let storage = storage::DefaultDispatcher::default();
+let cb = nasl_builtin_std::ContextFactory::new(loader, logger, storage);
 ```
 
 ## Add functions to std

--- a/rust/nasl-builtin-std/src/array.rs
+++ b/rust/nasl-builtin-std/src/array.rs
@@ -21,7 +21,7 @@ use nasl_builtin_utils::resolve_positional_arguments;
 /// Each uneven arguments out of positional arguments are used as keys while each even even argument is used a value.
 /// When there is an uneven number of elements the last key will be dropped, as there is no corresponding value.
 /// So `make_array(1, 0, 1)` will return the same response as `make_array(1, 0)`.
-fn make_array<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn make_array(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut values = HashMap::new();
     for (idx, val) in positional.iter().enumerate() {
@@ -47,20 +47,20 @@ fn nasl_make_list(register: &Register) -> Result<Vec<NaslValue>, FunctionErrorKi
     Ok(values)
 }
 /// NASL function to create a list out of a number of unnamed arguments
-fn make_list<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn make_list(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let values = nasl_make_list(register)?;
     Ok(NaslValue::Array(values))
 }
 
 /// NASL function to sorts the values of a dict/array. WARNING: drops the keys of a dict and returns an array.
-fn nasl_sort<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn nasl_sort(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let mut values = nasl_make_list(register)?;
     values.sort();
     Ok(NaslValue::Array(values))
 }
 
 /// Returns an array with the keys of a dict
-fn keys<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn keys(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut keys = Vec::<NaslValue>::new();
     for val in positional.iter() {
@@ -75,7 +75,7 @@ fn keys<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErr
 }
 
 /// NASL function to return the length of an array|dict.
-fn max_index<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn max_index(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = register.positional();
     if positional.is_empty() {
         return Ok(NaslValue::Null);
@@ -89,7 +89,7 @@ fn max_index<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Functi
 }
 
 /// Returns found function for key or None when not found
-pub(crate) fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub(crate) fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "make_array" => Some(make_array),
         "make_list" => Some(make_list),

--- a/rust/nasl-builtin-std/src/lib.rs
+++ b/rust/nasl-builtin-std/src/lib.rs
@@ -6,8 +6,7 @@
 #![warn(missing_docs)]
 
 use nasl_builtin_utils::{Context, NaslFunctionRegister, NaslVarRegister, Register};
-use nasl_syntax::{logger::NaslLogger, Loader};
-use storage::{ContextKey, DefaultDispatcher, Storage};
+use storage::{ContextKey, DefaultDispatcher};
 mod array;
 
 /// The description builtin function
@@ -164,66 +163,68 @@ fn add_raw_ip_vars(
     builder
 }
 
-/// Contains the key as well as the dispatcher.
-///
-/// This is to ensure that the key and the dispatcher do have the same type.
-/// It makes it also a bit easier to use as the key as well as the dispatcher are usually created
-/// together.
-pub struct KeyDispatcherSet {
-    key: ContextKey,
-    storage: Box<dyn Storage>,
-}
-
 /// The context builder.
 ///
 /// This is the main entry point for the nasl interpreter and adds all the functions defined in
 /// [nasl_std_functions] to functions register.
 // TODO: remove key and target and box dyn
-pub struct ContextBuilder<S> {
-    /// The key and dispatcher set.
-    pub key: S,
-    /// The target to test.
-    pub target: String,
+pub struct ContextFactory<Loader, Logger, Storage> {
+    /// The shared storage
+    pub storage: Storage,
     /// The loader to load the nasl files.
-    pub loader: Box<dyn Loader>,
+    pub loader: Loader,
     /// The logger to log.
-    pub logger: Box<dyn NaslLogger>,
+    pub logger: Logger,
     /// The functions available to the nasl script.
     pub functions: NaslFunctionRegister,
 }
 
-impl Default for ContextBuilder<KeyDispatcherSet> {
+impl Default
+    for ContextFactory<
+        nasl_syntax::NoOpLoader,
+        nasl_syntax::logger::DefaultLogger,
+        storage::DefaultDispatcher,
+    >
+{
     fn default() -> Self {
         Self {
-            key: KeyDispatcherSet {
-                key: ContextKey::FileName(Default::default()),
-                storage: Box::<DefaultDispatcher>::default(),
-            },
-            target: Default::default(),
-            loader: Default::default(),
+            loader: nasl_syntax::NoOpLoader::default(),
             logger: Default::default(),
             functions: nasl_std_functions(),
+            storage: DefaultDispatcher::default(),
         }
     }
 }
 
-impl<S> ContextBuilder<S> {
-    /// Sets the target to test.
-    pub fn target(mut self, target: String) -> Self {
-        self.target = target;
-        self
+impl<A, B, C> ContextFactory<A, B, C>
+where
+    A: nasl_syntax::Loader,
+    B: nasl_syntax::logger::NaslLogger,
+    C: storage::Storage,
+{
+    /// Creates a new ContextFactory with nasl_std_functions
+    ///
+    /// If you want to override the functions register please use functions method.
+    pub fn new(loader: A, logger: B, storage: C) -> ContextFactory<A, B, C> {
+        ContextFactory {
+            storage,
+            loader,
+            logger,
+            functions: nasl_std_functions(),
+        }
     }
 
-    /// Sets the loader to load the nasl files.
-    pub fn loader<L: Loader + 'static>(mut self, loader: L) -> Self {
-        self.loader = Box::new(loader);
-        self
-    }
-
-    /// Sets the logger to log.
-    pub fn logger<L: NaslLogger + 'static>(mut self, logger: L) -> Self {
-        self.logger = Box::new(logger);
-        self
+    /// Creates a new ContextFactory with a DefaultLogger
+    pub fn with_default_logger(
+        loader: A,
+        storage: C,
+    ) -> ContextFactory<A, nasl_syntax::logger::DefaultLogger, C> {
+        ContextFactory {
+            storage,
+            loader,
+            logger: Default::default(),
+            functions: nasl_std_functions(),
+        }
     }
 
     /// Sets the functions available to the nasl script.
@@ -231,32 +232,16 @@ impl<S> ContextBuilder<S> {
         self.functions = functions;
         self
     }
-}
 
-impl ContextBuilder<KeyDispatcherSet> {
-    /// Creates a new context builder with the given key and storage.
-    // TODO remove key and move it to build as they change per script call
-    pub fn new(key: ContextKey, storage: Box<dyn Storage>) -> Self {
-        Self {
-            key: KeyDispatcherSet { key, storage },
-            target: Default::default(),
-            loader: Default::default(),
-            logger: Default::default(),
-            functions: nasl_std_functions(),
-        }
-    }
-
-    /// Createz the context.
-    ///
-    /// Be aware that unlike normal builder, because of the lifetime of the dispatcher, the ContextBuilder must exist as long as the context and cannot be dropped immediately.
-    pub fn build(&self) -> Context {
+    /// Creates a new Context with the shared loader, logger and function register
+    pub fn build(&self, key: ContextKey, target: String) -> Context {
         Context::new(
-            &self.key.key,
-            &self.target,
-            self.key.storage.as_dispatcher(),
-            self.key.storage.as_retriever(),
-            &*self.loader,
-            self.logger.as_ref(),
+            key,
+            target,
+            self.storage.as_dispatcher(),
+            self.storage.as_retriever(),
+            &self.loader,
+            &self.logger,
             &self.functions,
         )
     }

--- a/rust/nasl-builtin-std/tests/array.rs
+++ b/rust/nasl-builtin-std/tests/array.rs
@@ -6,7 +6,7 @@
 mod tests {
     use std::collections::HashMap;
 
-    use nasl_builtin_std::ContextBuilder;
+    use nasl_builtin_std::ContextFactory;
     use nasl_builtin_utils::Register;
     use nasl_interpreter::CodeInterpreter;
     use nasl_syntax::NaslValue;
@@ -35,8 +35,8 @@ mod tests {
         make_array();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(make_dict!(1 => 0i64, 2 => 1i64))));
         assert_eq!(parser.next(), Some(Ok(make_dict!(1 => 0i64, 2 => 1i64))));
@@ -56,8 +56,8 @@ mod tests {
         make_list(1, 0, a);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),
@@ -109,8 +109,8 @@ mod tests {
         s = sort(l);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -134,8 +134,8 @@ mod tests {
         keys(a,l);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         parser.next();
@@ -159,8 +159,8 @@ mod tests {
         max_index(make_list());
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(parser.next(), Some(Ok(NaslValue::Number(5))));

--- a/rust/nasl-builtin-string/src/lib.rs
+++ b/rust/nasl-builtin-string/src/lib.rs
@@ -58,7 +58,7 @@ fn append_nasl_value_as_u8(data: &mut Vec<u8>, p: &NaslValue) {
 }
 
 /// NASL function to parse numeric values into characters and combine with additional values
-fn raw_string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn raw_string(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut data: Vec<u8> = vec![];
     for p in positional {
@@ -100,7 +100,7 @@ fn write_nasl_string(s: &mut String, value: &NaslValue) -> Result<(), FunctionEr
 }
 
 /// NASL function to parse values into string representations
-fn string<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn string(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let mut s = String::with_capacity(2 * positional.len());
     for p in positional {
@@ -139,7 +139,7 @@ fn write_nasl_string_value(s: &mut String, value: &NaslValue) -> Result<(), Func
 /// NASL function to return uppercase equivalent of a given string
 ///
 /// If this function retrieves anything but a string it returns NULL
-fn toupper<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn toupper(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.first() {
         Some(NaslValue::String(x)) => x.to_uppercase().into(),
@@ -156,7 +156,7 @@ fn toupper<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Function
 /// NASL function to return lowercase equivalent of a given string
 ///
 /// If this function retrieves anything but a string it returns NULL
-fn tolower<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn tolower(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.first() {
         Some(NaslValue::String(x)) => x.to_lowercase().into(),
@@ -173,7 +173,7 @@ fn tolower<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, Function
 /// NASL function to return the length of string
 ///
 /// If this function retrieves anything but a string it returns 0
-fn strlen<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn strlen(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     Ok(match positional.first() {
         Some(NaslValue::String(x)) => x.len().into(),
@@ -189,7 +189,7 @@ fn strlen<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// The optional third positional argument is an *int* and contains the end index for the slice.
 /// If not given it is set to the end of the string.
 /// If the start integer is higher than the value of the string NULL is returned.
-fn substr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn substr(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     if positional.len() < 2 {
         return Ok(NaslValue::Null);
@@ -215,7 +215,7 @@ fn substr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 ///
 /// If the positional arguments are empty it returns NaslValue::Null.
 /// It only uses the first positional argument and when it is not a NaslValue:String than it returns NaslValue::Null.
-fn hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn hexstr(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let hexler = |x: &str| -> Result<NaslValue, FunctionErrorKind> {
         let mut s = String::with_capacity(2 * x.len());
@@ -234,7 +234,7 @@ fn hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// NASL function to convert a hexadecimal representation into byte data.
 ///
 /// The first positional argument must be a string, all other arguments are ignored. If either the no argument was given or the first positional is not a string, a error is returned.
-fn hexstr_to_data<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn hexstr_to_data(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match resolve_positional_arguments(register).first() {
         Some(NaslValue::String(x)) => match decode_hex(x) {
             Ok(y) => Ok(NaslValue::Data(y)),
@@ -258,7 +258,7 @@ fn hexstr_to_data<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, F
 /// NASL function to convert byte data into hexadecimal representation as lower case string.
 ///
 /// The first positional argument must be byte data, all other arguments are ignored. If either the no argument was given or the first positional is not byte data, a error is returned.
-fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn data_to_hexstr(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     match resolve_positional_arguments(register).first() {
         Some(NaslValue::Data(x)) => Ok(encode_hex(x)?.into()),
         Some(x) => Err(("first positional argument", "data", x.to_string().as_str()).into()),
@@ -270,7 +270,7 @@ fn data_to_hexstr<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, F
 ///
 /// Length argument is required and can be a named argument or a positional argument.
 /// Data argument is an optional named argument and is taken to be "X" if not provided.
-fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn crap(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let data = match register.named("data") {
         None => "X",
         Some(ContextType::Value(NaslValue::String(x))) => x,
@@ -300,7 +300,7 @@ fn crap<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErr
 /// NASL function to remove trailing whitespaces from a string
 ///
 /// Takes one required positional argument of string type.
-fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn chomp(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     match positional.first() {
         Some(NaslValue::String(x)) => Ok(x.trim_end().to_owned().into()),
@@ -320,7 +320,7 @@ fn chomp<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionEr
 /// The first positional argument is the *string* to search through.
 /// The second positional argument is the *string* to search for.
 /// The optional third positional argument is an *int* containing an offset from where to start the search.
-fn stridx<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn stridx(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let positional = resolve_positional_arguments(register);
     let haystack = match positional.first() {
         Some(NaslValue::String(x)) => x,
@@ -343,13 +343,13 @@ fn stridx<K>(register: &Register, _: &Context<K>) -> Result<NaslValue, FunctionE
 /// NASL function to display any number of NASL values
 ///
 /// Internally the string function is used to concatenate the given parameters
-fn display<K>(register: &Register, configs: &Context<K>) -> Result<NaslValue, FunctionErrorKind> {
+fn display(register: &Register, configs: &Context) -> Result<NaslValue, FunctionErrorKind> {
     println!("{}", &string(register, configs)?);
     Ok(NaslValue::Null)
 }
 
 /// Returns found function for key or None when not found
-pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
+pub fn lookup(key: &str) -> Option<NaslFunction> {
     match key {
         "hexstr" => Some(hexstr),
         "raw_string" => Some(raw_string),
@@ -371,17 +371,17 @@ pub fn lookup<K>(key: &str) -> Option<NaslFunction<K>> {
 /// The description builtin function
 pub struct NaslString;
 
-impl<K: AsRef<str>> nasl_builtin_utils::NaslFunctionExecuter<K> for NaslString {
+impl nasl_builtin_utils::NaslFunctionExecuter for NaslString {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<nasl_builtin_utils::NaslResult> {
         lookup(name).map(|x| x(register, context))
     }
 
     fn nasl_fn_defined(&self, name: &str) -> bool {
-        lookup::<K>(name).is_some()
+        lookup(name).is_some()
     }
 }

--- a/rust/nasl-builtin-string/tests/string.rs
+++ b/rust/nasl-builtin-string/tests/string.rs
@@ -16,8 +16,8 @@ mod tests {
         hexstr(raw_string(10, 208, 102, 165, 210, 159, 63, 42, 42, 28, 124, 23, 221, 8, 42, 121));
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         parser.next();
         assert_eq!(parser.next(), Some(Ok("666f6f".into())));
@@ -39,8 +39,8 @@ mod tests {
         raw_string(0x7B, 1, "Hallo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(vec![123].into())));
         assert_eq!(parser.next(), Some(Ok(vec![123, 1].into())));
@@ -56,8 +56,8 @@ mod tests {
         tolower('HALLO');
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok("hallo".into())));
@@ -69,8 +69,8 @@ mod tests {
         toupper('hallo');
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok("HALLO".into())));
@@ -82,8 +82,8 @@ mod tests {
         strlen('hallo');
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(0i64.into())));
         assert_eq!(parser.next(), Some(Ok(5i64.into())));
@@ -97,8 +97,8 @@ mod tests {
         string(0x7B, 1, NULL, "Hallo");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok("123".into())));
         assert_eq!(parser.next(), Some(Ok("1231".into())));
@@ -114,8 +114,8 @@ mod tests {
         substr("hello", 6);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok("ello".into())));
         assert_eq!(parser.next(), Some(Ok("hell".into())));
@@ -130,8 +130,8 @@ mod tests {
         crap(data: "ab", length: 5);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok("XXXXX".into())));
         assert_eq!(parser.next(), Some(Ok("XXXXX".into())));
@@ -147,8 +147,8 @@ mod tests {
         chomp("abc\n\t\r ");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok("abc".into())));
         assert_eq!(parser.next(), Some(Ok("abc".into())));
@@ -167,8 +167,8 @@ mod tests {
         stridx("blahbc", "abc", 2);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok((-1_i64).into())));
         assert_eq!(parser.next(), Some(Ok(1_i64.into())));
@@ -184,8 +184,8 @@ mod tests {
         display("abc");
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
     }
@@ -197,8 +197,8 @@ mod tests {
         data_to_hexstr(a);
         "#;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),

--- a/rust/nasl-builtin-utils/README.md
+++ b/rust/nasl-builtin-utils/README.md
@@ -74,12 +74,12 @@ impl NaslFunctionExecuter for Test {
 
 
 let key = "test".into();
-let target = "localhost";
+let target = "localhost".into();
 let storage = storage::DefaultDispatcher::default();
 let loader = nasl_syntax::NoOpLoader::default();
 let logger = nasl_syntax::logger::DefaultLogger::default();
 let context =
-    Context::new(&key, target, &storage, &storage, &loader, &logger, &Test);
+    Context::new(key, target, &storage, &storage, &loader, &logger, &Test);
 let mut register = Register::default();
 register.add_local("a", 1.into());
 register.add_local("b", 2.into());

--- a/rust/nasl-builtin-utils/README.md
+++ b/rust/nasl-builtin-utils/README.md
@@ -8,12 +8,12 @@ To create a builtin function you have to implement the [NaslFunctionExecuter] tr
 
 use nasl_builtin_utils::{Context, Register, NaslFunctionExecuter, NaslResult, get_named_parameter};
 struct Test;
-impl NaslFunctionExecuter<String> for Test {
+impl NaslFunctionExecuter for Test {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        _context: &Context<String>,
+        _context: &Context,
     ) -> Option<NaslResult> {
         match name {
             "test" => {
@@ -46,12 +46,12 @@ If you want to construct it manually (e.g. for testing) you can do it by creatin
 use nasl_builtin_utils::*;
 
 struct Test;
-impl NaslFunctionExecuter<String> for Test {
+impl NaslFunctionExecuter for Test {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &Register,
-        _context: &Context<String>,
+        _context: &Context,
     ) -> Option<NaslResult> {
         match name {
             "test" => {
@@ -73,7 +73,7 @@ impl NaslFunctionExecuter<String> for Test {
 }
 
 
-let key = "test".to_owned();
+let key = "test".into();
 let target = "localhost";
 let storage = storage::DefaultDispatcher::default();
 let loader = nasl_syntax::NoOpLoader::default();

--- a/rust/nasl-builtin-utils/src/context.rs
+++ b/rust/nasl-builtin-utils/src/context.rs
@@ -5,7 +5,7 @@
 //! Defines the context used within the interpreter and utilized by the builtin functions
 
 use nasl_syntax::{logger::NaslLogger, Loader, NaslValue, Statement};
-use storage::{Dispatcher, Retriever};
+use storage::{ContextKey, Dispatcher, Retriever};
 
 use crate::lookup_keys::FC_ANON_ARGS;
 
@@ -325,34 +325,34 @@ impl NaslContext {
 ///
 /// This struct includes all objects that a nasl function requires.
 /// New objects must be added here in
-pub struct Context<'a, K> {
-    /// key for this context. A name or an OID
-    key: &'a K,
+pub struct Context<'a> {
+    /// key for this context. A file name or a scan id
+    key: &'a ContextKey,
     /// target to run a scan against
     target: &'a str,
     /// Default Dispatcher
-    dispatcher: &'a dyn Dispatcher<K>,
+    dispatcher: &'a dyn Dispatcher,
     /// Default Retriever
-    retriever: &'a dyn Retriever<K>,
+    retriever: &'a dyn Retriever,
     /// Default Loader
     loader: &'a dyn Loader,
     // TODO remove logger in favor of tracing
     /// Default logger.
     logger: &'a dyn NaslLogger,
     /// Default logger.
-    executor: &'a dyn super::NaslFunctionExecuter<K>,
+    executor: &'a dyn super::NaslFunctionExecuter,
 }
 
-impl<'a, K> Context<'a, K> {
+impl<'a> Context<'a> {
     /// Creates an empty configuration
     pub fn new(
-        key: &'a K,
+        key: &'a ContextKey,
         target: &'a str,
-        dispatcher: &'a dyn Dispatcher<K>,
-        retriever: &'a dyn Retriever<K>,
+        dispatcher: &'a dyn Dispatcher,
+        retriever: &'a dyn Retriever,
         loader: &'a dyn Loader,
         logger: &'a dyn NaslLogger,
-        executor: &'a dyn super::NaslFunctionExecuter<K>,
+        executor: &'a dyn super::NaslFunctionExecuter,
     ) -> Self {
         Self {
             key,
@@ -383,12 +383,12 @@ impl<'a, K> Context<'a, K> {
     }
 
     /// Get the executor
-    pub fn executor(&self) -> &'a dyn super::NaslFunctionExecuter<K> {
+    pub fn executor(&self) -> &'a dyn super::NaslFunctionExecuter {
         self.executor
     }
 
     /// Get the Key
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &ContextKey {
         self.key
     }
     /// Get the target host
@@ -396,11 +396,11 @@ impl<'a, K> Context<'a, K> {
         self.target
     }
     /// Get the storage
-    pub fn dispatcher(&self) -> &dyn Dispatcher<K> {
+    pub fn dispatcher(&self) -> &dyn Dispatcher {
         self.dispatcher
     }
     /// Get the storage
-    pub fn retriever(&self) -> &dyn Retriever<K> {
+    pub fn retriever(&self) -> &dyn Retriever {
         self.retriever
     }
     /// Get the loader

--- a/rust/nasl-builtin-utils/src/context.rs
+++ b/rust/nasl-builtin-utils/src/context.rs
@@ -327,9 +327,9 @@ impl NaslContext {
 /// New objects must be added here in
 pub struct Context<'a> {
     /// key for this context. A file name or a scan id
-    key: &'a ContextKey,
+    key: ContextKey,
     /// target to run a scan against
-    target: &'a str,
+    target: String,
     /// Default Dispatcher
     dispatcher: &'a dyn Dispatcher,
     /// Default Retriever
@@ -346,8 +346,8 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Creates an empty configuration
     pub fn new(
-        key: &'a ContextKey,
-        target: &'a str,
+        key: ContextKey,
+        target: String,
         dispatcher: &'a dyn Dispatcher,
         retriever: &'a dyn Retriever,
         loader: &'a dyn Loader,
@@ -389,11 +389,11 @@ impl<'a> Context<'a> {
 
     /// Get the Key
     pub fn key(&self) -> &ContextKey {
-        self.key
+        &self.key
     }
     /// Get the target host
     pub fn target(&self) -> &str {
-        self.target
+        &self.target
     }
     /// Get the storage
     pub fn dispatcher(&self) -> &dyn Dispatcher {

--- a/rust/nasl-builtin-utils/src/lib.rs
+++ b/rust/nasl-builtin-utils/src/lib.rs
@@ -20,12 +20,12 @@ pub type NaslResult = Result<nasl_syntax::NaslValue, FunctionErrorKind>;
 /// It is mostly used internally when building a NaslFunctionExecuter.
 /// The register as well as the context are given by the interpreter that wants either a result or
 /// an error back.
-pub type NaslFunction<'a, K> =
-    fn(&Register, &Context<K>) -> Result<nasl_syntax::NaslValue, FunctionErrorKind>;
+pub type NaslFunction<'a> =
+    fn(&Register, &Context) -> Result<nasl_syntax::NaslValue, FunctionErrorKind>;
 
 /// Looks up functions and executes them. Returns None when no function is found and a result
 /// otherwise.
-pub trait NaslFunctionExecuter<K> {
+pub trait NaslFunctionExecuter {
     /// Executes function found by name if it registered.
     ///
     /// Usually it is called by the context and not directly from the interpreter. This way it is
@@ -35,7 +35,7 @@ pub trait NaslFunctionExecuter<K> {
         &self,
         name: &str,
         register: &Register,
-        context: &Context<K>,
+        context: &Context,
     ) -> Option<NaslResult>;
 
     /// Returns true when the nasl function is defined otherwise false.
@@ -96,31 +96,31 @@ pub fn get_named_parameter<'a>(
 }
 /// Holds registered NaslFunctionExecuter and executes them in order of registration.
 #[derive(Default)]
-pub struct NaslFunctionRegister<K> {
-    executor: Vec<Box<dyn NaslFunctionExecuter<K>>>,
+pub struct NaslFunctionRegister {
+    executor: Vec<Box<dyn NaslFunctionExecuter>>,
 }
 
-impl<K> NaslFunctionRegister<K> {
+impl NaslFunctionRegister {
     /// Creates a new NaslFunctionRegister
-    pub fn new(executor: Vec<Box<dyn NaslFunctionExecuter<K>>>) -> Self {
+    pub fn new(executor: Vec<Box<dyn NaslFunctionExecuter>>) -> Self {
         Self { executor }
     }
 
     /// Pushes a NaslFunctionExecuter to the register
     pub fn push_executer<T>(&mut self, executor: T)
     where
-        T: NaslFunctionExecuter<K> + 'static,
+        T: NaslFunctionExecuter + 'static,
     {
         self.executor.push(Box::new(executor));
     }
 }
 
-impl<K> NaslFunctionExecuter<K> for NaslFunctionRegister<K> {
+impl NaslFunctionExecuter for NaslFunctionRegister {
     fn nasl_fn_execute(
         &self,
         name: &str,
         register: &context::Register,
-        context: &context::Context<K>,
+        context: &context::Context,
     ) -> Option<NaslResult> {
         for executor in &self.executor {
             if let Some(r) = executor.nasl_fn_execute(name, register, context) {
@@ -142,11 +142,11 @@ impl<K> NaslFunctionExecuter<K> for NaslFunctionRegister<K> {
 
 #[derive(Default)]
 /// A builder for NaslFunctionRegister
-pub struct NaslfunctionRegisterBuilder<K> {
-    executor: Vec<Box<dyn NaslFunctionExecuter<K>>>,
+pub struct NaslfunctionRegisterBuilder {
+    executor: Vec<Box<dyn NaslFunctionExecuter>>,
 }
 
-impl<K> NaslfunctionRegisterBuilder<K> {
+impl NaslfunctionRegisterBuilder {
     /// New NaslFunctionRegisterBuilder
     pub fn new() -> Self {
         Self {
@@ -157,14 +157,14 @@ impl<K> NaslfunctionRegisterBuilder<K> {
     /// Pushes a NaslFunctionExecuter to the register
     pub fn push_register<T>(mut self, executor: T) -> Self
     where
-        T: NaslFunctionExecuter<K> + 'static,
+        T: NaslFunctionExecuter + 'static,
     {
         self.executor.push(Box::new(executor));
         self
     }
 
     /// Builds the NaslFunctionRegister
-    pub fn build(self) -> NaslFunctionRegister<K> {
+    pub fn build(self) -> NaslFunctionRegister {
         NaslFunctionRegister::new(self.executor)
     }
 }
@@ -226,12 +226,12 @@ impl NaslVarRegisterBuilder {
 mod test {
 
     struct Test;
-    impl crate::NaslFunctionExecuter<std::string::String> for Test {
+    impl crate::NaslFunctionExecuter for Test {
         fn nasl_fn_execute(
             &self,
             name: &str,
             register: &crate::Register,
-            _context: &crate::Context<String>,
+            _context: &crate::Context,
         ) -> Option<crate::NaslResult> {
             match name {
                 "test" => {
@@ -253,7 +253,7 @@ mod test {
     }
     #[test]
     fn register_new_function() {
-        let key = "test".to_owned();
+        let key = storage::ContextKey::FileName("test".to_owned());
         let target = "localhost";
         let storage = storage::DefaultDispatcher::default();
         let loader = nasl_syntax::NoOpLoader::default();

--- a/rust/nasl-builtin-utils/src/lib.rs
+++ b/rust/nasl-builtin-utils/src/lib.rs
@@ -258,8 +258,15 @@ mod test {
         let storage = storage::DefaultDispatcher::default();
         let loader = nasl_syntax::NoOpLoader::default();
         let logger = nasl_syntax::logger::DefaultLogger::default();
-        let context =
-            crate::Context::new(&key, target, &storage, &storage, &loader, &logger, &Test);
+        let context = crate::Context::new(
+            key,
+            target.into(),
+            &storage,
+            &storage,
+            &loader,
+            &logger,
+            &Test,
+        );
         let mut register = crate::Register::default();
         register.add_local("a", 1.into());
         register.add_local("b", 2.into());

--- a/rust/nasl-interpreter/README.md
+++ b/rust/nasl-interpreter/README.md
@@ -20,10 +20,10 @@ An interpreter requires:
 ## Example
 
 ```
-use nasl_interpreter::{CodeInterpreter, Register, ContextBuilder};
+use nasl_interpreter::{CodeInterpreter, Register, ContextFactory};
 let mut register = Register::default();
-let context_builder = ContextBuilder::default();
-let context = context_builder.build();
+let context_builder = ContextFactory::default();
+let context = context_builder.build(storage::ContextKey::Scan("1".into()), "localhost".into());
 let code = "display('hi');";
 let mut parser = CodeInterpreter::new(code, register, &context);
 ```

--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -271,8 +271,8 @@ mod tests {
         --a;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(12.into())));
         assert_eq!(parser.next(), Some(Ok(25.into())));
@@ -304,8 +304,8 @@ mod tests {
         ++a[0];
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(12.into())));
         assert_eq!(parser.next(), Some(Ok(25.into())));
@@ -326,8 +326,8 @@ mod tests {
         a;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(12.into())));
         assert_eq!(
@@ -349,8 +349,8 @@ mod tests {
         a;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(12.into())));
         assert_eq!(parser.next(), Some(Ok(12.into())));
@@ -373,8 +373,8 @@ mod tests {
         a['hi'];
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(12.into())));
         assert_eq!(
@@ -393,8 +393,8 @@ mod tests {
         a = [1, 2, 3];
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(
             parser.next(),

--- a/rust/nasl-interpreter/src/assign.rs
+++ b/rust/nasl-interpreter/src/assign.rs
@@ -51,10 +51,7 @@ fn prepare_dict(left: NaslValue) -> HashMap<String, NaslValue> {
     }
 }
 
-impl<'a, K> Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> Interpreter<'a> {
     fn save(&mut self, idx: usize, key: &str, value: NaslValue) {
         self.register_mut()
             .add_to_index(idx, key, ContextType::Value(value));
@@ -186,10 +183,7 @@ where
     }
 }
 
-impl<'a, K> AssignExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> AssignExtension for Interpreter<'a> {
     fn assign(
         &mut self,
         category: &TokenCategory,

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -20,10 +20,7 @@ pub(crate) trait CallExtension {
     fn call(&mut self, name: &Token, arguments: &[Statement]) -> InterpretResult;
 }
 
-impl<'a, K> CallExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> CallExtension for Interpreter<'a> {
     fn call(&mut self, name: &Token, arguments: &[Statement]) -> InterpretResult {
         let name = &Self::identifier(name)?;
         // get the context

--- a/rust/nasl-interpreter/src/call.rs
+++ b/rust/nasl-interpreter/src/call.rs
@@ -124,8 +124,8 @@ mod tests {
         test();
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(3.into())));

--- a/rust/nasl-interpreter/src/declare.rs
+++ b/rust/nasl-interpreter/src/declare.rs
@@ -18,10 +18,7 @@ pub(crate) trait DeclareFunctionExtension {
     ) -> InterpretResult;
 }
 
-impl<'a, K> DeclareFunctionExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> DeclareFunctionExtension for Interpreter<'a> {
     fn declare_function(
         &mut self,
         name: &Token,
@@ -49,10 +46,7 @@ pub(crate) trait DeclareVariableExtension {
     fn declare_variable(&mut self, scope: &Token, stmts: &[Statement]) -> InterpretResult;
 }
 
-impl<'a, K> DeclareVariableExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> DeclareVariableExtension for Interpreter<'a> {
     fn declare_variable(&mut self, scope: &Token, stmts: &[Statement]) -> InterpretResult {
         let mut add = |key: &str| {
             let value = ContextType::Value(NaslValue::Null);

--- a/rust/nasl-interpreter/src/declare.rs
+++ b/rust/nasl-interpreter/src/declare.rs
@@ -91,8 +91,8 @@ mod tests {
         c;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(3.into())));
@@ -108,8 +108,8 @@ mod tests {
         test(a: 1, b: 2);
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut parser = CodeInterpreter::new(code, register, &context);
         assert_eq!(parser.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(parser.next(), Some(Ok(3.into())));

--- a/rust/nasl-interpreter/src/fork_interpreter.rs
+++ b/rust/nasl-interpreter/src/fork_interpreter.rs
@@ -22,10 +22,10 @@ impl<'a, 'b> CodeInterpreter<'a, 'b> {
     /// Example:
     /// ```
     /// use nasl_syntax::NaslValue;
-    /// use nasl_interpreter::{Register, ContextBuilder, CodeInterpreter};
+    /// use nasl_interpreter::{Register, ContextFactory , CodeInterpreter};
     /// let register = Register::default();
-    /// let context_builder = ContextBuilder::default();
-    /// let context = context_builder.build();
+    /// let context_builder = ContextFactory ::default();
+    /// let context = context_builder.build(Default::default(), Default::default());
     /// let code = r#"
     /// set_kb_item(name: "test", value: 1);
     /// set_kb_item(name: "test", value: 2);
@@ -56,10 +56,10 @@ impl<'a, 'b> CodeInterpreter<'a, 'b> {
     /// Example:
     /// ```
     /// use nasl_syntax::NaslValue;
-    /// use nasl_interpreter::{Register, ContextBuilder, CodeInterpreter};
+    /// use nasl_interpreter::{Register, ContextFactory , CodeInterpreter};
     /// let register = Register::default();
-    /// let context_builder = ContextBuilder::default();
-    /// let context = context_builder.build();
+    /// let context_builder = ContextFactory ::default();
+    /// let context = context_builder.build(Default::default(), Default::default());
     /// let code = r#"
     /// set_kb_item(name: "test", value: 1);
     /// set_kb_item(name: "test", value: 2);
@@ -121,11 +121,11 @@ impl<'a, 'b> Iterator for CodeInterpreter<'a, 'b> {
 mod rests {
     #[test]
     fn code_interpreter() {
-        use crate::{CodeInterpreter, ContextBuilder, Register};
+        use crate::{CodeInterpreter, ContextFactory, Register};
         use nasl_syntax::NaslValue;
         let register = Register::default();
-        let context_builder = ContextBuilder::default();
-        let context = context_builder.build();
+        let context_builder = ContextFactory::default();
+        let context = context_builder.build(Default::default(), Default::default());
         let code = r#"
             set_kb_item(name: "test", value: 1);
             set_kb_item(name: "test", value: 2);

--- a/rust/nasl-interpreter/src/fork_interpreter.rs
+++ b/rust/nasl-interpreter/src/fork_interpreter.rs
@@ -8,18 +8,15 @@ use crate::interpreter::InterpretResult;
 /// To allow closures we use a heap stored statement consumer
 pub type StatementConsumer = Box<dyn Fn(&Statement)>;
 /// Uses given code to return results based on that.
-pub struct CodeInterpreter<'a, 'b, K> {
+pub struct CodeInterpreter<'a, 'b> {
     lexer: nasl_syntax::Lexer<'b>,
-    interpreter: crate::interpreter::Interpreter<'a, K>,
+    interpreter: crate::interpreter::Interpreter<'a>,
     statement: Option<Statement>,
     /// call back function for Statements before they get interpret
     pub statement_cb: Option<StatementConsumer>,
 }
 
-impl<'a, 'b, K> CodeInterpreter<'a, 'b, K>
-where
-    K: AsRef<str>,
-{
+impl<'a, 'b> CodeInterpreter<'a, 'b> {
     /// Creates a new code interpreter
     ///
     /// Example:
@@ -41,8 +38,8 @@ where
     pub fn new(
         code: &'b str,
         register: crate::Register,
-        context: &'a crate::Context<'a, K>,
-    ) -> CodeInterpreter<'a, 'b, K> {
+        context: &'a crate::Context<'a>,
+    ) -> CodeInterpreter<'a, 'b> {
         let token = nasl_syntax::Tokenizer::new(code);
         let lexer = nasl_syntax::Lexer::new(token);
         let interpreter = crate::interpreter::Interpreter::new(register, context);
@@ -75,9 +72,9 @@ where
     pub fn with_statement_callback(
         code: &'b str,
         register: crate::Register,
-        context: &'a crate::Context<'a, K>,
+        context: &'a crate::Context<'a>,
         cb: &'static dyn Fn(&Statement),
-    ) -> CodeInterpreter<'a, 'b, K> {
+    ) -> CodeInterpreter<'a, 'b> {
         let mut result = Self::new(code, register, context);
         result.statement_cb = Some(Box::new(cb));
         result
@@ -105,10 +102,7 @@ where
     }
 }
 
-impl<'a, 'b, K> Iterator for CodeInterpreter<'a, 'b, K>
-where
-    K: AsRef<str>,
-{
+impl<'a, 'b> Iterator for CodeInterpreter<'a, 'b> {
     type Item = InterpretResult;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -42,11 +42,13 @@ mod tests {
         test();
         "#;
         let register = Register::default();
-        let context = ContextBuilder {
-            loader: Box::new(loader),
-            ..Default::default()
+        let context = ContextFactory {
+            loader,
+            logger: logger::DefaultLogger::default(),
+            functions: nasl_std_functions(),
+            storage: storage::DefaultDispatcher::default(),
         };
-        let ctx = context.build();
+        let ctx = context.build(Default::default(), Default::default());
         let mut interpreter = CodeInterpreter::new(code, register, &ctx);
         assert_eq!(interpreter.next(), Some(Ok(NaslValue::Null)));
         assert_eq!(interpreter.next(), Some(Ok(12.into())));

--- a/rust/nasl-interpreter/src/interpreter.rs
+++ b/rust/nasl-interpreter/src/interpreter.rs
@@ -69,15 +69,12 @@ pub(crate) struct RunSpecific {
 pub trait ContextLifeTimeCapture<'a> {}
 impl<'a, T: ?Sized> ContextLifeTimeCapture<'a> for T {}
 
-struct StatementIter<'a, 'b, K> {
-    interpreter: &'b mut Interpreter<'a, K>,
+struct StatementIter<'a, 'b> {
+    interpreter: &'b mut Interpreter<'a>,
     statement: Statement,
 }
 
-impl<'a, 'b, K> Iterator for StatementIter<'a, 'b, K>
-where
-    K: AsRef<str>,
-{
+impl<'a, 'b> Iterator for StatementIter<'a, 'b> {
     type Item = InterpretResult;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -96,9 +93,9 @@ where
 }
 
 /// Used to interpret a Statement
-pub struct Interpreter<'a, K> {
+pub struct Interpreter<'a> {
     pub(crate) run_specific: Vec<RunSpecific>,
-    pub(crate) ctxconfigs: &'a Context<'a, K>,
+    pub(crate) ctxconfigs: &'a Context<'a>,
     pub(crate) index: usize,
 }
 
@@ -107,12 +104,9 @@ pub struct Interpreter<'a, K> {
 /// When a result does not contain a value than NaslValue::Null must be returned.
 pub type InterpretResult = Result<NaslValue, InterpretError>;
 
-impl<'a, K> Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> Interpreter<'a> {
     /// Creates a new Interpreter
-    pub fn new(register: Register, ctxconfigs: &'a Context<K>) -> Self {
+    pub fn new(register: Register, ctxconfigs: &'a Context) -> Self {
         let root_run = RunSpecific {
             register,
             position: Position::new(0),
@@ -149,7 +143,7 @@ where
     /// again. This is done to inform the caller that all interpreter interpret this statement and
     /// the next Statement can be executed.
     // TODO remove in favor of iterrator of run_specific
-    pub fn next_interpreter(&mut self) -> Option<&mut Interpreter<'a, K>> {
+    pub fn next_interpreter(&mut self) -> Option<&mut Interpreter<'a>> {
         if self.run_specific.len() == 1 || self.index + 1 == self.run_specific.len() {
             return None;
         }

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -24,7 +24,7 @@ pub use interpreter::ContextLifeTimeCapture;
 pub use interpreter::Interpreter;
 
 // we expose the other libraries to allow users to use them without having to import them
-pub use nasl_builtin_std::{nasl_std_functions, ContextBuilder, KeyDispatcherSet, RegisterBuilder};
+pub use nasl_builtin_std::{nasl_std_functions, ContextFactory, RegisterBuilder};
 pub use nasl_builtin_utils::{
     Context, ContextType, FunctionErrorKind, NaslFunctionRegister, NaslVarRegister, Register,
 };

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -177,8 +177,8 @@ mod tests {
         }
         a;
         "###;
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let register = Register::default();
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
@@ -198,8 +198,8 @@ mod tests {
         a;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
             parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
@@ -220,8 +220,8 @@ mod tests {
         a;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
             parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
@@ -246,8 +246,8 @@ mod tests {
         i;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
             parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
@@ -273,8 +273,8 @@ mod tests {
         i;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
             parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));
@@ -305,8 +305,8 @@ mod tests {
         i;
         "###;
         let register = Register::default();
-        let binding = ContextBuilder::default();
-        let context = binding.build();
+        let binding = ContextFactory::default();
+        let context = binding.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &context);
         let mut interpreter =
             parse(code).map(|x| interpreter.resolve(&x.expect("unexpected parse error")));

--- a/rust/nasl-interpreter/src/loop_extension.rs
+++ b/rust/nasl-interpreter/src/loop_extension.rs
@@ -61,10 +61,7 @@ pub(crate) trait LoopExtension {
 
 /// Implementation for the Loop extension. Note that for all loops, we do not
 /// change the context, as the current NASL also does not change it too.
-impl<'a, K> LoopExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> LoopExtension for Interpreter<'a> {
     fn for_loop(
         &mut self,
         assignment: &Statement,

--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -15,10 +15,7 @@ pub(crate) trait OperatorExtension {
     fn operator(&mut self, category: &TokenCategory, stmts: &[Statement]) -> InterpretResult;
 }
 
-impl<'a, K> Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> Interpreter<'a> {
     fn execute(
         &mut self,
         stmts: &[Statement],
@@ -115,10 +112,7 @@ macro_rules! minus_left_right_data {
     }};
 }
 
-impl<'a, K> OperatorExtension for Interpreter<'a, K>
-where
-    K: AsRef<str>,
-{
+impl<'a> OperatorExtension for Interpreter<'a> {
     fn operator(&mut self, category: &TokenCategory, stmts: &[Statement]) -> InterpretResult {
         match category {
             // number and string

--- a/rust/nasl-interpreter/src/operator.rs
+++ b/rust/nasl-interpreter/src/operator.rs
@@ -251,8 +251,8 @@ mod tests {
             #[test]
             fn $name() {
                 let register = Register::default();
-                let binding = ContextBuilder::default();
-                let context = binding.build();
+                let binding = ContextFactory ::default();
+                let context = binding.build(Default::default(), Default::default());
                 let mut interpreter = Interpreter::new(register, &context);
                 let parser = parse($code).map(|x|
                     interpreter.resolve(&x.expect("unexpected parse error"))

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -74,7 +74,7 @@ if(description)
         )];
         let register = Register::root_initial(&initial);
         let logger = DefaultLogger::default();
-        let key = "test.nasl".to_owned();
+        let key = "test.nasl".into();
         let target = String::new();
         let functions = nasl_builtin_std::nasl_std_functions();
         let ctxconfigs = Context::new(
@@ -97,7 +97,7 @@ if(description)
                 .collect::<Vec<_>>(),
             vec![
                 NVT(Oid("0.0.0.0.0.0.0.0.0.1".to_owned())),
-                NVT(FileName(key)),
+                NVT(FileName(key.value())),
                 NVT(NoOp),
                 NVT(Tag(CreationDate, TagValue::Number(1366091481))),
                 NVT(Name("that is a very long and descriptive name".to_owned())),

--- a/rust/nasl-interpreter/tests/description.rs
+++ b/rust/nasl-interpreter/tests/description.rs
@@ -74,11 +74,17 @@ if(description)
         )];
         let register = Register::root_initial(&initial);
         let logger = DefaultLogger::default();
-        let key = "test.nasl".into();
+        let key: storage::ContextKey = "test.nasl".into();
         let target = String::new();
         let functions = nasl_builtin_std::nasl_std_functions();
         let ctxconfigs = Context::new(
-            &key, &target, &storage, &storage, &loader, &logger, &functions,
+            key.clone(),
+            target,
+            &storage,
+            &storage,
+            &loader,
+            &logger,
+            &functions,
         );
         let mut interpreter = Interpreter::new(register, &ctxconfigs);
         let results = parse(code)

--- a/rust/nasl-interpreter/tests/local_var.rs
+++ b/rust/nasl-interpreter/tests/local_var.rs
@@ -19,9 +19,9 @@ if (a) {
 }
 a;
         "###;
-        let dc = ContextBuilder::default();
+        let dc = ContextFactory::default();
         let register = Register::default();
-        let ctx = dc.build();
+        let ctx = dc.build(Default::default(), Default::default());
         let mut interpreter = Interpreter::new(register, &ctx);
         let results = parse(code)
             .map(|stmt| match stmt {

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -64,7 +64,7 @@ impl<S, DB, T> ContextBuilder<S, DB, T> {
         self.feed_config = Some(config);
         if let Some(fp) = self.feed_config.as_ref() {
             let loader = nasl_interpreter::FSPluginLoader::new(fp.path.clone());
-            let dispatcher: DefaultDispatcher<String> = DefaultDispatcher::default();
+            let dispatcher: DefaultDispatcher = DefaultDispatcher::default();
             let version =
                 feed::version(&loader, &dispatcher).unwrap_or_else(|_| String::from("UNDEFINED"));
             self.response.set_feed_version(&version);

--- a/rust/openvasd/src/feed.rs
+++ b/rust/openvasd/src/feed.rs
@@ -28,7 +28,7 @@ impl FeedIdentifier {
         // e.g. 2006/something.nasl
         let loader = nasl_interpreter::FSPluginLoader::new(path);
         let verifier = feed::HashSumNameLoader::sha256(&loader)?;
-        let updater = feed::Update::init("1", 5, loader.clone(), storage, verifier);
+        let updater = feed::Update::init("1", 5, &loader, &storage, verifier);
 
         if signature_check {
             match updater.verify_signature() {

--- a/rust/openvasd/src/feed.rs
+++ b/rust/openvasd/src/feed.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use storage::StorageError::{self};
+use storage::{ContextKey, StorageError};
 #[derive(Debug, Default, Clone)]
 pub struct FeedIdentifier {
     oids: Arc<RwLock<Vec<String>>>,
@@ -85,8 +85,8 @@ impl FeedIdentifier {
     }
 }
 
-impl storage::Dispatcher<String> for FeedIdentifier {
-    fn dispatch(&self, _: &String, scope: storage::Field) -> Result<(), storage::StorageError> {
+impl storage::Dispatcher for FeedIdentifier {
+    fn dispatch(&self, _: &ContextKey, scope: storage::Field) -> Result<(), storage::StorageError> {
         use storage::item::NVTField::Oid;
         if let storage::Field::NVT(Oid(x)) = scope {
             let mut oids = self.oids.write()?;

--- a/rust/openvasd/src/storage/file.rs
+++ b/rust/openvasd/src/storage/file.rs
@@ -416,7 +416,7 @@ struct Dispa {
     feed_version: Arc<std::sync::RwLock<String>>,
 }
 
-impl ItemDispatcher<String> for Dispa {
+impl ItemDispatcher for Dispa {
     fn dispatch_nvt(&self, nvt: Nvt) -> Result<(), storage::StorageError> {
         let mut storage = self.storage.write().unwrap();
         let oid = nvt.oid.clone();

--- a/rust/openvasd/src/storage/file.rs
+++ b/rust/openvasd/src/storage/file.rs
@@ -79,7 +79,7 @@ impl<S> Storage<S> {
                 storage: cache,
                 feed_version,
             });
-            let mut fu = feed::Update::init(oversion, 5, loader.clone(), store, verifier);
+            let mut fu = feed::Update::init(oversion, 5, &loader, &store, verifier);
             if let Some(x) = fu.find_map(|x| x.err()) {
                 tracing::debug!("{}", x);
                 Err(Error::from(x))

--- a/rust/openvasd/src/storage/inmemory.rs
+++ b/rust/openvasd/src/storage/inmemory.rs
@@ -359,7 +359,7 @@ where
             let verifier = feed::HashSumNameLoader::sha256(&loader)?;
 
             let store = PerItemDispatcher::new(Dispa { nvts, feed_version });
-            let mut fu = feed::Update::init(oversion, 5, loader.clone(), store, verifier);
+            let mut fu = feed::Update::init(oversion, 5, &loader, &store, verifier);
             if let Some(x) = fu.find_map(|x| x.err()) {
                 Err(Error::from(x))
             } else {

--- a/rust/openvasd/src/storage/inmemory.rs
+++ b/rust/openvasd/src/storage/inmemory.rs
@@ -37,7 +37,7 @@ struct Dispa {
     feed_version: Arc<RwLock<String>>,
 }
 
-impl ItemDispatcher<String> for Dispa {
+impl ItemDispatcher for Dispa {
     fn dispatch_nvt(&self, nvt: Nvt) -> Result<(), storage::StorageError> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -80,7 +80,7 @@ impl<T> Storage<T> {
             let redis_cache: CacheDispatcher<RedisCtx> =
                 redis_storage::CacheDispatcher::init(&url, FEEDUPDATE_SELECTOR)?;
             let store = PerItemDispatcher::new(redis_cache);
-            let mut fu = feed::Update::init(oversion, 5, loader.clone(), store, verifier);
+            let mut fu = feed::Update::init(oversion, 5, &loader, &store, verifier);
             if let Some(x) = fu.find_map(|x| x.err()) {
                 Err(Error::from(x))
             } else {

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -43,7 +43,7 @@ impl<T> Storage<T> {
             let loader = FSPluginLoader::new(notus_feed_path);
             let advisories_files = HashsumAdvisoryLoader::new(loader.clone())?;
 
-            let redis_cache: CacheDispatcher<RedisCtx, String> =
+            let redis_cache: CacheDispatcher<RedisCtx> =
                 redis_storage::CacheDispatcher::init(&url, NOTUSUPDATE_SELECTOR)?;
             let store = PerItemDispatcher::new(redis_cache);
             for filename in advisories_files.get_advisories()?.iter() {
@@ -55,10 +55,13 @@ impl<T> Storage<T> {
                         famile: advisories.family.clone(),
                         filename: filename.to_owned(),
                     };
-                    store.dispatch(&"".to_string(), Field::NotusAdvisory(Box::new(Some(data))))?;
+                    store.dispatch(
+                        &Default::default(),
+                        Field::NotusAdvisory(Box::new(Some(data))),
+                    )?;
                 }
             }
-            store.dispatch(&"".to_string(), Field::NotusAdvisory(Box::new(None)))?;
+            store.dispatch(&Default::default(), Field::NotusAdvisory(Box::new(None)))?;
             tracing::debug!("finished notus feed update");
             Ok(())
         })
@@ -74,7 +77,7 @@ impl<T> Storage<T> {
             let loader = FSPluginLoader::new(nasl_feed_path);
             let verifier = feed::HashSumNameLoader::sha256(&loader)?;
 
-            let redis_cache: CacheDispatcher<RedisCtx, String> =
+            let redis_cache: CacheDispatcher<RedisCtx> =
                 redis_storage::CacheDispatcher::init(&url, FEEDUPDATE_SELECTOR)?;
             let store = PerItemDispatcher::new(redis_cache);
             let mut fu = feed::Update::init(oversion, 5, loader.clone(), store, verifier);

--- a/rust/openvasd/src/tls.rs
+++ b/rust/openvasd/src/tls.rs
@@ -9,7 +9,7 @@
 //!
 //! ```rust
 //!let scanner = scan::OSPDWrapper::from_env();
-//!let ctx = controller::ContextBuilder::new()
+//!let ctx = controller::ContextFactory | update::new()
 //!    .scanner(scanner)
 //!    .build();
 //!let controller = std::sync::Arc::new(ctx);

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -5,7 +5,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -22,6 +21,7 @@ use storage::item::NvtRef;
 use storage::item::PerItemDispatcher;
 use storage::item::TagKey;
 use storage::item::TagValue;
+use storage::ContextKey;
 use storage::Kb;
 use storage::NotusAdvisory;
 
@@ -645,20 +645,15 @@ impl RedisCtx {
 /// we need to have all references and preferences to respect the order to be downwards compatible.
 /// This should be changed when there is new OSP frontend available.
 #[derive(Debug, Default)]
-pub struct CacheDispatcher<R, K>
+pub struct CacheDispatcher<R>
 where
     R: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    K: AsRef<str>,
 {
     cache: Arc<Mutex<R>>,
     kbs: Arc<Mutex<Vec<Kb>>>,
-    phanton: PhantomData<K>,
 }
 
-impl<K> CacheDispatcher<RedisCtx, K>
-where
-    K: AsRef<str>,
-{
+impl CacheDispatcher<RedisCtx> {
     /// Initialize and return an NVT Cache Object
     ///
     /// The redis_url must be a complete url including the used protocol e.g.:
@@ -666,13 +661,12 @@ where
     pub fn init(
         redis_url: &str,
         selector: &[NameSpaceSelector],
-    ) -> RedisStorageResult<CacheDispatcher<RedisCtx, K>> {
+    ) -> RedisStorageResult<CacheDispatcher<RedisCtx>> {
         let rctx = RedisCtx::open(redis_url, selector)?;
 
         Ok(CacheDispatcher {
             cache: Arc::new(Mutex::new(rctx)),
             kbs: Arc::new(Mutex::new(Vec::new())),
-            phanton: PhantomData,
         })
     }
 
@@ -683,7 +677,7 @@ where
     pub fn as_dispatcher(
         redis_url: &str,
         selector: &[NameSpaceSelector],
-    ) -> RedisStorageResult<PerItemDispatcher<CacheDispatcher<RedisCtx, K>, K>> {
+    ) -> RedisStorageResult<PerItemDispatcher<CacheDispatcher<RedisCtx>>> {
         let cache = Self::init(redis_url, selector)?;
         cache.flushdb()?;
         Ok(PerItemDispatcher::new(cache))
@@ -706,10 +700,9 @@ where
     }
 }
 
-impl<S, K> storage::item::ItemDispatcher<K> for CacheDispatcher<S, K>
+impl<S> storage::item::ItemDispatcher for CacheDispatcher<S>
 where
     S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    K: AsRef<str>,
 {
     fn dispatch_nvt(&self, nvt: Nvt) -> Result<(), StorageError> {
         let mut cache = Arc::as_ref(&self.cache).lock()?;
@@ -721,7 +714,7 @@ where
         cache.rpush(CACHE_KEY, &[&version]).map_err(|e| e.into())
     }
 
-    fn dispatch_kb(&self, _: &K, kb: storage::Kb) -> Result<(), StorageError> {
+    fn dispatch_kb(&self, _: &ContextKey, kb: storage::Kb) -> Result<(), StorageError> {
         let mut kbs = self.kbs.lock().map_err(StorageError::from)?;
         kbs.push(kb);
         Ok(())
@@ -736,14 +729,13 @@ where
     }
 }
 
-impl<S, K> storage::Retriever<K> for CacheDispatcher<S, K>
+impl<S> storage::Retriever for CacheDispatcher<S>
 where
     S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    K: AsRef<str>,
 {
     fn retrieve(
         &self,
-        _: &K,
+        _: &ContextKey,
         scope: storage::Retrieve,
     ) -> Result<Box<dyn Iterator<Item = storage::Field>>, StorageError> {
         Ok(match scope {
@@ -764,14 +756,13 @@ where
         &self,
         _field: storage::Field,
         _scope: storage::Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, storage::Field)>>, StorageError> {
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, storage::Field)>>, StorageError> {
         todo!()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
     use std::sync::mpsc::{self, Sender, TryRecvError};
     use std::sync::{Arc, Mutex};
 
@@ -883,14 +874,12 @@ mod tests {
         let fr = FakeRedis { sender };
         let cache = Arc::new(Mutex::new(fr));
         let kbs = Arc::new(Mutex::new(Vec::new()));
-        let rcache = CacheDispatcher {
-            cache,
-            kbs,
-            phanton: PhantomData,
-        };
+        let rcache = CacheDispatcher { cache, kbs };
         let dispatcher = PerItemDispatcher::new(rcache);
         for c in commands {
-            dispatcher.dispatch(&"test.nasl", c).unwrap();
+            dispatcher
+                .dispatch(&storage::ContextKey::FileName("test.nasl".to_string()), c)
+                .unwrap();
         }
         dispatcher.on_exit().unwrap();
         let mut results = 0;

--- a/rust/scannerctl/src/feed/update.rs
+++ b/rust/scannerctl/src/feed/update.rs
@@ -11,7 +11,7 @@ use crate::CliError;
 
 pub fn run<S>(storage: S, path: PathBuf, signature_check: bool) -> Result<(), CliError>
 where
-    S: Sync + Send + Dispatcher<String>,
+    S: Sync + Send + Dispatcher,
 {
     tracing::debug!("description run syntax in {path:?}.");
     // needed to strip the root path so that we can build a relative path

--- a/rust/scannerctl/src/feed/update.rs
+++ b/rust/scannerctl/src/feed/update.rs
@@ -18,7 +18,7 @@ where
     // e.g. 2006/something.nasl
     let loader = FSPluginLoader::new(path);
     let verifier = feed::HashSumNameLoader::sha256(&loader)?;
-    let updater = feed::Update::init("1", 5, loader.clone(), storage, verifier);
+    let updater = feed::Update::init("1", 5, &loader, &storage, verifier);
 
     if signature_check {
         match updater.verify_signature() {

--- a/rust/scannerctl/src/interpret/mod.rs
+++ b/rust/scannerctl/src/interpret/mod.rs
@@ -4,79 +4,119 @@
 
 use std::path::PathBuf;
 
-use feed::HashSumNameLoader;
 use nasl_interpreter::{
-    load_non_utf8_path, CodeInterpreter, ContextBuilder, FSPluginLoader, KeyDispatcherSet,
-    LoadError, Loader, NaslValue, NoOpLoader, RegisterBuilder,
+    load_non_utf8_path, CodeInterpreter, FSPluginLoader, LoadError, NaslValue, NoOpLoader,
+    RegisterBuilder,
 };
+use nasl_syntax::logger::DefaultLogger;
 use redis_storage::FEEDUPDATE_SELECTOR;
 use storage::{ContextKey, DefaultDispatcher};
 
 use crate::{CliError, CliErrorKind, Db};
 
-struct Run<S> {
-    context_builder: nasl_interpreter::ContextBuilder<S>,
-    feed: Option<PathBuf>,
+struct Run<L, S> {
+    context_builder: nasl_interpreter::ContextFactory<L, DefaultLogger, S>,
+    target: String,
+    scan_id: String,
 }
 
-impl Run<KeyDispatcherSet> {
-    fn new(db: &Db, feed: Option<PathBuf>, target: Option<String>) -> Self {
-        let key = ContextKey::Scan(String::default());
+struct RunBuilder<L, S> {
+    loader: L,
+    storage: S,
+    target: String,
+    scan_id: String,
+}
 
-        let mut context_builder = match db {
-            Db::InMemory => ContextBuilder::new(key, Box::<DefaultDispatcher>::default()),
-            Db::Redis(url) => ContextBuilder::new(
-                key,
-                Box::new(
-                    redis_storage::CacheDispatcher::as_dispatcher(url, FEEDUPDATE_SELECTOR)
-                        .unwrap(),
-                ),
-            ),
-        };
-
-        context_builder = match feed.clone() {
-            Some(x) => context_builder.loader(FSPluginLoader::new(x)),
-            None => context_builder.loader(NoOpLoader::default()),
-        }
-        .target(target.unwrap_or_default());
-
+impl Default for RunBuilder<NoOpLoader, DefaultDispatcher> {
+    fn default() -> Self {
         Self {
-            context_builder,
-            feed,
+            storage: DefaultDispatcher::default(),
+            loader: NoOpLoader::default(),
+            target: String::default(),
+            scan_id: "scannerctl".to_string(),
+        }
+    }
+}
+
+impl<L, S> RunBuilder<L, S>
+where
+    S: storage::Storage,
+    L: nasl_interpreter::Loader,
+{
+    pub fn storage<S2>(self, s: S2) -> RunBuilder<L, S2> {
+        RunBuilder {
+            loader: self.loader,
+            storage: s,
+            target: self.target,
+            scan_id: self.scan_id,
         }
     }
 
+    pub fn loader<L2>(self, l: L2) -> RunBuilder<L2, S> {
+        RunBuilder {
+            loader: l,
+            storage: self.storage,
+            target: self.target,
+            scan_id: self.scan_id,
+        }
+    }
+
+    pub fn target(mut self, target: String) -> RunBuilder<L, S> {
+        self.target = target;
+        self
+    }
+
+    pub fn scan_id(mut self, scan_id: String) -> RunBuilder<L, S> {
+        self.scan_id = scan_id;
+        self
+    }
+
+    pub fn build(self) -> Run<L, S> {
+        Run {
+            context_builder: nasl_interpreter::ContextFactory::new(
+                self.loader,
+                nasl_syntax::logger::DefaultLogger::default(),
+                self.storage,
+            ),
+            scan_id: self.scan_id,
+            target: self.target,
+        }
+    }
+}
+
+impl<L, S> Run<L, S>
+where
+    L: nasl_interpreter::Loader,
+    S: storage::Storage,
+{
     fn load(&self, script: &str) -> Result<String, CliErrorKind> {
         match load_non_utf8_path(&script) {
             Ok(x) => Ok(x),
-            Err(LoadError::NotFound(_)) => match self.feed.clone() {
-                Some(f) => {
-                    let loader = FSPluginLoader::new(f);
-                    match HashSumNameLoader::sha256(&loader) {
-                        Ok(hsnl) => {
-                            let oid_filename =
-                                feed::Oid::init(loader.clone(), hsnl).find(|x| match x {
-                                    Ok((_, oid)) => oid == script, //self.loader.load(f).map_err(|e| e.into()),
-                                    Err(_) => false,
-                                });
-                            match oid_filename {
-                                Some(Ok((f, _))) => loader.load(&f).map_err(|e| e.into()),
-                                Some(_) | None => {
-                                    Err(LoadError::NotFound(script.to_string()).into())
-                                }
-                            }
-                        }
-                        Err(e) => Err(e.into()),
-                    }
+            Err(LoadError::NotFound(_)) => {
+                let iter = self.context_builder.storage.retrieve_by_field(
+                    storage::Field::NVT(storage::item::NVTField::Oid(script.into())),
+                    // TODO: maybe NvtField::FileName would be better?
+                    storage::Retrieve::NVT(None),
+                )?;
+                let results: Option<String> = iter
+                    .filter_map(|(k, _)| match k {
+                        ContextKey::Scan(_) => None,
+                        ContextKey::FileName(f) => Some(f.to_string()),
+                    })
+                    .next();
+                match results {
+                    Some(f) => Ok(self.context_builder.loader.load(&f)?),
+                    None => Err(LoadError::NotFound(script.to_string()).into()),
                 }
-                None => Err(LoadError::NotFound(script.to_string()).into()),
-            },
+            }
             Err(e) => Err(e.into()),
         }
     }
 
     fn run(&self, script: &str) -> Result<(), CliErrorKind> {
-        let context = self.context_builder.build();
+        let context = self
+            .context_builder
+            .build(ContextKey::Scan(self.scan_id.clone()), self.target.clone());
         let register = RegisterBuilder::build();
         let code = self.load(script)?;
         let interpreter =
@@ -112,14 +152,58 @@ impl Run<KeyDispatcherSet> {
     }
 }
 
+fn create_redis_storage(
+    url: &str,
+) -> storage::item::PerItemDispatcher<redis_storage::CacheDispatcher<redis_storage::RedisCtx>> {
+    redis_storage::CacheDispatcher::as_dispatcher(url, FEEDUPDATE_SELECTOR).unwrap()
+}
+
+fn create_fp_loader<S>(storage: &S, path: PathBuf) -> Result<FSPluginLoader<PathBuf>, CliError>
+where
+    S: storage::Dispatcher,
+{
+    // update feed with storage
+
+    tracing::info!("loading feed. This may take a while.");
+    let result = FSPluginLoader::new(path);
+    let verifier = feed::HashSumNameLoader::sha256(&result)?;
+    let updater = feed::Update::init("scannerctl", 5, &result, storage, verifier);
+    for u in updater {
+        tracing::warn!(updated=?u);
+        u?;
+    }
+    tracing::info!("loaded feed.");
+    Ok(result)
+}
+
 pub fn run(
     db: &Db,
     feed: Option<PathBuf>,
     script: String,
     target: Option<String>,
 ) -> Result<(), CliError> {
-    let runner = Run::new(db, feed, target);
-    runner.run(&script).map_err(|e| CliError {
+    let builder = RunBuilder::default()
+        .target(target.unwrap_or_default())
+        .scan_id(format!("scannerctl-{script}"));
+    let result = match (db, feed) {
+        (Db::Redis(url), None) => builder
+            .storage(create_redis_storage(url))
+            .build()
+            .run(&script),
+        (Db::InMemory, None) => builder.build().run(&script),
+        (Db::Redis(url), Some(path)) => {
+            let storage = create_redis_storage(url);
+            let builder = RunBuilder::default().loader(create_fp_loader(&storage, path)?);
+            builder.storage(storage).build().run(&script)
+        }
+        (Db::InMemory, Some(path)) => {
+            let storage = DefaultDispatcher::new(true);
+            let builder = RunBuilder::default().loader(create_fp_loader(&storage, path)?);
+            builder.storage(storage).build().run(&script)
+        }
+    };
+
+    result.map_err(|e| CliError {
         filename: script,
         kind: e,
     })

--- a/rust/scannerctl/src/interpret/mod.rs
+++ b/rust/scannerctl/src/interpret/mod.rs
@@ -10,21 +10,21 @@ use nasl_interpreter::{
     LoadError, Loader, NaslValue, NoOpLoader, RegisterBuilder,
 };
 use redis_storage::FEEDUPDATE_SELECTOR;
-use storage::DefaultDispatcher;
+use storage::{ContextKey, DefaultDispatcher};
 
 use crate::{CliError, CliErrorKind, Db};
 
-struct Run<K: AsRef<str>> {
-    context_builder: nasl_interpreter::ContextBuilder<K, KeyDispatcherSet<K>>,
+struct Run<S> {
+    context_builder: nasl_interpreter::ContextBuilder<S>,
     feed: Option<PathBuf>,
 }
 
-impl Run<String> {
+impl Run<KeyDispatcherSet> {
     fn new(db: &Db, feed: Option<PathBuf>, target: Option<String>) -> Self {
-        let key = String::default();
+        let key = ContextKey::Scan(String::default());
 
         let mut context_builder = match db {
-            Db::InMemory => ContextBuilder::new(key, Box::<DefaultDispatcher<String>>::default()),
+            Db::InMemory => ContextBuilder::new(key, Box::<DefaultDispatcher>::default()),
             Db::Redis(url) => ContextBuilder::new(
                 key,
                 Box::new(

--- a/rust/scannerctl/src/notusupdate/update.rs
+++ b/rust/scannerctl/src/notusupdate/update.rs
@@ -8,11 +8,11 @@ use crate::{CliError, CliErrorKind};
 
 use nasl_syntax::{FSPluginLoader, LoadError};
 use notus::loader::{hashsum::HashsumAdvisoryLoader, AdvisoryLoader};
-use storage::Dispatcher;
+use storage::{ContextKey, Dispatcher};
 
 pub fn run<S>(storage: S, path: PathBuf, signature_check: bool) -> Result<(), CliError>
 where
-    S: Sync + Send + Dispatcher<String>,
+    S: Sync + Send + Dispatcher,
 {
     let loader = FSPluginLoader::new(path);
     let advisories_files = match HashsumAdvisoryLoader::new(loader.clone()) {
@@ -61,7 +61,7 @@ where
 
         for adv in advisories.advisories {
             let _ = storage.dispatch(
-                &String::new(),
+                &Default::default(),
                 storage::Field::NotusAdvisory(Box::new(Some(models::VulnerabilityData {
                     adv,
                     famile: advisories.family.clone(),
@@ -71,7 +71,8 @@ where
         }
     }
     let _ = storage.dispatch(
-        &"notuscache".to_string(),
+        // TODO: incorrect?
+        &ContextKey::FileName("notuscache".to_string()),
         storage::Field::NotusAdvisory(Box::new(None)),
     );
 

--- a/rust/scannerctl/src/scanconfig.rs
+++ b/rust/scannerctl/src/scanconfig.rs
@@ -269,9 +269,9 @@ struct ScanConfigPreferenceNvt {
     name: String,
 }
 
-pub fn parse_vts<R, K>(
+pub fn parse_vts<R>(
     sc: R,
-    retriever: &dyn storage::Retriever<K>,
+    retriever: &dyn storage::Retriever,
     vts: &[models::VT],
 ) -> Result<Vec<models::VT>, Error>
 where
@@ -459,17 +459,17 @@ mod tests {
         let result = quick_xml::de::from_str::<ScanConfig>(sc).unwrap();
         assert_eq!(result.nvt_selectors.nvt_selector.len(), 2);
         assert_eq!(result.preferences.preference.len(), 3);
-        let shop: storage::DefaultDispatcher<String> = storage::DefaultDispatcher::default();
+        let shop: storage::DefaultDispatcher = storage::DefaultDispatcher::default();
         let add_product_detection = |oid: &str| {
             shop.as_dispatcher()
                 .dispatch(
-                    &oid.to_string(),
+                    &storage::ContextKey::Scan(oid.to_string()),
                     storage::Field::NVT(storage::item::NVTField::Oid(oid.to_owned().to_string())),
                 )
                 .unwrap();
             shop.as_dispatcher()
                 .dispatch(
-                    &oid.to_string(),
+                    &storage::ContextKey::Scan(oid.to_string()),
                     storage::Field::NVT(storage::item::NVTField::Family(
                         "Product detection".to_string(),
                     )),

--- a/rust/storage/src/item.rs
+++ b/rust/storage/src/item.rs
@@ -6,7 +6,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Display,
-    marker::PhantomData,
     str::FromStr,
     sync::{Arc, Mutex},
 };
@@ -14,7 +13,8 @@ use std::{
 use models::{Vulnerability, VulnerabilityData};
 
 use crate::{
-    time::AsUnixTimeStamp, types, Dispatcher, Field, Kb, NotusAdvisory, Retriever, StorageError,
+    time::AsUnixTimeStamp, types, ContextKey, Dispatcher, Field, Kb, NotusAdvisory, Retriever,
+    StorageError,
 };
 
 /// Attack Category either set by script_category
@@ -588,7 +588,7 @@ impl From<(&str, Vulnerability)> for Nvt {
     }
 }
 /// Is a specialized Dispatcher for NVT information within the description block.
-pub trait ItemDispatcher<K> {
+pub trait ItemDispatcher {
     /// Dispatches the feed version as well as NVT.
     ///
     /// The NVT is collected when a description run is finished.
@@ -604,7 +604,7 @@ pub trait ItemDispatcher<K> {
     /// accordingly.
     /// The default is set to return `Ok(())` without doing something to net enforce every
     /// ItemDispatcher to implement it.
-    fn dispatch_kb(&self, _: &K, _: Kb) -> Result<(), StorageError> {
+    fn dispatch_kb(&self, _: &ContextKey, _: Kb) -> Result<(), StorageError> {
         Ok(())
     }
     /// Stores an advisory
@@ -614,26 +614,23 @@ pub trait ItemDispatcher<K> {
 
 /// Collects the information while being in a description run and calls the dispatch method
 /// on exit.
-pub struct PerItemDispatcher<S, K>
+pub struct PerItemDispatcher<S>
 where
-    S: ItemDispatcher<K>,
+    S: ItemDispatcher,
 {
     nvt: Arc<Mutex<Option<Nvt>>>,
     dispatcher: S,
-    phantom: PhantomData<K>,
 }
 
-impl<S, K> PerItemDispatcher<S, K>
+impl<S> PerItemDispatcher<S>
 where
-    S: ItemDispatcher<K>,
-    K: AsRef<str>,
+    S: ItemDispatcher,
 {
     /// Creates a new ItemDispatcher without a feed_version and nvt.
     pub fn new(dispatcher: S) -> Self {
         Self {
             nvt: Arc::new(Mutex::new(None)),
             dispatcher,
-            phantom: PhantomData,
         }
     }
 
@@ -671,16 +668,16 @@ where
     }
 }
 
-impl<S, K> Dispatcher<K> for PerItemDispatcher<S, K>
+impl<S> Dispatcher for PerItemDispatcher<S>
 where
-    K: AsRef<str> + Send + Sync,
-    S: ItemDispatcher<K> + Send + Sync,
+    S: ItemDispatcher + Send + Sync,
 {
-    fn dispatch(&self, key: &K, scope: crate::Field) -> Result<(), StorageError> {
+    fn dispatch(&self, key: &ContextKey, scope: crate::Field) -> Result<(), StorageError> {
         match scope {
             Field::NVT(nvt) => self.store_nvt_field(nvt),
             Field::KB(kb) => self.dispatcher.dispatch_kb(key, kb),
-            Field::NotusAdvisory(adv) => self.dispatcher.dispatch_advisory(key.as_ref(), adv),
+            // TODO: rename value to owned_value, create value to return a ref
+            Field::NotusAdvisory(adv) => self.dispatcher.dispatch_advisory(&key.value(), adv),
         }
     }
 
@@ -695,14 +692,13 @@ where
     }
 }
 
-impl<S, K> Retriever<K> for PerItemDispatcher<S, K>
+impl<S> Retriever for PerItemDispatcher<S>
 where
-    K: AsRef<str>,
-    S: ItemDispatcher<K> + Retriever<K>,
+    S: ItemDispatcher + Retriever,
 {
     fn retrieve(
         &self,
-        key: &K,
+        key: &ContextKey,
         scope: crate::Retrieve,
     ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
         self.dispatcher.retrieve(key, scope)
@@ -712,7 +708,7 @@ where
         &self,
         field: Field,
         scope: crate::Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, Field)>>, StorageError> {
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, Field)>>, StorageError> {
         self.dispatcher.retrieve_by_field(field, scope)
     }
 }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -342,9 +342,7 @@ impl Retriever for DefaultDispatcher {
                 let scope = scope.clone();
                 let scope2 = scope.clone();
                 v.into_iter()
-                    .filter(move |v| {
-                        scope.for_field(v)
-                    })
+                    .filter(move |v| scope.for_field(v))
                     .map(move |v| {
                         (
                             match &scope2 {

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -13,12 +13,46 @@ pub mod types;
 use std::{
     fmt::Display,
     io,
-    marker::PhantomData,
     sync::{Arc, PoisonError, RwLock},
 };
 
 use item::NVTField;
 use types::Primitive;
+
+/// Is a key used by a Storage to find data within a certain scope.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContextKey {
+    /// The context is used within a scan.
+    ///
+    /// This is used to limit kb items or results to a specific scan.
+    Scan(String),
+    /// The context is used within a feed update.
+    ///
+    /// The filename is used to know that a given information belongs to certain nasl script.
+    FileName(String),
+}
+
+impl Default for ContextKey {
+    fn default() -> Self {
+        ContextKey::FileName(Default::default())
+    }
+}
+
+impl From<&str> for ContextKey {
+    fn from(value: &str) -> Self {
+        Self::FileName(value.into())
+    }
+}
+
+impl ContextKey {
+    /// Returns the owned inner value of ContextKey
+    pub fn value(&self) -> String {
+        match self {
+            ContextKey::Scan(x) => x.to_string(),
+            ContextKey::FileName(x) => x.to_string(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(
@@ -135,11 +169,11 @@ impl Display for StorageError {
 impl std::error::Error for StorageError {}
 
 /// Defines the Dispatcher interface to distribute fields
-pub trait Dispatcher<K>: Sync + Send {
+pub trait Dispatcher: Sync + Send {
     /// Distributes given field under a key
     ///
     /// A key is usually a OID that was given when starting a script but in description run it is the filename.
-    fn dispatch(&self, key: &K, scope: Field) -> Result<(), StorageError>;
+    fn dispatch(&self, key: &ContextKey, scope: Field) -> Result<(), StorageError>;
 
     /// On exit is called when a script exit
     ///
@@ -147,7 +181,12 @@ pub trait Dispatcher<K>: Sync + Send {
     fn on_exit(&self) -> Result<(), StorageError>;
 
     /// Retries a dispatch for the amount of retries when a retrieable error occurs.
-    fn retry_dispatch(&self, retries: usize, key: &K, scope: Field) -> Result<(), StorageError> {
+    fn retry_dispatch(
+        &self,
+        retries: usize,
+        key: &ContextKey,
+        scope: Field,
+    ) -> Result<(), StorageError> {
         match self.dispatch(key, scope.clone()) {
             Ok(r) => Ok(r),
             Err(e) => {
@@ -161,11 +200,11 @@ pub trait Dispatcher<K>: Sync + Send {
     }
 }
 
-impl<K, T> Dispatcher<K> for Arc<T>
+impl<T> Dispatcher for Arc<T>
 where
-    T: Dispatcher<K>,
+    T: Dispatcher,
 {
-    fn dispatch(&self, key: &K, scope: Field) -> Result<(), StorageError> {
+    fn dispatch(&self, key: &ContextKey, scope: Field) -> Result<(), StorageError> {
         self.as_ref().dispatch(key, scope)
     }
 
@@ -175,22 +214,22 @@ where
 }
 
 /// Convenience trait to use a dispatcher and retriever implementation
-pub trait Storage<K>: Dispatcher<K> + Retriever<K> {
+pub trait Storage: Dispatcher + Retriever {
     /// Returns a reference to the retriever
-    fn as_retriever(&self) -> &dyn Retriever<K>;
+    fn as_retriever(&self) -> &dyn Retriever;
     /// Returns a reference to the dispatcher
-    fn as_dispatcher(&self) -> &dyn Dispatcher<K>;
+    fn as_dispatcher(&self) -> &dyn Dispatcher;
 }
 
-impl<K, T> Storage<K> for T
+impl<T> Storage for T
 where
-    T: Dispatcher<K> + Retriever<K>,
+    T: Dispatcher + Retriever,
 {
-    fn as_retriever(&self) -> &dyn Retriever<K> {
+    fn as_retriever(&self) -> &dyn Retriever {
         self
     }
 
-    fn as_dispatcher(&self) -> &dyn Dispatcher<K> {
+    fn as_dispatcher(&self) -> &dyn Dispatcher {
         self
     }
 }
@@ -202,23 +241,21 @@ type StoreItem = Vec<(String, Vec<Field>)>;
 
 /// Is a in-memory dispatcher that behaves like a Storage.
 #[derive(Default)]
-pub struct DefaultDispatcher<K> {
+pub struct DefaultDispatcher {
     /// If dirty it will not clean the data on_exit
     dirty: bool,
-    key: PhantomData<K>,
     /// The data storage
     ///
     /// The memory access is managed via an Arc while the Mutex ensures that only one consumer at a time is accessing it.
     data: Arc<RwLock<StoreItem>>,
 }
 
-impl<K> DefaultDispatcher<K> {
+impl DefaultDispatcher {
     /// Creates a new DefaultDispatcher
     pub fn new(dirty: bool) -> Self {
         Self {
             dirty,
             data: Default::default(),
-            key: PhantomData,
         }
     }
 
@@ -231,15 +268,12 @@ impl<K> DefaultDispatcher<K> {
     }
 }
 
-impl<K> Dispatcher<K> for DefaultDispatcher<K>
-where
-    K: AsRef<str> + Display + Default + From<String> + Send + Sync,
-{
-    fn dispatch(&self, key: &K, scope: Field) -> Result<(), StorageError> {
+impl Dispatcher for DefaultDispatcher {
+    fn dispatch(&self, key: &ContextKey, scope: Field) -> Result<(), StorageError> {
         let mut data = Arc::as_ref(&self.data).write()?;
-        match data.iter_mut().find(|(k, _)| k.as_str() == key.as_ref()) {
+        match data.iter_mut().find(|(k, _)| k.as_str() == key.value()) {
             Some((_, v)) => v.push(scope),
-            None => data.push((key.as_ref().to_owned(), vec![scope])),
+            None => data.push((key.value(), vec![scope])),
         }
         tracing::trace!("Keys: {}", data.len());
         Ok(())
@@ -278,18 +312,15 @@ impl<T> Iterator for InMemoryDataWrapper<T> {
     }
 }
 
-impl<K> Retriever<K> for DefaultDispatcher<K>
-where
-    K: AsRef<str> + Display + Default + From<String> + 'static,
-{
+impl Retriever for DefaultDispatcher {
     fn retrieve(
         &self,
-        key: &K,
+        key: &ContextKey,
         scope: Retrieve,
     ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
         let data = Arc::as_ref(&self.data).read()?;
         let data = InMemoryDataWrapper::new(data.clone());
-        let skey = key.to_string();
+        let skey = key.value();
         Ok(Box::new(
             data.into_iter()
                 .filter(move |(k, _)| k == &skey)
@@ -302,7 +333,7 @@ where
         &self,
         field: Field,
         scope: Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, Field)>>, StorageError> {
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, Field)>>, StorageError> {
         let data = Arc::as_ref(&self.data).read()?;
         tracing::debug!("Entries: {:?}", data.len());
         let data = InMemoryDataWrapper::new(data.clone());
@@ -311,9 +342,19 @@ where
             .filter(move |(_, v)| v.contains(&field))
             .flat_map(move |(k, v)| {
                 let scope = scope.clone();
+                let scope2 = scope.clone();
                 v.into_iter()
                     .filter(move |v| scope.for_field(v))
-                    .map(move |v| (K::from(k.clone()), v))
+                    .map(move |v| {
+                        (
+                            match &scope2 {
+                                Retrieve::NVT(_) => ContextKey::FileName(k.clone()),
+                                Retrieve::KB(_) => ContextKey::Scan(k.clone()),
+                                Retrieve::NotusAdvisory(_) => ContextKey::FileName(k.clone()),
+                            },
+                            v,
+                        )
+                    })
             });
         Ok(Box::new(result))
     }
@@ -330,7 +371,7 @@ mod tests {
     #[test]
     pub fn default_storage() -> Result<(), StorageError> {
         let storage = DefaultDispatcher::default();
-        let key: String = Default::default();
+        let key = ContextKey::FileName(String::new());
         storage.dispatch(&key, NVT(Oid("moep".to_owned())))?;
         assert_eq!(
             storage

--- a/rust/storage/src/retrieve.rs
+++ b/rust/storage/src/retrieve.rs
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::marker::PhantomData;
-
 use crate::{
     item::{NVTField, NVTKey},
-    Field, StorageError,
+    ContextKey, Field, StorageError,
 };
 
 /// Retrieve command for a given Field
@@ -85,13 +83,11 @@ impl Retrieve {
 }
 
 /// Retrieves fields based on a key and scope.
-// TODO: remove K infavor of a enum, as a user of that interface it is very hard to differentiate
-// when to use an OID and when not. A better solution would be to use enums.
-pub trait Retriever<K> {
+pub trait Retriever {
     /// Gets Fields find by key and scope. This is to get all instances.
     fn retrieve(
         &self,
-        key: &K,
+        key: &ContextKey,
         scope: Retrieve,
     ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError>;
 
@@ -102,7 +98,7 @@ pub trait Retriever<K> {
         &self,
         field: Field,
         scope: Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, Field)>>, StorageError>;
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, Field)>>, StorageError>;
 }
 
 /// A NoOpRetriever is for cases that don't require a retriever but it is needed due to contract.
@@ -111,14 +107,12 @@ pub trait Retriever<K> {
 /// but since it is not needed for a description run it wouldn't make sense to instantiate a
 /// reriever instance.
 #[derive(Default)]
-pub struct NoOpRetriever<K> {
-    phantom: PhantomData<K>,
-}
+pub struct NoOpRetriever {}
 
-impl<K: 'static> Retriever<K> for NoOpRetriever<K> {
+impl Retriever for NoOpRetriever {
     fn retrieve(
         &self,
-        _: &K,
+        _: &ContextKey,
         _: Retrieve,
     ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
         Ok(Box::new(vec![].into_iter()))
@@ -128,7 +122,7 @@ impl<K: 'static> Retriever<K> for NoOpRetriever<K> {
         &self,
         _: Field,
         _: Retrieve,
-    ) -> Result<Box<dyn Iterator<Item = (K, Field)>>, StorageError> {
+    ) -> Result<Box<dyn Iterator<Item = (ContextKey, Field)>>, StorageError> {
         Ok(Box::new(vec![].into_iter()))
     }
 }


### PR DESCRIPTION
To make it clearer when to use what a ContextKey to define the scope of
the Retrieve, Dispatcher is introduced. ContextKey is a enum containing
either FileName or Scan with a String value for either a Scan context or
a feed update context.

The reason to introduce a enum over a String value is to make the
context more clear and to allow key verifications later on.
