### PR TITLE
Fix line/col display in scannerctl/CliError.

### DIFF
--- a/rust/scannerctl/src/error.rs
+++ b/rust/scannerctl/src/error.rs
@@ -79,7 +79,7 @@ impl Display for CliError {
             self.filename,
             self.kind
                 .as_token()
-                .map(|x| { format!(", line: {}, col: {}", x.position.0, x.position.1) })
+                .map(|x| { format!(", line: {}, col: {}", x.line_column.0, x.line_column.1) })
                 .unwrap_or_default(),
             self.kind
         )


### PR DESCRIPTION
Jira: SC-1126

Fixes scannerctl displaying wrong line /column numbers on errors.

Example `test.nasl`
```
display("hello world");
foo();
```


Before:
```
> scannerctl execute script test.nasl
2024-08-05T10:29:27.253212Z  WARN scannerctl: script error, test.nasl, line: 45, col: 48: foo();: Key not found: foo
```

After: 
```
> scannerctl execute script test.nasl
2024-08-05T10:30:53.401412Z  WARN scannerctl: script error, test.nasl, line: 2, col: 1: foo();: Key not found: foo
```