### PR TITLE
Fix unused code warning for `decode_hex`

### DIFF
--- a/rust/nasl-builtin-cryptographic/src/lib.rs
+++ b/rust/nasl-builtin-cryptographic/src/lib.rs
@@ -23,9 +23,6 @@ enum Crypt {
     Decrypt,
 }
 
-/// Decodes given string as hex and returns the result as a byte array
-// TODO only used in tests, move tests to its own module and define there
-
 pub(crate) fn lookup(function_name: &str) -> Option<NaslFunction> {
     aes_ccm::lookup(function_name)
         .or_else(|| hmac::lookup(function_name))

--- a/rust/nasl-builtin-cryptographic/tests/hash.rs
+++ b/rust/nasl-builtin-cryptographic/tests/hash.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-mod helper;
-
 #[cfg(test)]
 mod tests {
     use nasl_interpreter::*;

--- a/rust/nasl-builtin-cryptographic/tests/hmac.rs
+++ b/rust/nasl-builtin-cryptographic/tests/hmac.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-mod helper;
-
 #[cfg(test)]
 mod tests {
     use nasl_interpreter::*;

--- a/rust/nasl-c-lib/tests/helper/mod.rs
+++ b/rust/nasl-c-lib/tests/helper/mod.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 use std::num::ParseIntError;
+
+/// Decodes given string as hex and returns the result as a byte array
 pub(crate) fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
     (0..s.len())
         .step_by(2)


### PR DESCRIPTION
Nobody really asked for this but seeing this on every test build annoyed me:

```
warning: function `decode_hex` is never used
 --> nasl-builtin-cryptographic/tests/helper/mod.rs:7:8
  |
7 | pub fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
  |        ^^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default
```

I also found a documentation string in `lib.rs` which documented this function (but it wasn't there), so I moved it to the function and removed the unnecessary TODO.

Note: Replacing the current 
`cargo clippy -- -D warnings`
 with 
`cargo clippy --tests -- -D warnings` 
in CI would have caught this.