### PR TITLE
Fix: CMake. Use pkg-config instead of the dropped libgcrypt-config

### DIFF
--- a/nasl/CMakeLists.txt
+++ b/nasl/CMakeLists.txt
@@ -84,26 +84,7 @@ if (NETSNMP)
 endif (NETSNMP)
 
 message (STATUS "Looking for libgcrypt...")
-find_library (GCRYPT gcrypt)
-message (STATUS "Looking for libgcrypt... ${GCRYPT}")
-if (NOT GCRYPT)
-  message (SEND_ERROR "The libgcrypt library is required.")
-else (NOT GCRYPT)
-  execute_process (COMMAND libgcrypt-config --libs
-    OUTPUT_VARIABLE GCRYPT_LDFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND libgcrypt-config --cflags
-    OUTPUT_VARIABLE GCRYPT_CFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND libgcrypt-config --version
-    OUTPUT_VARIABLE GCRYPT_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  message (STATUS "  found libgcrypt, version ${GCRYPT_VERSION}")
-  if (GCRYPT_VERSION VERSION_LESS "1.6")
-    message (SEND_ERROR "libgcrypt 1.6 or greater is required")
-  endif (GCRYPT_VERSION VERSION_LESS "1.6")
-  string(REPLACE "-I" "" GCRYPT_INCLUDE_DIRS "${GCRYPT_CFLAGS}")
-endif (NOT GCRYPT)
+pkg_check_modules (GCRYPT REQUIRED libgcrypt)
 
 
 ## Library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,26 +19,7 @@ pkg_check_modules (GLIB REQUIRED glib-2.0>=2.42)
 pkg_check_modules (LIBBSD REQUIRED libbsd)
 
 message (STATUS "Looking for libgcrypt...")
-find_library (GCRYPT gcrypt)
-if (NOT GCRYPT)
-  message (SEND_ERROR "The libgcrypt library is required.")
-else (NOT GCRYPT)
-  message (STATUS "Looking for libgcrypt... ${GCRYPT}")
-  execute_process (COMMAND libgcrypt-config --libs
-    OUTPUT_VARIABLE GCRYPT_LDFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND libgcrypt-config --cflags
-    OUTPUT_VARIABLE GCRYPT_CFLAGS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process (COMMAND libgcrypt-config --version
-    OUTPUT_VARIABLE GCRYPT_VERSION
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  message (STATUS "  found libgcrypt, version ${GCRYPT_VERSION}")
-  if (GCRYPT_VERSION VERSION_LESS "1.6")
-    message (SEND_ERROR "libgcrypt 1.6 or greater is required")
-  endif (GCRYPT_VERSION VERSION_LESS "1.6")
-  string(REPLACE "-I" "" GCRYPT_INCLUDE_DIRS "${GCRYPT_CFLAGS}")
-endif (NOT GCRYPT)
+pkg_check_modules (GCRYPT REQUIRED libgcrypt)
 
 message (STATUS "Looking for pcap...")
 find_library (PCAP pcap)


### PR DESCRIPTION
**What**:
Fix: CMake. Use pkg-config instead of the dropped libgcrypt-config
Closes #1681
Jira: SC-1113

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
libgcrypt-config has been dropped
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
