### PR TITLE
Move NASL misc builtins to new argument handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "nasl-builtin-ssh",
  "nasl-builtin-string",
  "nasl-builtin-utils",
+ "nasl-function-proc-macro",
  "nasl-interpreter",
  "nasl-syntax",
  "storage",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "chrono",
  "flate2",
  "nasl-builtin-utils",
+ "nasl-function-proc-macro",
  "nasl-interpreter",
  "nasl-syntax",
  "storage",

--- a/rust/nasl-builtin-misc/Cargo.toml
+++ b/rust/nasl-builtin-misc/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 nasl-builtin-utils = {path = "../nasl-builtin-utils"}
+nasl-function-proc-macro = {path = "../nasl-function-proc-macro"}
 nasl-syntax = {path = "../nasl-syntax"}
 storage = {path = "../storage"}
 

--- a/rust/nasl-builtin-misc/src/lib.rs
+++ b/rust/nasl-builtin-misc/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 use chrono::{
     self, DateTime, Datelike, FixedOffset, Local, LocalResult, Offset, TimeZone, Timelike, Utc,
 };
+use nasl_function_proc_macro::nasl_function;
 use nasl_syntax::NaslValue;
 
 use flate2::{
@@ -35,188 +36,121 @@ pub fn random_impl() -> Result<i64, FunctionErrorKind> {
 }
 
 /// NASL function to get random number
-fn rand(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    random_impl().map(NaslValue::Number)
+#[nasl_function]
+fn rand() -> Result<i64, FunctionErrorKind> {
+    random_impl()
 }
 
 /// NASL function to get host byte order
-fn get_byte_order(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    Ok(NaslValue::Boolean(cfg!(target_endian = "little")))
+#[nasl_function]
+fn get_byte_order() -> bool {
+    cfg!(target_endian = "little")
 }
 
 /// NASL function to convert given number to string
-fn dec2str(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    match register.named("num") {
-        Some(ContextType::Value(NaslValue::Number(x))) => Ok(NaslValue::String(x.to_string())),
-        x => Err(("0", "numeric", x).into()),
-    }
+#[nasl_function(named(num))]
+fn dec2str(num: i64) -> String {
+    num.to_string()
 }
 
 /// takes an integer and sleeps the amount of seconds
-fn sleep(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = register.positional();
-    match positional[0] {
-        NaslValue::Number(x) => {
-            thread::sleep(Duration::new(x as u64, 0));
-            Ok(NaslValue::Null)
-        }
-        _ => Ok(NaslValue::Null),
-    }
+#[nasl_function]
+fn sleep(secs: u64) {
+    thread::sleep(Duration::from_secs(secs))
 }
 
 /// takes an integer and sleeps the amount of microseconds
-fn usleep(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = register.positional();
-    match positional[0] {
-        NaslValue::Number(x) => {
-            thread::sleep(Duration::new(0, (1000 * x) as u32));
-            Ok(NaslValue::Null)
-        }
-        _ => Ok(NaslValue::Null),
-    }
+#[nasl_function]
+fn usleep(micros: u64) {
+    thread::sleep(Duration::from_micros(micros))
 }
 
 /// Returns the type of given unnamed argument.
 // typeof is a reserved keyword, therefore it is prefixed with "nasl_"
-fn nasl_typeof(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = register.positional();
-    if positional.is_empty() {
-        return Ok(NaslValue::Null);
-    }
-    match positional[0] {
-        NaslValue::Null => Ok(NaslValue::String("undef".to_string())),
-        NaslValue::String(_) => Ok(NaslValue::String("string".to_string())),
-        NaslValue::Array(_) => Ok(NaslValue::String("array".to_string())),
-        NaslValue::Dict(_) => Ok(NaslValue::String("array".to_string())),
-        NaslValue::Boolean(_) => Ok(NaslValue::String("int".to_string())),
-        NaslValue::Number(_) => Ok(NaslValue::String("int".to_string())),
-        NaslValue::Data(_) => Ok(NaslValue::String("data".to_string())),
-        _ => Ok(NaslValue::String("unknown".to_string())),
+#[nasl_function]
+fn nasl_typeof(val: NaslValue) -> &str {
+    match val {
+        NaslValue::Null => "undef",
+        NaslValue::String(_) => "string",
+        NaslValue::Array(_) => "array",
+        NaslValue::Dict(_) => "array",
+        NaslValue::Boolean(_) => "int",
+        NaslValue::Number(_) => "int",
+        NaslValue::Data(_) => "data",
+        _ => "unknown",
     }
 }
 
 /// Returns true when the given unnamed argument is null.
-fn isnull(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = register.positional();
-    if positional.is_empty() {
-        return Err(FunctionErrorKind::MissingPositionalArguments {
-            expected: 1,
-            got: positional.len(),
-        });
-    }
-    match positional[0] {
-        NaslValue::Null => Ok(NaslValue::Boolean(true)),
-        _ => Ok(NaslValue::Boolean(false)),
-    }
+#[nasl_function]
+fn isnull(val: NaslValue) -> bool {
+    matches!(val, NaslValue::Null)
 }
 
 /// Returns the seconds counted from 1st January 1970 as an integer.
-fn unixtime(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    match std::time::SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(t) => Ok(NaslValue::Number(t.as_secs() as i64)),
-        Err(_) => Err(FunctionErrorKind::wrong_unnamed_argument("0", "numeric")),
-    }
+#[nasl_function]
+fn unixtime() -> Result<u64, FunctionErrorKind> {
+    std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|t| t.as_secs())
+        .map_err(|_| {
+            FunctionErrorKind::Dirty("System time set to time before 1st January 1960".into())
+        })
 }
 
 /// Compress given data with gzip, when headformat is set to 'gzip' it uses gzipheader.
-fn gzip(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let data = match register.named("data") {
-        Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
-        Some(ContextType::Value(x)) => Vec::<u8>::from(x),
-        _ => return Err(FunctionErrorKind::missing_argument("data")),
-    };
-    let headformat = match register.named("headformat") {
-        Some(ContextType::Value(NaslValue::String(x))) => x,
-        _ => "noheaderformat",
-    };
-
-    match headformat.to_string().eq_ignore_ascii_case("gzip") {
-        true => {
-            let mut e = GzEncoder::new(Vec::new(), Compression::default());
-            match e.write_all(&data) {
-                Ok(_) => match e.finish() {
-                    Ok(compress) => Ok(NaslValue::Data(compress)),
-                    Err(_) => Ok(NaslValue::Null),
-                },
-                Err(_) => Ok(NaslValue::Null),
-            }
-        }
-        false => {
-            let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
-            match e.write_all(&data) {
-                Ok(_) => match e.finish() {
-                    Ok(compress) => Ok(NaslValue::Data(compress)),
-                    Err(_) => Ok(NaslValue::Null),
-                },
-                Err(_) => Ok(NaslValue::Null),
-            }
-        }
+#[nasl_function(named(data, headformat))]
+fn gzip(data: NaslValue, headformat: Option<&str>) -> Option<Vec<u8>> {
+    let data = Vec::<u8>::from(data);
+    let headformat = headformat.unwrap_or("noheaderformat");
+    if headformat.eq_ignore_ascii_case("gzip") {
+        let mut e = GzEncoder::new(Vec::new(), Compression::default());
+        e.write_all(&data).and_then(|_| e.finish()).ok()
+    } else {
+        let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
+        e.write_all(&data).and_then(|_| e.finish()).ok()
     }
 }
 
 /// uncompress given data with gzip, when headformat is set to 'gzip' it uses gzipheader.
-fn gunzip(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let data = match register.named("data") {
-        Some(ContextType::Value(NaslValue::Null)) => return Ok(NaslValue::Null),
-        Some(ContextType::Value(x)) => Vec::<u8>::from(x),
-        _ => return Err(FunctionErrorKind::missing_argument("data")),
-    };
-
+#[nasl_function(named(data))]
+fn gunzip(data: NaslValue) -> Option<String> {
+    let data = Vec::<u8>::from(data);
     let mut uncompress = ZlibDecoder::new(&data[..]);
     let mut uncompressed = String::new();
     match uncompress.read_to_string(&mut uncompressed) {
-        Ok(_) => Ok(NaslValue::String(uncompressed)),
+        Ok(_) => Some(uncompressed),
         Err(_) => {
             let mut uncompress = GzDecoder::new(&data[..]);
             let mut uncompressed = String::new();
             if uncompress.read_to_string(&mut uncompressed).is_ok() {
-                Ok(NaslValue::String(uncompressed))
+                Some(uncompressed)
             } else {
-                Ok(NaslValue::Null)
+                None
             }
         }
     }
 }
-/// Takes seven named arguments sec, min, hour, mday, mon, year, isdst and returns the Unix time.
-fn mktime(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let sec = match register.named("sec") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
-        _ => 0,
-    };
-    let min = match register.named("min") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
-        _ => 0,
-    };
-    let hour = match register.named("hour") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
-        _ => 0,
-    };
-    let mday = match register.named("mday") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
-        _ => 0,
-    };
-    let mon = match register.named("mon") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as u32,
-        _ => 1,
-    };
-    let year = match register.named("year") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as i32,
-        _ => 0,
-    };
 
+/// Takes seven named arguments sec, min, hour, mday, mon, year, isdst and returns the Unix time.
+#[nasl_function(named(sec, min, hour, mday, mon, year, isdst))]
+fn mktime(
+    sec: u32,
+    min: u32,
+    hour: u32,
+    mday: u32,
+    mon: u32,
+    year: i32,
+    isdst: Option<i32>,
+) -> Option<i64> {
     // TODO: fix isdst
-    let _isdst = match register.named("isdst") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x as i32,
-        _ => -1,
-    };
+    let _isdst = isdst.unwrap_or(-1);
 
     let offset = chrono::Local::now().offset().fix().local_minus_utc();
     let r_dt = Utc.with_ymd_and_hms(year, mon, mday, hour, min, sec);
     match r_dt {
-        LocalResult::Single(x) => Ok(NaslValue::Number(
-            x.naive_local().and_utc().timestamp() - offset as i64,
-        )),
-        _ => Ok(NaslValue::Null),
+        LocalResult::Single(x) => Some(x.naive_local().and_utc().timestamp() - offset as i64),
+        _ => None,
     }
 }
 
@@ -242,26 +176,23 @@ where
 }
 
 /// Returns an dict(mday, mon, min, wday, sec, yday, isdst, year, hour) based on optional given time in seconds and optional flag if utc or not.
-fn localtime(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let utc_flag = match register.named("utc") {
-        Some(ContextType::Value(NaslValue::Number(x))) => *x != 0,
-        Some(ContextType::Value(NaslValue::Boolean(x))) => *x,
+#[nasl_function(named(utc))]
+fn localtime(secs: Option<i64>, utc: Option<NaslValue>) -> HashMap<String, NaslValue> {
+    let utc_flag = match utc {
+        Some(NaslValue::Number(x)) => x != 0,
+        Some(NaslValue::Boolean(x)) => x,
         _ => false,
     };
 
-    let secs = match register.positional() {
-        [] => 0,
-        [x0, ..] => i64::from(x0),
-    };
-    let date = match (utc_flag, secs) {
-        (true, 0) => create_localtime_map(Utc::now()),
-        (true, secs) => match Utc.timestamp_opt(secs, 0) {
+    match (utc_flag, secs) {
+        (true, None) => create_localtime_map(Utc::now()),
+        (false, None) => create_localtime_map(Local::now()),
+        (true, Some(secs)) => match Utc.timestamp_opt(secs, 0) {
             LocalResult::Single(x) => create_localtime_map(x),
             _ => create_localtime_map(Utc::now()),
         },
-        (false, 0) => create_localtime_map(Local::now()),
 
-        (false, secs) => match DateTime::from_timestamp(secs, 0) {
+        (false, Some(secs)) => match DateTime::from_timestamp(secs, 0) {
             Some(dt) => {
                 let offset = chrono::Local::now().offset().fix();
                 let dt: DateTime<FixedOffset> = (dt + offset).into();
@@ -269,9 +200,7 @@ fn localtime(register: &Register, _: &Context) -> Result<NaslValue, FunctionErro
             }
             _ => create_localtime_map(Local::now()),
         },
-    };
-
-    Ok(NaslValue::Dict(date))
+    }
 }
 
 /// NASL function to determine if a function is defined.
@@ -295,15 +224,12 @@ fn defined_func(register: &Register, ctx: &Context) -> Result<NaslValue, Functio
 /// containing the seconds separated by a `.` followed by the microseconds.
 ///
 /// For example: “1067352015.030757” means 1067352015 seconds and 30757 microseconds.
-fn gettimeofday(_: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
+#[nasl_function]
+fn gettimeofday() -> Result<String, FunctionErrorKind> {
     match time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH) {
         Ok(time) => {
             let time = time.as_micros();
-            Ok(NaslValue::String(format!(
-                "{}.{:06}",
-                time / 1000000,
-                time % 1000000
-            )))
+            Ok(format!("{}.{:06}", time / 1000000, time % 1000000))
         }
         Err(e) => Err(FunctionErrorKind::Dirty(format!("{e}"))),
     }

--- a/rust/nasl-builtin-misc/tests/misc.rs
+++ b/rust/nasl-builtin-misc/tests/misc.rs
@@ -7,8 +7,9 @@ mod tests {
     use chrono::Offset;
 
     use nasl_interpreter::{
-        check_ok_matches,
+        check_err_matches, check_ok_matches,
         test_utils::{check_multiple, check_ok, run},
+        FunctionErrorKind,
     };
     use nasl_syntax::NaslValue;
     use std::time::Instant;
@@ -37,7 +38,10 @@ mod tests {
         check_ok(r#"typeof(make_array());"#, "array");
         check_ok(r#"typeof(NULL);"#, "undef");
         check_ok(r#"typeof(a);"#, "undef");
-        check_ok(r#"typeof(23,76);"#, "int");
+        check_err_matches!(
+            r#"typeof(23,76);"#,
+            FunctionErrorKind::TrailingPositionalArguments { .. }
+        );
         check_multiple(
             "d['test'] = 2; typeof(d);",
             vec![NaslValue::from(2), NaslValue::from("array")],

--- a/rust/nasl-builtin-misc/tests/misc.rs
+++ b/rust/nasl-builtin-misc/tests/misc.rs
@@ -7,127 +7,67 @@ mod tests {
     use chrono::Offset;
 
     use nasl_builtin_utils::Register;
-    use nasl_interpreter::{CodeInterpreter, ContextFactory};
+    use nasl_interpreter::{
+        check_ok_matches,
+        test_utils::{check_multiple, check_ok},
+        CodeInterpreter, ContextFactory,
+    };
     use nasl_syntax::NaslValue;
     use std::time::Instant;
 
     #[test]
     fn rand() {
-        let code = r###"
-        rand();
-        rand();
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        let first = parser.next();
-        let second = parser.next();
-        assert!(matches!(first, Some(Ok(NaslValue::Number(_)))));
-        assert!(matches!(second, Some(Ok(NaslValue::Number(_)))));
-        assert_ne!(first, second);
+        check_ok_matches!("rand();", NaslValue::Number(_));
+        check_ok_matches!("rand();", NaslValue::Number(_));
     }
 
     #[test]
     fn get_byte_order() {
-        let code = r###"
-        get_byte_order();
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert!(matches!(parser.next(), Some(Ok(NaslValue::Boolean(_)))));
+        check_ok_matches!("get_byte_order();", NaslValue::Boolean(_));
     }
 
     #[test]
     fn dec2str() {
-        let code = r###"
-        dec2str(num: 23);
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert_eq!(parser.next(), Some(Ok("23".into())));
+        check_ok("dec2str(num: 23);", "23");
     }
 
     #[test]
     fn nasl_typeof() {
-        let code = r#"
-        typeof("AA");
-        typeof(1);
-        typeof('AA');
-        typeof(make_array());
-        d['test'] = 2;
-        typeof(d);
-        typeof(NULL);
-        typeof(a);
-        typeof(23,76);
-        "#;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("string".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("int".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("data".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("array".into()))));
-        parser.next();
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("array".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("undef".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("undef".into()))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::String("int".into()))));
+        check_ok(r#"typeof("AA");"#, "string");
+        check_ok(r#"typeof(1);"#, "int");
+        check_ok(r#"typeof('AA');"#, "data");
+        check_ok(r#"typeof(make_array());"#, "array");
+        check_ok(r#"typeof(NULL);"#, "undef");
+        check_ok(r#"typeof(a);"#, "undef");
+        check_ok(r#"typeof(23,76);"#, "int");
+        check_multiple(
+            "d['test'] = 2; typeof(d);",
+            vec![NaslValue::from(2), NaslValue::from("array")],
+        )
     }
 
     #[test]
     fn isnull() {
-        let code = r###"
-        isnull(42);
-        isnull(Null);
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert_eq!(parser.next(), Some(Ok(NaslValue::Boolean(false))));
-        assert_eq!(parser.next(), Some(Ok(NaslValue::Boolean(true))));
+        check_ok(r#"isnull(42);"#, false);
+        check_ok(r#"isnull(Null);"#, true);
     }
 
     #[test]
     fn unixtime() {
-        let code = r###"
-        unixtime();
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert!(matches!(parser.next(), Some(Ok(NaslValue::Number(_)))));
+        check_ok_matches!(r#"unixtime();"#, NaslValue::Number(_));
     }
 
     #[test]
     fn gzip() {
-        let code = r#"
-        gzip(data: 'z', headformat: "gzip");
-        gzip(data: 'z');
-        "#;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert_eq!(
-            parser.next(),
-            Some(Ok(NaslValue::Data(
-                [31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 171, 2, 0, 175, 119, 210, 98, 1, 0, 0, 0]
-                    .into()
-            )))
+        check_ok(
+            r#"gzip(data: 'z', headformat: "gzip");"#,
+            vec![
+                31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 171, 2, 0, 175, 119, 210, 98, 1, 0, 0, 0,
+            ],
         );
-        assert_eq!(
-            parser.next(),
-            Some(Ok(NaslValue::Data(
-                [120, 156, 171, 2, 0, 0, 123, 0, 123].into()
-            )))
+        check_ok(
+            r#"gzip(data: 'z');"#,
+            vec![120, 156, 171, 2, 0, 0, 123, 0, 123],
         );
     }
 
@@ -231,45 +171,24 @@ mod tests {
 
     #[test]
     fn mktime() {
-        let code = r###"
-        mktime(sec: 01, min: 02, hour: 03, mday: 01, mon: 01, year: 1970);
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
         let offset = chrono::Local::now().offset().fix().local_minus_utc();
-        assert_eq!(
-            parser.next(),
-            Some(Ok(NaslValue::Number(10921 - offset as i64)))
+        check_ok(
+            r#"mktime(sec: 01, min: 02, hour: 03, mday: 01, mon: 01, year: 1970);"#,
+            10921 - offset,
         );
     }
 
     #[test]
     fn sleep() {
-        let code = r###"
-        sleep(1);
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
         let now = Instant::now();
-        parser.next();
+        check_ok(r#"sleep(1);"#, NaslValue::Null);
         assert!(now.elapsed().as_secs() >= 1);
     }
 
     #[test]
     fn usleep() {
-        let code = r###"
-        usleep(1000);
-        "###;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
         let now = Instant::now();
-        parser.next();
+        check_ok(r#"usleep(1000);"#, NaslValue::Null);
         assert!(now.elapsed().as_micros() >= 1000);
     }
 
@@ -283,15 +202,16 @@ mod tests {
         defined_func("a");
         defined_func(a);
         "#;
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        assert_eq!(parser.next(), Some(Ok(NaslValue::Null))); // defining function b
-        assert_eq!(parser.next(), Some(Ok(true.into()))); // is b defined
-        assert_eq!(parser.next(), Some(Ok(true.into()))); // is defined_func defined
-        assert_eq!(parser.next(), Some(Ok(12i64.into()))); // defining variable a
-        assert_eq!(parser.next(), Some(Ok(false.into()))); // is a a function
-        assert_eq!(parser.next(), Some(Ok(false.into()))); // is the value of a a function
+        check_multiple(
+            code,
+            vec![
+                NaslValue::Null, // defining function b
+                true.into(),     // is b defined
+                true.into(),     // is defined_func defined
+                12i64.into(),    // defining variable a
+                false.into(),    // is a a function
+                false.into(),    // is the value of a a function
+            ],
+        )
     }
 }

--- a/rust/nasl-builtin-std/Cargo.toml
+++ b/rust/nasl-builtin-std/Cargo.toml
@@ -14,6 +14,7 @@ nasl-builtin-host = {path = "../nasl-builtin-host"}
 nasl-builtin-http = { version = "0.1.0", path = "../nasl-builtin-http" }
 nasl-builtin-description = {path = "../nasl-builtin-description"}
 nasl-builtin-misc = {path = "../nasl-builtin-misc"}
+nasl-function-proc-macro = {path = "../nasl-function-proc-macro"}
 storage = {path = "../storage"}
 models = { path = "../models" }
 nasl-syntax = {path = "../nasl-syntax"}

--- a/rust/nasl-builtin-std/src/array.rs
+++ b/rust/nasl-builtin-std/src/array.rs
@@ -9,14 +9,10 @@
 
 use std::collections::HashMap;
 
-use nasl_builtin_utils::error::FunctionErrorKind;
-
 use nasl_builtin_utils::function::{CheckedPositionals, Positionals};
-use nasl_builtin_utils::{Context, NaslFunction, Register};
+use nasl_builtin_utils::NaslFunction;
 use nasl_function_proc_macro::nasl_function;
 use nasl_syntax::NaslValue;
-
-use nasl_builtin_utils::resolve_positional_arguments;
 
 /// NASL function to create a dictionary out of an even number of arguments
 ///
@@ -34,11 +30,9 @@ fn make_array(positionals: CheckedPositionals<NaslValue>) -> HashMap<String, Nas
     values.into()
 }
 
-/// NASL function to create a list out of a number of unnamed arguments
-fn nasl_make_list(register: &Register) -> Result<Vec<NaslValue>, FunctionErrorKind> {
-    let arr = resolve_positional_arguments(register);
+fn create_list(positionals: CheckedPositionals<NaslValue>) -> Vec<NaslValue> {
     let mut values = Vec::<NaslValue>::new();
-    for val in arr.iter() {
+    for val in positionals.iter() {
         match val {
             NaslValue::Dict(x) => values.extend(x.values().cloned().collect::<Vec<NaslValue>>()),
             NaslValue::Array(x) => values.extend(x.clone()),
@@ -46,19 +40,20 @@ fn nasl_make_list(register: &Register) -> Result<Vec<NaslValue>, FunctionErrorKi
             x => values.push(x.clone()),
         }
     }
-    Ok(values)
+    values
 }
 /// NASL function to create a list out of a number of unnamed arguments
-fn make_list(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let values = nasl_make_list(register)?;
-    Ok(NaslValue::Array(values))
+#[nasl_function]
+fn make_list(positionals: CheckedPositionals<NaslValue>) -> Vec<NaslValue> {
+    create_list(positionals)
 }
 
 /// NASL function to sorts the values of a dict/array. WARNING: drops the keys of a dict and returns an array.
-fn nasl_sort(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let mut values = nasl_make_list(register)?;
+#[nasl_function]
+fn nasl_sort(positionals: CheckedPositionals<NaslValue>) -> Vec<NaslValue> {
+    let mut values = create_list(positionals);
     values.sort();
-    Ok(NaslValue::Array(values))
+    values
 }
 
 /// Returns an array with the keys of a dict

--- a/rust/nasl-builtin-std/src/array.rs
+++ b/rust/nasl-builtin-std/src/array.rs
@@ -27,7 +27,7 @@ fn make_array(positionals: CheckedPositionals<NaslValue>) -> HashMap<String, Nas
             values.insert(positionals[idx - 1].to_string(), val.clone());
         }
     }
-    values.into()
+    values
 }
 
 fn create_list(positionals: CheckedPositionals<NaslValue>) -> Vec<NaslValue> {

--- a/rust/nasl-builtin-std/src/array.rs
+++ b/rust/nasl-builtin-std/src/array.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 
 use nasl_builtin_utils::error::FunctionErrorKind;
 
+use nasl_builtin_utils::function::{CheckedPositionals, Positionals};
 use nasl_builtin_utils::{Context, NaslFunction, Register};
 use nasl_function_proc_macro::nasl_function;
 use nasl_syntax::NaslValue;
@@ -22,15 +23,15 @@ use nasl_builtin_utils::resolve_positional_arguments;
 /// Each uneven arguments out of positional arguments are used as keys while each even even argument is used a value.
 /// When there is an uneven number of elements the last key will be dropped, as there is no corresponding value.
 /// So `make_array(1, 0, 1)` will return the same response as `make_array(1, 0)`.
-fn make_array(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = resolve_positional_arguments(register);
+#[nasl_function]
+fn make_array(positionals: CheckedPositionals<NaslValue>) -> HashMap<String, NaslValue> {
     let mut values = HashMap::new();
-    for (idx, val) in positional.iter().enumerate() {
+    for (idx, val) in positionals.iter().enumerate() {
         if idx % 2 == 1 {
-            values.insert(positional[idx - 1].to_string(), val.clone());
+            values.insert(positionals[idx - 1].to_string(), val.clone());
         }
     }
-    Ok(values.into())
+    values.into()
 }
 
 /// NASL function to create a list out of a number of unnamed arguments
@@ -62,7 +63,7 @@ fn nasl_sort(register: &Register, _: &Context) -> Result<NaslValue, FunctionErro
 
 /// Returns an array with the keys of a dict
 #[nasl_function]
-fn keys(positionals: Positionals) -> Option<Vec<NaslValue>> {
+fn keys(positionals: Positionals<NaslValue>) -> Option<Vec<NaslValue>> {
     let mut keys = vec![];
     for val in positionals.iter() {
         match val.unwrap() {

--- a/rust/nasl-builtin-std/src/array.rs
+++ b/rust/nasl-builtin-std/src/array.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use nasl_builtin_utils::error::FunctionErrorKind;
 
 use nasl_builtin_utils::{Context, NaslFunction, Register};
+use nasl_function_proc_macro::nasl_function;
 use nasl_syntax::NaslValue;
 
 use nasl_builtin_utils::resolve_positional_arguments;
@@ -60,31 +61,26 @@ fn nasl_sort(register: &Register, _: &Context) -> Result<NaslValue, FunctionErro
 }
 
 /// Returns an array with the keys of a dict
-fn keys(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = resolve_positional_arguments(register);
-    let mut keys = Vec::<NaslValue>::new();
-    for val in positional.iter() {
-        match val {
+#[nasl_function]
+fn keys(positionals: Positionals) -> Option<Vec<NaslValue>> {
+    let mut keys = vec![];
+    for val in positionals.iter() {
+        match val.unwrap() {
             NaslValue::Dict(x) => keys.extend(x.keys().map(|a| NaslValue::from(a.to_string()))),
             NaslValue::Array(x) => keys.extend((0..(x.len() as i64)).map(NaslValue::from)),
-            _ => return Ok(NaslValue::Null),
+            _ => return None,
         }
     }
-
-    Ok(NaslValue::Array(keys))
+    Some(keys)
 }
 
 /// NASL function to return the length of an array|dict.
-fn max_index(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
-    let positional = register.positional();
-    if positional.is_empty() {
-        return Ok(NaslValue::Null);
-    };
-
-    match &positional[0] {
-        NaslValue::Dict(x) => Ok(NaslValue::Number(x.len() as i64)),
-        NaslValue::Array(x) => Ok(NaslValue::Number(x.len() as i64)),
-        _ => Ok(NaslValue::Null),
+#[nasl_function]
+fn max_index(arr: &NaslValue) -> Option<usize> {
+    match arr {
+        NaslValue::Dict(x) => Some(x.len()),
+        NaslValue::Array(x) => Some(x.len()),
+        _ => None,
     }
 }
 

--- a/rust/nasl-builtin-string/src/lib.rs
+++ b/rust/nasl-builtin-string/src/lib.rs
@@ -7,7 +7,7 @@
 use core::fmt::Write;
 use glob::{MatchOptions, Pattern};
 use nasl_builtin_utils::{
-    function::{FromNaslValue, Maybe},
+    function::{CheckedPositionals, FromNaslValue, Maybe},
     Context, FunctionErrorKind, NaslFunction, Register,
 };
 use nasl_function_proc_macro::nasl_function;

--- a/rust/nasl-builtin-string/src/lib.rs
+++ b/rust/nasl-builtin-string/src/lib.rs
@@ -127,7 +127,7 @@ fn write_nasl_string(s: &mut String, value: &NaslValue) -> Result<(), FunctionEr
 fn string(positional: CheckedPositionals<&NaslValue>) -> Result<NaslValue, FunctionErrorKind> {
     let mut s = String::with_capacity(2 * positional.len());
     for p in positional {
-        write_nasl_string_value(&mut s, &p)?;
+        write_nasl_string_value(&mut s, p)?;
     }
     Ok(s.into())
 }

--- a/rust/nasl-builtin-string/tests/string.rs
+++ b/rust/nasl-builtin-string/tests/string.rs
@@ -3,48 +3,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 #[cfg(test)]
 mod tests {
-    use nasl_builtin_utils::function::ToNaslResult;
-    use nasl_interpreter::*;
+    use nasl_interpreter::{
+        test_utils::{check_multiple, check_ok},
+        *,
+    };
     use FunctionErrorKind::*;
     use NaslValue::*;
-
-    fn check_line_of_code(code: &str, f: impl Fn(Result<NaslValue, InterpretError>)) {
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let mut parser = CodeInterpreter::new(code, register, &context);
-        f(parser.next().unwrap())
-    }
-
-    fn check_err(code: &str, f: impl Fn(FunctionErrorKind) -> bool) {
-        check_line_of_code(code, |val| {
-            let val = val.unwrap_err();
-            match val.kind {
-                InterpretErrorKind::FunctionCallError(err) => {
-                    assert!(f(err.kind));
-                }
-                _ => panic!("Function did not return expected error."),
-            }
-        });
-    }
-
-    fn check_ok(code: &str, expected: impl ToNaslResult) {
-        let expected = expected.to_nasl_result().unwrap();
-        check_line_of_code(code, |val| {
-            let val = val.unwrap();
-            assert_eq!(val, expected);
-        });
-    }
-
-    fn check_multiple(code: &str, expected: Vec<NaslValue>) {
-        let register = Register::default();
-        let binding = ContextFactory::default();
-        let context = binding.build(Default::default(), Default::default());
-        let parser = CodeInterpreter::new(code, register, &context);
-        for (val, expected) in parser.zip(expected.into_iter()) {
-            assert_eq!(val, Ok(expected));
-        }
-    }
 
     #[test]
     fn hexstr() {
@@ -112,9 +76,7 @@ mod tests {
         check_ok("chomp('abc\n');", "abc");
         check_ok("chomp('abc  ');", "abc");
         check_ok("chomp('abc\n\t\r ');", "abc");
-        check_err("chomp();", |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
+        check_err_matches!("chomp();", MissingPositionalArguments { .. });
     }
 
     #[test]
@@ -156,10 +118,8 @@ mod tests {
         check_ok(r#"ord("b");"#, 98);
         check_ok(r#"ord("c");"#, 99);
         check_ok(r#"ord("");"#, Null);
-        check_err("ord(1);", |err| matches!(err, WrongArgument { .. }));
-        check_err("ord();", |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
+        check_err_matches!("ord(1);", WrongArgument { .. });
+        check_err_matches!("ord();", MissingPositionalArguments { .. });
     }
 
     #[test]
@@ -177,12 +137,8 @@ mod tests {
         // g_pattern_spec allows globs to match slashes, make sure we do too
         check_ok(r#"match(string: "a///", pattern: "a*");"#, true);
         check_ok(r#"match(string: "///a", pattern: "*a");"#, true);
-        check_err(r#"match(string: "abcd");"#, |err| {
-            matches!(err, MissingArguments { .. })
-        });
-        check_err(r#"match(pattern: "ab");"#, |err| {
-            matches!(err, MissingArguments { .. })
-        });
+        check_err_matches!(r#"match(string: "abcd");"#, MissingArguments { .. });
+        check_err_matches!(r#"match(pattern: "ab");"#, MissingArguments { .. });
     }
 
     #[test]
@@ -193,18 +149,14 @@ mod tests {
         check_ok(r#"hex(256);"#, "0x00");
         check_ok(r#"hex(257);"#, "0x01");
         check_ok(r#"hex(-2);"#, "0xfe");
-        check_err(r#"hex();"#, |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
+        check_err_matches!(r#"hex();"#, MissingPositionalArguments { .. });
     }
 
     #[test]
     fn insstr() {
         check_ok(r#"insstr("foo bar", "rab", 4);"#, "foo rab");
         check_ok(r#"insstr("foo bar", "rab", 4, 100);"#, "foo rab");
-        check_err(r#"insstr("foo bar", "rab", 4, 0);"#, |err| {
-            matches!(err, WrongArgument { .. })
-        });
+        check_err_matches!(r#"insstr("foo bar", "rab", 4, 0);"#, WrongArgument { .. });
     }
 
     #[test]
@@ -230,9 +182,7 @@ mod tests {
             r#"split("a;b;c", sep: ";");"#,
             vec!["a;".to_string(), "b;".to_string(), "c".to_string()],
         );
-        check_err(r#"split();"#, |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
+        check_err_matches!(r#"split();"#, MissingPositionalArguments { .. });
     }
 
     #[test]
@@ -241,12 +191,8 @@ mod tests {
             r#"replace(string: "abc", find: "b", replace: "foo");"#,
             "afooc",
         );
-        check_err(r#"replace();"#, |err| {
-            matches!(err, MissingArguments { .. })
-        });
-        check_err(r#"replace(string: "abc");"#, |err| {
-            matches!(err, MissingArguments { .. })
-        });
+        check_err_matches!(r#"replace();"#, MissingArguments { .. });
+        check_err_matches!(r#"replace(string: "abc");"#, MissingArguments { .. });
         check_ok(r#"replace(string: "abc", find: "b");"#, "ac");
         check_ok(r#"replace(string: "abcbd", find: "b", count: 1);"#, "acbd");
     }
@@ -255,11 +201,7 @@ mod tests {
     fn strstr() {
         check_ok(r#"strstr("abc", "b");"#, "bc");
         check_ok(r#"strstr("abcbd", "b");"#, "bcbd");
-        check_err(r#"strstr();"#, |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
-        check_err(r#"strstr("a");"#, |err| {
-            matches!(err, MissingPositionalArguments { .. })
-        });
+        check_err_matches!(r#"strstr();"#, MissingPositionalArguments { .. });
+        check_err_matches!(r#"strstr("a");"#, MissingPositionalArguments { .. });
     }
 }

--- a/rust/nasl-builtin-string/tests/string.rs
+++ b/rust/nasl-builtin-string/tests/string.rs
@@ -13,7 +13,10 @@ mod tests {
     #[test]
     fn hexstr() {
         check_ok("hexstr('foo');", "666f6f");
-        check_ok("hexstr('foo', 'I will be ignored');", "666f6f");
+        check_err_matches!(
+            "hexstr('foo', 'I will be ignored');",
+            TrailingPositionalArguments { .. }
+        );
         check_ok("hexstr(6);", Null);
         check_ok("hexstr();", Null);
         check_ok("hexstr(raw_string(10, 208, 102, 165, 210, 159, 63, 42, 42, 28, 124, 23, 221, 8, 42, 121));", "0ad066a5d29f3f2a2a1c7c17dd082a79");

--- a/rust/nasl-builtin-utils/Cargo.toml
+++ b/rust/nasl-builtin-utils/Cargo.toml
@@ -10,3 +10,7 @@ nasl-syntax = { path = "../nasl-syntax" }
 storage = { path = "../storage" }
 thiserror = "1.0.62"
 tracing = "0.1"
+
+[features]
+default = ["enforce-no-trailing-arguments"]
+enforce-no-trailing-arguments = []

--- a/rust/nasl-builtin-utils/src/context.rs
+++ b/rust/nasl-builtin-utils/src/context.rs
@@ -183,7 +183,7 @@ impl Register {
     }
 
     /// Return an iterator over the names of the named arguments.
-    pub fn iter_named_args<'a>(&'a self) -> Option<impl Iterator<Item = &str>> {
+    pub fn iter_named_args(&self) -> Option<impl Iterator<Item = &str>> {
         self.blocks
             .last()
             .map(|x| x.defined.keys().map(|x| x.as_str()))

--- a/rust/nasl-builtin-utils/src/context.rs
+++ b/rust/nasl-builtin-utils/src/context.rs
@@ -182,6 +182,13 @@ impl Register {
         self.blocks.last().and_then(|x| x.named(self, name))
     }
 
+    /// Return an iterator over the names of the named arguments.
+    pub fn iter_named_args<'a>(&'a self) -> Option<impl Iterator<Item = &str>> {
+        self.blocks
+            .last()
+            .map(|x| x.defined.keys().map(|x| x.as_str()))
+    }
+
     /// Adds a named parameter to the root context
     pub fn add_global(&mut self, name: &str, value: ContextType) {
         let global = &mut self.blocks[0];

--- a/rust/nasl-builtin-utils/src/error.rs
+++ b/rust/nasl-builtin-utils/src/error.rs
@@ -25,9 +25,20 @@ pub enum FunctionErrorKind {
         /// Actual amount of arguments
         got: usize,
     },
+    /// Function called with trailing positional arguments
+    #[error("Expected {expected} but got {got}")]
+    TrailingPositionalArguments {
+        /// Expected amount of arguments
+        expected: usize,
+        /// Actual amount of arguments
+        got: usize,
+    },
     /// Function called without required named arguments
     #[error("Missing arguments: {}", .0.join(", "))]
     MissingArguments(Vec<String>),
+    /// Function called with additional, unexpected named arguments
+    #[error("Unknown named argument given to function: {}", .0)]
+    UnexpectedArgument(String),
     /// Wraps formatting error
     #[error("Formatting error: {0}")]
     FMTError(#[from] std::fmt::Error),

--- a/rust/nasl-builtin-utils/src/function/maybe.rs
+++ b/rust/nasl-builtin-utils/src/function/maybe.rs
@@ -8,6 +8,7 @@ use super::FromNaslValue;
 /// of a particular type, but it being of a different type
 /// will be handled by ignoring the value (and probably returning
 /// `None` or some sentinel value), instead of producing an error.
+#[derive(Debug)]
 pub struct Maybe<T>(Option<T>);
 
 impl<'a, T: FromNaslValue<'a>> FromNaslValue<'a> for Maybe<T> {

--- a/rust/nasl-builtin-utils/src/function/positionals.rs
+++ b/rust/nasl-builtin-utils/src/function/positionals.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Index};
 
 use crate::{FunctionErrorKind, Register};
 
@@ -81,5 +81,13 @@ impl<'a, T: FromNaslValue<'a>> IntoIterator for CheckedPositionals<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.data.into_iter()
+    }
+}
+
+impl<T> Index<usize> for CheckedPositionals<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index]
     }
 }

--- a/rust/nasl-builtin-utils/src/function/to_nasl_result.rs
+++ b/rust/nasl-builtin-utils/src/function/to_nasl_result.rs
@@ -83,8 +83,13 @@ impl ToNaslResult for Vec<String> {
     }
 }
 
-impl<T: ToNaslResult> ToNaslResult for HashMap<String, T>
-{
+impl ToNaslResult for Vec<NaslValue> {
+    fn to_nasl_result(self) -> NaslResult {
+        Ok(NaslValue::Array(self))
+    }
+}
+
+impl<T: ToNaslResult> ToNaslResult for HashMap<String, T> {
     fn to_nasl_result(self) -> NaslResult {
         Ok(NaslValue::Dict(
             self.into_iter()
@@ -99,7 +104,6 @@ impl ToNaslResult for bool {
         Ok(NaslValue::Boolean(self))
     }
 }
-
 
 macro_rules! impl_to_nasl_result_for_numeric_type {
     ($ty: ty) => {

--- a/rust/nasl-builtin-utils/src/function/to_nasl_result.rs
+++ b/rust/nasl-builtin-utils/src/function/to_nasl_result.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use nasl_syntax::NaslValue;
 
 use crate::{FunctionErrorKind, NaslResult};
@@ -81,11 +83,23 @@ impl ToNaslResult for Vec<String> {
     }
 }
 
+impl<T: ToNaslResult> ToNaslResult for HashMap<String, T>
+{
+    fn to_nasl_result(self) -> NaslResult {
+        Ok(NaslValue::Dict(
+            self.into_iter()
+                .map(|(key, s)| s.to_nasl_result().map(|res| (key, res)))
+                .collect::<Result<HashMap<_, _>, FunctionErrorKind>>()?,
+        ))
+    }
+}
+
 impl ToNaslResult for bool {
     fn to_nasl_result(self) -> NaslResult {
         Ok(NaslValue::Boolean(self))
     }
 }
+
 
 macro_rules! impl_to_nasl_result_for_numeric_type {
     ($ty: ty) => {

--- a/rust/nasl-builtin-utils/src/function/utils.rs
+++ b/rust/nasl-builtin-utils/src/function/utils.rs
@@ -1,6 +1,7 @@
 //! Convenience functions, used internally in the `NaslFunctionArg` macro.
 
 use crate::function::FromNaslValue;
+use crate::lookup_keys::FC_ANON_ARGS;
 use crate::{ContextType, FunctionErrorKind, Register};
 use nasl_syntax::NaslValue;
 
@@ -102,4 +103,54 @@ pub fn get_maybe_named_arg<'a, T: FromNaslValue<'a>>(
     } else {
         get_named_arg(register, name)
     }
+}
+
+/// Check that named and maybe_named arguments account for
+/// all given named arguments (i.e. no additional, unknown
+/// arguments exist).
+/// Return the number of maybe named arguments that were given
+/// as a named argument.
+fn check_named_args(
+    register: &Register,
+    named: &[&str],
+    maybe_named: &[&str],
+) -> Result<usize, FunctionErrorKind> {
+    let mut num_maybe_named = 0;
+    for arg_name in register.iter_named_args().unwrap() {
+        if arg_name == FC_ANON_ARGS {
+            continue;
+        } else {
+            if named.contains(&arg_name) {
+                continue;
+            } else if maybe_named.contains(&arg_name) {
+                num_maybe_named += 1;
+            } else {
+                return Err(FunctionErrorKind::UnexpectedArgument(arg_name.into()));
+            }
+        }
+    }
+    Ok(num_maybe_named)
+}
+
+/// Check that the number of expected positional arguments given to a
+/// NASL function matches the actual number given, and that all given
+/// named arguments exist.
+pub fn check_args(
+    register: &Register,
+    named: &[&str],
+    maybe_named: &[&str],
+    max_num_expected_positional: Option<usize>,
+) -> Result<(), FunctionErrorKind> {
+    let num_maybe_named_given = check_named_args(register, named, maybe_named)?;
+    let num_positional_given = register.positional().len();
+    if let Some(max_num_expected_positional) = max_num_expected_positional {
+        let num_positional_expected = max_num_expected_positional - num_maybe_named_given;
+        if num_positional_given > num_positional_expected {
+            return Err(FunctionErrorKind::TrailingPositionalArguments {
+                expected: num_positional_expected,
+                got: num_positional_given,
+            });
+        }
+    }
+    Ok(())
 }

--- a/rust/nasl-builtin-utils/src/function/utils.rs
+++ b/rust/nasl-builtin-utils/src/function/utils.rs
@@ -112,21 +112,23 @@ pub fn get_maybe_named_arg<'a, T: FromNaslValue<'a>>(
 /// as a named argument.
 fn check_named_args(
     register: &Register,
+    _nasl_fn_name: &str,
     named: &[&str],
     maybe_named: &[&str],
 ) -> Result<usize, FunctionErrorKind> {
     let mut num_maybe_named = 0;
     for arg_name in register.iter_named_args().unwrap() {
-        if arg_name == FC_ANON_ARGS {
+        if arg_name == FC_ANON_ARGS || named.contains(&arg_name) {
             continue;
+        } else if maybe_named.contains(&arg_name) {
+            num_maybe_named += 1;
         } else {
-            if named.contains(&arg_name) {
-                continue;
-            } else if maybe_named.contains(&arg_name) {
-                num_maybe_named += 1;
-            } else {
-                return Err(FunctionErrorKind::UnexpectedArgument(arg_name.into()));
-            }
+            #[cfg(feature = "enforce-no-trailing-arguments")]
+            return Err(FunctionErrorKind::UnexpectedArgument(arg_name.into()));
+            #[cfg(not(feature = "enforce-no-trailing-arguments"))]
+            tracing::debug!(
+                "Unexpected named argument '{arg_name}' in NASL function {_nasl_fn_name}."
+            );
         }
     }
     Ok(num_maybe_named)
@@ -137,19 +139,25 @@ fn check_named_args(
 /// named arguments exist.
 pub fn check_args(
     register: &Register,
+    _nasl_fn_name: &str,
     named: &[&str],
     maybe_named: &[&str],
     max_num_expected_positional: Option<usize>,
 ) -> Result<(), FunctionErrorKind> {
-    let num_maybe_named_given = check_named_args(register, named, maybe_named)?;
+    let num_maybe_named_given = check_named_args(register, _nasl_fn_name, named, maybe_named)?;
     let num_positional_given = register.positional().len();
     if let Some(max_num_expected_positional) = max_num_expected_positional {
         let num_positional_expected = max_num_expected_positional - num_maybe_named_given;
         if num_positional_given > num_positional_expected {
+            #[cfg(feature = "enforce-no-trailing-arguments")]
             return Err(FunctionErrorKind::TrailingPositionalArguments {
                 expected: num_positional_expected,
                 got: num_positional_given,
             });
+            #[cfg(not(feature = "enforce-no-trailing-arguments"))]
+            tracing::debug!(
+                "Trailing positional arguments in NASL function {_nasl_fn_name}. Expected {num_positional_expected}, found {num_positional_given}"
+            );
         }
     }
     Ok(())

--- a/rust/nasl-function-proc-macro/src/codegen.rs
+++ b/rust/nasl-function-proc-macro/src/codegen.rs
@@ -21,24 +21,25 @@ impl<'a> ArgsStruct<'a> {
                 let num_required_positional_args = self.num_required_positional();
                 let ident = &arg.ident;
                 let mutability = if arg.mutable { quote! { mut } } else { quote ! {}};
+                let inner_ty = &arg.inner_ty;
                 let ty = &arg.ty;
-                let parse = match &arg.kind {
+                let expr = match &arg.kind {
                     ArgKind::Positional(positional) => {
                         let position = positional.position;
                             if arg.optional {
-                                quote! { ::nasl_builtin_utils::function::utils::get_optional_positional_arg::<#ty>(_register, #position)? }
+                                quote! { ::nasl_builtin_utils::function::utils::get_optional_positional_arg::<#inner_ty>(_register, #position)? }
                             }
                             else {
-                                quote! { ::nasl_builtin_utils::function::utils::get_positional_arg::<#ty>(_register, #position, #num_required_positional_args)? }
+                                quote! { ::nasl_builtin_utils::function::utils::get_positional_arg::<#inner_ty>(_register, #position, #num_required_positional_args)? }
                             }
                     }
                     ArgKind::Named(named) => {
                         let name = &named.name;
                         if arg.optional {
-                            quote! { ::nasl_builtin_utils::function::utils::get_optional_named_arg::<#ty>(_register, #name)? }
+                            quote! { ::nasl_builtin_utils::function::utils::get_optional_named_arg::<#inner_ty>(_register, #name)? }
                         }
                         else {
-                            quote! { ::nasl_builtin_utils::function::utils::get_named_arg::<#ty>(_register, #name)? }
+                            quote! { ::nasl_builtin_utils::function::utils::get_named_arg::<#inner_ty>(_register, #name)? }
                         }
                     }
                     ArgKind::MaybeNamed(positional, named) => {
@@ -46,12 +47,12 @@ impl<'a> ArgsStruct<'a> {
                         let position = positional.position;
                         if arg.optional {
                             quote! {
-                                ::nasl_builtin_utils::function::utils::get_optional_maybe_named_arg::<#ty>(_register, #name, #position)?
+                                ::nasl_builtin_utils::function::utils::get_optional_maybe_named_arg::<#inner_ty>(_register, #name, #position)?
                             }
                         }
                         else {
                             quote! {
-                                ::nasl_builtin_utils::function::utils::get_maybe_named_arg::<#ty>(_register, #name, #position)?
+                                ::nasl_builtin_utils::function::utils::get_maybe_named_arg::<#inner_ty>(_register, #name, #position)?
                             }
                         }
                     }
@@ -77,7 +78,7 @@ impl<'a> ArgsStruct<'a> {
                     }
                 };
                 quote! {
-                    let #mutability #ident = #parse;
+                    let #mutability #ident: #ty = #expr;
                 }
             })
             .collect()

--- a/rust/nasl-function-proc-macro/src/codegen.rs
+++ b/rust/nasl-function-proc-macro/src/codegen.rs
@@ -121,8 +121,9 @@ impl<'a> ArgsStruct<'a> {
             let num = self.max_num_allowed_positional();
             quote! { Some(#num) }
         };
+        let fn_name = self.function.sig.ident.to_string();
         quote! {
-            ::nasl_builtin_utils::function::utils::check_args(_register, #named_array, #maybe_named_array, #num_allowed_positional_args)?;
+            ::nasl_builtin_utils::function::utils::check_args(_register, #fn_name, #named_array, #maybe_named_array, #num_allowed_positional_args)?;
         }
     }
 

--- a/rust/nasl-function-proc-macro/src/codegen.rs
+++ b/rust/nasl-function-proc-macro/src/codegen.rs
@@ -60,6 +60,11 @@ impl<'a> ArgsStruct<'a> {
                             _context
                         }
                     },
+                    ArgKind::Register => {
+                        quote! {
+                            _register
+                        }
+                    },
                     ArgKind::PositionalIterator => {
                         quote! {
                             ::nasl_builtin_utils::function::Positionals::new(_register)

--- a/rust/nasl-function-proc-macro/src/parse.rs
+++ b/rust/nasl-function-proc-macro/src/parse.rs
@@ -93,19 +93,20 @@ impl Parse for Attrs {
 
 impl<'a> Arg<'a> {
     fn new(arg: &'a FnArg, attrs: &Attrs, position: usize) -> Result<Self> {
-        let (ident, ty, mutable, optional) = get_arg_info(arg)?;
+        let (ident, ty, inner_ty, mutable, optional) = get_arg_info(arg)?;
         let kind = attrs.get_arg_kind(ident, position, ty);
         Ok(Self {
             kind,
             ident,
             ty,
+            inner_ty,
             optional,
             mutable,
         })
     }
 }
 
-fn get_arg_info(arg: &FnArg) -> Result<(&Ident, &Type, bool, bool)> {
+fn get_arg_info(arg: &FnArg) -> Result<(&Ident, &Type, &Type, bool, bool)> {
     match arg {
         FnArg::Receiver(_) => unreachable!(),
         FnArg::Typed(typed) => {
@@ -119,12 +120,12 @@ fn get_arg_info(arg: &FnArg) -> Result<(&Ident, &Type, bool, bool)> {
                 }
             };
             let ty = &typed.ty;
-            let (optional, ty) = if let Some(ty) = get_subty_if_name_is(ty, "Option") {
+            let (optional, inner_ty) = if let Some(ty) = get_subty_if_name_is(ty, "Option") {
                 (true, ty)
             } else {
                 (false, ty.as_ref())
             };
-            Ok((ident, ty, mutable, optional))
+            Ok((ident, ty, inner_ty, mutable, optional))
         }
     }
 }

--- a/rust/nasl-function-proc-macro/src/parse.rs
+++ b/rust/nasl-function-proc-macro/src/parse.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::types::*;
-use crate::utils::{get_subty_if_name_is, ty_is_context, ty_name_is};
+use crate::utils::{get_subty_if_name_is, ty_is_context, ty_is_register, ty_name_is};
 use syn::{
     parenthesized, parse::Parse, punctuated::Punctuated, spanned::Spanned, FnArg, Ident, ItemFn,
     Token, Type,
@@ -40,6 +40,9 @@ impl Attrs {
     fn get_arg_kind(&self, ident: &Ident, position: usize, ty: &Type) -> ArgKind {
         if ty_is_context(ty) {
             return ArgKind::Context;
+        }
+        if ty_is_register(ty) {
+            return ArgKind::Register;
         }
         if ty_name_is(ty, "Positionals") {
             return ArgKind::PositionalIterator;

--- a/rust/nasl-function-proc-macro/src/types.rs
+++ b/rust/nasl-function-proc-macro/src/types.rs
@@ -28,6 +28,7 @@ pub enum ReceiverType {
 pub struct Arg<'a> {
     pub ident: &'a Ident,
     pub ty: &'a Type,
+    pub inner_ty: &'a Type,
     pub optional: bool,
     pub kind: ArgKind,
     pub mutable: bool,

--- a/rust/nasl-function-proc-macro/src/types.rs
+++ b/rust/nasl-function-proc-macro/src/types.rs
@@ -44,6 +44,24 @@ pub enum ArgKind {
     CheckedPositionalIterator,
 }
 
+impl ArgKind {
+    pub fn get_named_arg_name(&self) -> Option<&str> {
+        if let Self::Named(name) = self {
+            Some(&name.name)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_maybe_named_arg_name(&self) -> Option<&str> {
+        if let Self::MaybeNamed(_, name) = self {
+            Some(&name.name)
+        } else {
+            None
+        }
+    }
+}
+
 pub struct NamedArg {
     pub name: String,
 }

--- a/rust/nasl-function-proc-macro/src/types.rs
+++ b/rust/nasl-function-proc-macro/src/types.rs
@@ -38,6 +38,7 @@ pub enum ArgKind {
     Named(NamedArg),
     MaybeNamed(PositionalArg, NamedArg),
     Context,
+    Register,
     PositionalIterator,
     CheckedPositionalIterator,
 }

--- a/rust/nasl-function-proc-macro/src/utils.rs
+++ b/rust/nasl-function-proc-macro/src/utils.rs
@@ -14,6 +14,14 @@ pub fn ty_is_context(ty: &Type) -> bool {
     }
 }
 
+pub fn ty_is_register(ty: &Type) -> bool {
+    if let Type::Reference(TypeReference { elem, .. }) = ty {
+        ty_name_is(elem, "Register")
+    } else {
+        false
+    }
+}
+
 pub fn get_subty_if_name_is<'a>(ty: &'a Type, name: &str) -> Option<&'a Type> {
     get_last_segment(ty)
         .filter(|segment| segment.ident == name)

--- a/rust/nasl-interpreter/src/lib.rs
+++ b/rust/nasl-interpreter/src/lib.rs
@@ -18,6 +18,8 @@ mod operator;
 mod scan_interpreter;
 pub mod scheduling;
 
+pub mod test_utils;
+
 pub use error::FunctionError;
 pub use error::InterpretError;
 pub use error::InterpretErrorKind;

--- a/rust/nasl-interpreter/src/test_utils.rs
+++ b/rust/nasl-interpreter/src/test_utils.rs
@@ -1,0 +1,71 @@
+//! Utilities to test the outcome of NASL functions
+
+use crate::*;
+use nasl_builtin_utils::function::ToNaslResult;
+
+/// Check that a single line of code fulfills some property by running
+/// a check function on the result.
+pub fn check_line_of_code(code: &str, f: impl Fn(Result<NaslValue, InterpretError>)) {
+    let register = Register::default();
+    let binding = ContextFactory::default();
+    let context = binding.build(Default::default(), Default::default());
+    let mut parser = CodeInterpreter::new(code, register, &context);
+    f(parser.next().unwrap())
+}
+
+/// Check that the returned error from a line of NASL code fulfills a given
+/// property
+pub fn check_err(code: &str, f: impl Fn(&FunctionErrorKind) -> bool) {
+    check_line_of_code(code, |val| {
+        let val = val.unwrap_err();
+        match val.kind {
+            InterpretErrorKind::FunctionCallError(err) => {
+                assert!(f(&err.kind), "Found {}", &err.kind);
+            }
+            _ => panic!("Function did not return expected error."),
+        }
+    });
+}
+
+/// Check that the value returned from a line of NASL code is
+/// Ok(...) and that the inner value is equal to the expected
+/// value.
+pub fn check_ok(code: &str, expected: impl ToNaslResult) {
+    let expected = expected.to_nasl_result().unwrap();
+    check_line_of_code(code, |val| {
+        let val = val.unwrap();
+        assert_eq!(val, expected);
+    });
+}
+
+/// Check that the expected value of multiple lines of NASL code
+/// matches the given values.
+pub fn check_multiple(code: &str, expected: Vec<impl ToNaslResult>) {
+    let register = Register::default();
+    let binding = ContextFactory::default();
+    let context = binding.build(Default::default(), Default::default());
+    let parser = CodeInterpreter::new(code, register, &context);
+    for (val, expected) in parser.zip(expected.into_iter()) {
+        assert_eq!(val, Ok(expected.to_nasl_result().unwrap()));
+    }
+}
+
+/// Check that the line of NASL code returns an Err variant
+/// and that the inner error matches a pattern.
+#[macro_export]
+macro_rules! check_err_matches {
+    ($code: literal, $pat: pat) => {
+        ::nasl_interpreter::test_utils::check_err($code, |e| matches!(e, $pat));
+    };
+}
+
+/// Check that the line of NASL code returns an Ok variant
+/// and that the inner value matches a pattern.
+#[macro_export]
+macro_rules! check_ok_matches {
+    ($code: literal, $pat: pat) => {
+        ::nasl_interpreter::test_utils::check_line_of_code($code, |res| {
+            assert!(matches!(res, Ok($pat)));
+        });
+    };
+}


### PR DESCRIPTION
- Refactor the`nasl-builtins-misc` crate using the changes in #1682.
- Adds some convenience to the proc macro
- Adds proper checking of the arguments passed into nasl functions. The check behaves either as a proper error (for testing) or a `debug!(...)` log message (to allow older scanner versions to run new versions of the feed in which arguments to builtin methods may have changed). This behavior is toggled by the `enforce-no-trailing-arguments` feature gate on `nasl_builtin_utils`.
- Adds some shared test utilities for NASL function tests.

Jira: SC-1123