### PR TITLE
set opt_level=2 for gcrypt to remove warning

### DIFF
--- a/rust/nasl-c-lib/build.rs
+++ b/rust/nasl-c-lib/build.rs
@@ -20,5 +20,6 @@ fn main() {
         .file("c/cryptographic/gcrypt_mac.c")
         .file("c/cryptographic/gcrypt_error.c")
         .include(canonicalize("./include").unwrap())
+        .opt_level(2)
         .compile("crypt");
 }


### PR DESCRIPTION
**What**:

This removes the annoying warning on debug-builds:
```
warning: nasl-c-lib@0.1.0: In file included from /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/bits/libc-header-start.h:33,
warning: nasl-c-lib@0.1.0:                  from /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/stdlib.h:26,
warning: nasl-c-lib@0.1.0:                  from /home/toni/projects/openvas-scanner/rust/nasl-c-lib/include/gcrypt.h:27,
warning: nasl-c-lib@0.1.0:                  from c/cryptographic/gcrypt_mac.h:9,
warning: nasl-c-lib@0.1.0:                  from c/cryptographic/gcrypt_mac.c:6:
warning: nasl-c-lib@0.1.0: /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/features.h:414:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
warning: nasl-c-lib@0.1.0:   414 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
warning: nasl-c-lib@0.1.0:       |    ^~~~~~~
warning: nasl-c-lib@0.1.0: In file included from /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/bits/libc-header-start.h:33,
warning: nasl-c-lib@0.1.0:                  from /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/stdlib.h:26,
warning: nasl-c-lib@0.1.0:                  from /home/toni/projects/openvas-scanner/rust/nasl-c-lib/include/gcrypt.h:27,
warning: nasl-c-lib@0.1.0:                  from c/cryptographic/gcrypt_error.h:9,
warning: nasl-c-lib@0.1.0:                  from c/cryptographic/gcrypt_error.c:6:
warning: nasl-c-lib@0.1.0: /nix/store/fwh4fxd747m0py3ib3s5abamia9nrf90-glibc-2.39-52-dev/include/features.h:414:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
warning: nasl-c-lib@0.1.0:   414 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
warning: nasl-c-lib@0.1.0:       |    ^~~~~~~
```

by increasing the opt level for the `gcrypt` build in `nasl-c-lib`.
