### PR TITLE
Fix: Feed is loaded many times in readis after openvasd restart

### DIFF
--- a/rust/feed/src/update/mod.rs
+++ b/rust/feed/src/update/mod.rs
@@ -107,6 +107,18 @@ where
         feed_version(self.loader, self.dispatcher)
     }
 
+    /// Check if the current feed is outdated.
+    pub fn feed_is_outdated(&self, current_version: String) -> Result<bool, ErrorKind> {
+        self.verify_signature()?;
+        // the version in file
+        let v = self.feed_version()?;
+        if !current_version.is_empty() {
+            return Ok(v.as_str() != current_version.as_str());
+        };
+
+        Ok(true)
+    }
+
     /// plugin_feed_info must be handled differently.
     ///
     /// Usually a plugin_feed_info.inc is setup as a listing of keys.

--- a/rust/openvasd/src/storage/mod.rs
+++ b/rust/openvasd/src/storage/mod.rs
@@ -186,6 +186,11 @@ pub trait NVTStorer {
 
     /// Returns the currently stored feed hash.
     async fn feed_hash(&self) -> Vec<FeedHash>;
+
+    /// Returns the current feed version, if any.
+    async fn current_feed_version(&self) -> Result<String, Error> {
+        Ok("".to_string())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
**What**:
Check if the current version is already in the cache before uploading. Also remove the old entries before uploading, if the entry is present to avoid the amount if items inside keys (duplication).
Jira: SC-1122

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
After reloading openvasd, the feed is completely uploaded without deleting the present entries which increases the memory usages.
Also, If the feed does not changed (same feed version), the feed shouldn't be uploaded.

<!-- Why are these changes necessary? -->

**How**:
restart openvasd  many times and check the redis cache
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
