### PR TITLE
Doc: Extend regex info in documentation

### DIFF
--- a/doc/manual/nasl/built-in-functions/regular-expressions/index.md
+++ b/doc/manual/nasl/built-in-functions/regular-expressions/index.md
@@ -8,6 +8,14 @@ Functions in this family will work with such regular expressions to find or repl
 
 All the regex functions work the same way. If you want to match from the beginning / end of your string (or your line, in the case of egrep), you’ll have to use ^ or $. You should read your (POSIX) system manual for details on regular expressions.
 
+All NASL internal regex related functions like `ereg()`, `eregmatch()`, `egrep()`, `ereg_replace()`, `=~` and `!~` are currently supporting the standard [POSIX Extended Regular Expressions (ERE)](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions) syntax only ([full overview](https://remram44.github.io/regex-cheatsheet/regex.html)). Examples:
+
+- `\s` = Match a whitespace character (except newline)
+- `[[:digit:]]` = Match a digit character
+- `\w` = Match a "word" character (alphanumeric plus `_`)
+
+It does **NOT** support Perl Compatible Regular Expressions (PCRE) like `\d`.
+
 ## TABLE OF CONTENT
 
 - **[egrep](egrep.md)** - looks for a patter in a string line by line and concatenates all lines the string was found

--- a/doc/manual/nasl/nasl-grammar/index.md
+++ b/doc/manual/nasl/nasl-grammar/index.md
@@ -117,7 +117,7 @@ NASL imported some operators from C:
   `s =~ "[ab]*x+"` is equivalent to `ereg(string:s, pattern:"[ab]*x+", icase:1)`
 - `!~` is the “regex don’t match” operator. It gives the opposite result of the previous one.
 
-Note: =~ and !~ supports the (standard extended POSIX) regex pattern. See Supported regex expression syntax for NASL Functions for more background info on the supported regex expression support.
+Note: `=~` and `!~` supports the (standard extended POSIX) regex pattern. See [Regular Expression Functions](../built-in-functions/regular-expressions/index.md) for more background info on the supported regex expression support.
 
 ### Compare Operators
 
@@ -199,7 +199,7 @@ In all shift operators, the count is on the right, i.e., `x>>2` is equivalent to
 
 ## Declarations
 
-###Variable Declarations
+### Variable Declarations
 
 NASL uses global and local variables. Local variables are created in a function and stop existing as soon as the function returns. When the interpreter looks for a variable, it first searches in the current function context, then in the calling context (if any) etc., until it reaches the top level context that contains the global variables.
 
@@ -277,5 +277,3 @@ function fact(prompt)
 }
 n = fact(3, prompt: ’> ’);
 ```
-
-


### PR DESCRIPTION
**What**:
This is information which had been provided / collected in Confluence in the past (IIRC based on feedback from @jjnicola) but it seems it got lost during the migration of the documentation to Github (only available on an attic page in Confluence, please DM me for a full link if you would like to do a verification).

**Why**:
Extended documentation

**How**:
N/A

**Checklist**:

- [ ] Tests N/A
- [x] PR merge commit message adjusted
