### PR TITLE
Add mTLS to authentication methods in response header

### DIFF
--- a/rust/openvasd/src/tls.rs
+++ b/rust/openvasd/src/tls.rs
@@ -165,9 +165,14 @@ pub fn config_to_tls_paths(
     )))
 }
 
-pub type TlsData = (Arc<RwLock<ClientIdentifier>>, ServerConfig, bool);
+#[derive(Debug)]
+pub struct TlsConfig {
+    pub client_identifier: Arc<RwLock<ClientIdentifier>>,
+    pub config: ServerConfig,
+    pub has_clients: bool,
+}
 
-pub fn tls_config(config: &crate::config::Config) -> Result<Option<TlsData>, Error> {
+pub fn tls_config(config: &crate::config::Config) -> Result<Option<TlsConfig>, Error> {
     let (key, certs, clients) = match config_to_tls_paths(config)? {
         Some(x) => x,
         None => return Ok(None),
@@ -191,7 +196,11 @@ pub fn tls_config(config: &crate::config::Config) -> Result<Option<TlsData>, Err
 
         config.alpn_protocols = vec![b"h2".to_vec()];
 
-        Ok(Some((client_identifier, config, !clients.is_empty())))
+        Ok(Some(TlsConfig {
+            client_identifier,
+            config,
+            has_clients: !clients.is_empty(),
+        }))
     } else {
         match &config.tls.client_certs {
             Some(clicerts) => {
@@ -222,7 +231,11 @@ pub fn tls_config(config: &crate::config::Config) -> Result<Option<TlsData>, Err
 
         config.alpn_protocols = vec![b"h2".to_vec()];
 
-        Ok(Some((client_identifier, config, !clients.is_empty())))
+        Ok(Some(TlsConfig {
+            client_identifier,
+            config,
+            has_clients: !clients.is_empty(),
+        }))
     }
 }
 


### PR DESCRIPTION
Jira: SC-1106

**What**:
Adds `mTLS` to authentication methods in the response header:

```
> curl --head --insecure --cert client.cert --key client.key --cacert CA/ca.cert --request GET https://localhost:3000/scans -H "X-API-KEY: mtls_is_preferred"  

HTTP/2 401 
authentication: mTLS
api-version: 1
feed-version: UNDEFINED
date: Wed, 10 Jul 2024 10:00:51 GMT
```


**How**:
The authentication methods are updated via the `ContextBuilder::add_authentication` method which was previously only called from `ContextBuilder::api_key`. The problem is that previously, the TLS setup was done in `run`, after the `Context` had already been built. Adding the authentication method at this point would mean manually modifying the `ctx.response` which is a little ugly. Instead, I decided to move the TLS setup to the `ContextBuilder::build` method, which is called just before `run` anyway. The `ContextBuilder` now has all the information to decide on the proper response.

I'm not sure what the proper response is if both api key and TLS are used, since the api key will be internally disabled. Should it only be TLS, or both?

I also made the type alias `TlsData` a proper struct `TlsConfig` (renamed for consistency), because I felt that now that it is being used more often, it deserved being its own proper type.