### PR TITLE
Fix: update feed_version field in response after a feed update

### DIFF
--- a/rust/feed/src/update/mod.rs
+++ b/rust/feed/src/update/mod.rs
@@ -109,7 +109,6 @@ where
 
     /// Check if the current feed is outdated.
     pub fn feed_is_outdated(&self, current_version: String) -> Result<bool, ErrorKind> {
-        self.verify_signature()?;
         // the version in file
         let v = self.feed_version()?;
         if !current_version.is_empty() {

--- a/rust/openvasd/src/controller/context.rs
+++ b/rust/openvasd/src/controller/context.rs
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::sync::RwLock;
-
 use async_trait::async_trait;
+use std::sync::{Arc, RwLock};
 use storage::DefaultDispatcher;
 
 use crate::{config, notus::NotusWrapper, response, scheduling, tls::TlsConfig};
@@ -205,6 +204,8 @@ impl<S, DB> ContextBuilder<S, DB, Scanner<S>> {
             self.scanner.0,
             self.storage,
         );
+        let shared_feed = Arc::clone(&scheduler.feed_version());
+        self.response.add_feed_version(shared_feed);
         Context {
             response: self.response,
             scheduler,

--- a/rust/openvasd/src/storage/file.rs
+++ b/rust/openvasd/src/storage/file.rs
@@ -543,6 +543,11 @@ where
     async fn feed_hash(&self) -> Vec<FeedHash> {
         self.hash.read().await.to_vec()
     }
+
+    async fn current_feed_version(&self) -> Result<String, Error> {
+        let v = self.feed_version.read().unwrap().clone();
+        Ok(v)
+    }
 }
 
 #[cfg(test)]

--- a/rust/openvasd/src/storage/inmemory.rs
+++ b/rust/openvasd/src/storage/inmemory.rs
@@ -425,6 +425,11 @@ where
     async fn feed_hash(&self) -> Vec<FeedHash> {
         self.hash.read().await.to_vec()
     }
+
+    async fn current_feed_version(&self) -> Result<String, Error> {
+        let v = self.feed_version.read().await.clone();
+        Ok(v)
+    }
 }
 
 #[cfg(test)]

--- a/rust/openvasd/src/storage/mod.rs
+++ b/rust/openvasd/src/storage/mod.rs
@@ -188,9 +188,7 @@ pub trait NVTStorer {
     async fn feed_hash(&self) -> Vec<FeedHash>;
 
     /// Returns the current feed version, if any.
-    async fn current_feed_version(&self) -> Result<String, Error> {
-        Ok("".to_string())
-    }
+    async fn current_feed_version(&self) -> Result<String, Error>;
 }
 
 #[async_trait]


### PR DESCRIPTION
**What**:
Update feed_version response's field after feed update 
SC-1128

Thanks @nichtsfrei for the hint.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
