### PR TITLE
Fix: notus deb package parsing

### DIFF
--- a/rust/notus/src/packages/deb.rs
+++ b/rust/notus/src/packages/deb.rs
@@ -6,10 +6,14 @@ use super::{Package, PackageVersion};
 use lazy_regex::{lazy_regex, Lazy, Regex};
 use std::cmp::Ordering;
 
-static RE: Lazy<Regex> = lazy_regex!(r"(.*)-(?:(\d*):)?(\d.*)-(.*)");
-static RE_WO_REVISION: Lazy<Regex> = lazy_regex!(r"(.*)-(?:(\d*):)?(\d.*)");
-static RE_VERSION: Lazy<Regex> = lazy_regex!(r"(?:(\d*):)?(\d.*)-(.*)");
-static RE_VERSION_WO_REVISION: Lazy<Regex> = lazy_regex!(r"(?:(\d*):)?(\d.*)");
+static RE: Lazy<Regex> = lazy_regex!(
+    r"^([a-z0-9](?:[a-z0-9+\-.])*)-(?:(\d*):)?(\d[[:alnum:]+\-.~]*)(?:-([[:alnum:]+\-.~]*))$"
+);
+static RE_WO_REVISION: Lazy<Regex> =
+    lazy_regex!(r"^([a-z0-9](?:[a-z0-9+\-.])*)-(?:(\d*):)?(\d[[:alnum:]+\-.~]*)$");
+static RE_VERSION: Lazy<Regex> =
+    lazy_regex!(r"^(?:(\d*):)?(\d[[:alnum:]+\-.~]*)(?:-([[:alnum:]+\-.~]*))$");
+static RE_VERSION_WO_REVISION: Lazy<Regex> = lazy_regex!(r"^(?:(\d*):)?(\d[[:alnum:]+\-.~]*)$");
 
 /// Represent a based Redhat package
 #[derive(Debug, PartialEq, Clone)]
@@ -366,6 +370,19 @@ mod deb_tests {
         assert_eq!(package.upstream_version, PackageVersion("020".to_string()));
         assert_eq!(package.debian_revision, PackageVersion("".to_string()));
         assert_eq!(package.full_name, "apport-symptoms-020");
+
+        let package = Deb::from_full_name("mariadb-server-10.6-1:10.6.18+maria~ubu2204").unwrap();
+        assert_eq!(package.name, "mariadb-server-10.6");
+        assert_eq!(package.epoch, 1);
+        assert_eq!(
+            package.upstream_version,
+            PackageVersion("10.6.18+maria~ubu2204".to_string())
+        );
+        assert_eq!(package.debian_revision, PackageVersion("".to_string()));
+        assert_eq!(
+            package.full_name,
+            "mariadb-server-10.6-1:10.6.18+maria~ubu2204"
+        );
     }
     #[test]
     pub fn from_name_and_full_version() {


### PR DESCRIPTION
The parsing inside notus scanner was done wrong in some cases, as the following example shows. Here a package with full name including the version of the installed package:
```
mariadb-server-10.6-1:10.6.18+maria~ubu2204
```
which should separate name and version into:
```
name: mariadb-server-10.6
version: 1:10.6.18+maria~ubu2204
```
but resulted in:
```
name: mariadb-server
version: 10.6-1:10.6.18+maria~ubu2204
```
which is not even a valid version at all.
Updating the regular expressions fixes this issue.
This issue came up in https://forum.greenbone.net/t/ubuntu-22-04-lts-mariadb-server-false-positive/18779
SC-1121