### PR TITLE
Refactor: allow dead code on Igmp

### DIFF
--- a/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
@@ -1885,6 +1885,7 @@ pub mod igmp {
 
     /// Represents a generic IGMP packet.
     #[packet]
+    #[allow(dead_code)]
     pub struct Igmp {
         #[construct_with(u8)]
         pub igmp_type: IgmpType,

--- a/rust/nasl-interpreter/src/scan_interpreter.rs
+++ b/rust/nasl-interpreter/src/scan_interpreter.rs
@@ -17,7 +17,7 @@ use crate::{scheduling::ExecutionPlaner, InterpretError};
 ///
 /// As a Scan is able to configure the behavior of scripts (e.g. consider_alive means that each
 /// port within the scan is considered reachable without testing) each Interpreter must be created
-/// for each scan and is not reuseable.
+/// for each scan and is not reusable.
 pub struct SyncScanInterpreter<'a, S, L, N> {
     storage: &'a S,
     loader: &'a L,


### PR DESCRIPTION
To keep memory alignment between rust and c we allow dead_code on Igmp.
