### PR TITLE
Fix: use the right method to get vts from nvticache

### DIFF
--- a/rust/feed/src/transpile/mod.rs
+++ b/rust/feed/src/transpile/mod.rs
@@ -135,8 +135,10 @@ trait Matcher {
     fn matches(&self, s: &Statement) -> bool;
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 struct CallMatcher {}
+
 impl Matcher for CallMatcher {
     fn matches(&self, s: &Statement) -> bool {
         // Although Exit and Include are handled differently they share the call nature and hence

--- a/rust/nasl-builtin-http/src/lib.rs
+++ b/rust/nasl-builtin-http/src/lib.rs
@@ -443,6 +443,7 @@ impl NaslHttp {
     /// nasl named param
     ///   - handle The handle identifier
     ///   - header_item A string to add to the header
+    ///
     /// On success the function returns an integer. 0 on success. Null on error.
     fn set_custom_header(
         &self,

--- a/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/frame_forgery.rs
@@ -442,8 +442,9 @@ fn nasl_get_local_mac_address_from_ip(
 ///This function forges a datalink layer frame.
 /// - src_haddr: is a string containing the source MAC address
 /// - dst_haddr: is a string containing the destination MAC address
-/// -ether_proto: is an int containing the ethernet type (normally given as hexadecimal). It is optional and its default value is 0x0800. A list of Types can be e.g. looked up here.
-/// -payload: is any data, which is then attached as payload to the frame.
+/// - ether_proto: is an int containing the ethernet type (normally given as hexadecimal).
+///   It is optional and its default value is 0x0800. A list of Types can be e.g. looked up here.
+/// - payload: is any data, which is then attached as payload to the frame.
 fn nasl_forge_frame(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     let src_haddr = validate_mac_address(register.named("src_haddr"))?;
     let dst_haddr = validate_mac_address(register.named("dst_haddr"))?;

--- a/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
+++ b/rust/nasl-builtin-raw-ip/src/packet_forgery.rs
@@ -1239,7 +1239,7 @@ fn format_flags(pkt: &TcpPacket) -> String {
 /// - uh_sum: is the UDP checksum. Although it is not compulsory, the right value is computed by default.
 /// - uh_ulen: is the data length. By default it is set to the length the data argument plus the size of the UDP header.
 /// - update_ip_len: is a flag (TRUE by default). If set, NASL will recompute the size field of the IP datagram.
-
+///
 /// Returns the modified IP datagram or NULL on error.
 fn forge_udp_packet(
     register: &Register,

--- a/rust/nasl-builtin-ssh/src/lib.rs
+++ b/rust/nasl-builtin-ssh/src/lib.rs
@@ -403,7 +403,7 @@ impl Ssh {
     /// - scciphers SSH server-to-client ciphers.
     ///
     /// - timeout Set a timeout for the connection in seconds. Defaults to 10
-    /// seconds (defined by libssh internally) if not given.
+    ///   seconds (defined by libssh internally) if not given.
     ///
     /// nasl return An integer to identify the ssh session. Zero on error.
     fn nasl_ssh_connect(
@@ -1208,7 +1208,7 @@ impl Ssh {
     ///
     /// nasl named params
     /// - timeout: Enable the blocking ssh read until it gives the timeout or there is no
-    /// bytes left to read.
+    ///   bytes left to read.
     ///
     /// return A string on success or NULL on error.
     fn nasl_ssh_shell_read(
@@ -1942,6 +1942,7 @@ impl Ssh {
     ///
     /// nasluparam
     /// - An SSH session id.
+    ///
     /// naslret An int on success or NULL on error.
     ///
     /// param[in] lexic Lexical context of NASL interpreter.

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -215,7 +215,7 @@ where
         let url = self.url.to_string();
         let nr = tokio::task::spawn_blocking(move || {
             let mut nvt_redis = RedisCtx::open(&url, FEEDUPDATE_SELECTOR)?;
-            nvt_redis.redis_get_advisory(&aoid)
+            nvt_redis.redis_get_vt(&aoid)
         })
         .await
         .unwrap()?;
@@ -243,7 +243,7 @@ where
                 .keys("nvt:*")?
                 .into_iter()
                 .filter_map(|x| x.split('/').last().map(|x| x.to_string()))
-                .filter_map(move |oid| nvt_redis.redis_get_vt(&oid).ok())
+                .filter_map(move |oid| nvt_redis.redis_get_vt(&oid[4..]).ok())
                 .flatten();
             Ok::<_, Error>(foids)
         });

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -350,7 +350,15 @@ pub trait RedisGetNvt: RedisWrapper {
 
         for (k, v) in tag_list.into_iter() {
             if let Ok(tk) = TagKey::from_str(k) {
-                tag_map.insert(tk, TagValue::from(v));
+                match tk {
+                    TagKey::CreationDate | TagKey::LastModification | TagKey::SeverityDate => {
+                        tag_map.insert(
+                            tk,
+                            TagValue::from(i64::from_str(v).expect("Valid timestamp")),
+                        )
+                    }
+                    _ => tag_map.insert(tk, TagValue::from(v)),
+                };
             }
         }
 


### PR DESCRIPTION
**What**:
Fix: use the right method to get vts from nvticache
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
method GET /vts?information=1 only retrieves notus advisories
<!-- Why are these changes necessary? -->

**How**:
request GET /vts?information=1
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
