### PR TITLE
Fix typos

### DIFF
--- a/rust/infisto/Cargo.toml
+++ b/rust/infisto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "infisto"
-description = "A library to store and retrieve serializeable vec data in a file that can be accessed by an index."
+description = "A library to store and retrieve serializable vec data in a file that can be accessed by an index."
 version.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
@@ -1104,7 +1104,7 @@ fn insert_tcp_options(
         FunctionErrorKind::Dirty("No possible to create a packet from buffer".to_string())
     })?;
 
-    // At this point, opts len is a 4bytes multiple and the ofset is expressed in 32bits words
+    // At this point, opts len is a 4bytes multiple and the offset is expressed in 32bits words
     ori_tcp.set_data_offset(5 + opts_len as u8 / 4);
     if !opts.is_empty() {
         ori_tcp.set_options(&opts);

--- a/rust/openvasd/src/scheduling.rs
+++ b/rust/openvasd/src/scheduling.rs
@@ -272,7 +272,7 @@ where
                         }
                         new_status.scanning = Some(hs);
 
-                        // update the hosts stauts into the result before storing
+                        // update the hosts status into the result before storing
                         results.status.host_info = Some(new_status);
 
                         // Update start and end time if set from openvas


### PR DESCRIPTION
`typos` has increased its detection radius, to prevent other PR from
failing based on typos within the main branch `typos -w` is run.
