### PR TITLE
Use nasl function macro for builtin socket functions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -818,6 +818,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2 0.5.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +2044,7 @@ dependencies = [
 name = "nasl-builtin-network"
 version = "0.1.0"
 dependencies = [
+ "dns-lookup",
  "libc",
  "nasl-builtin-utils",
  "nasl-function-proc-macro",

--- a/rust/nasl-builtin-network/Cargo.toml
+++ b/rust/nasl-builtin-network/Cargo.toml
@@ -11,6 +11,7 @@ nasl-function-proc-macro = { path = "../nasl-function-proc-macro" }
 nasl-syntax = { path = "../nasl-syntax" }
 storage = { path = "../storage" }
 
+dns-lookup = "2.0"
 libc = "0.2"
 rustls = "0.23.5"
 rustls-pemfile = "2.1"

--- a/rust/nasl-builtin-network/src/lib.rs
+++ b/rust/nasl-builtin-network/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::Display;
 
-use nasl_builtin_utils::{Context, FunctionErrorKind, Register};
+use nasl_builtin_utils::{Context, FunctionErrorKind};
 use nasl_syntax::NaslValue;
 use storage::Field;
 
@@ -74,47 +74,6 @@ impl Display for OpenvasEncaps {
     }
 }
 
-fn get_named_value(r: &Register, name: &str) -> Result<NaslValue, FunctionErrorKind> {
-    match r.named(name) {
-        Some(x) => match x {
-            nasl_builtin_utils::ContextType::Function(_, _) => Err(
-                FunctionErrorKind::WrongArgument(format!("{name} is a function")),
-            ),
-            nasl_builtin_utils::ContextType::Value(val) => Ok(val.to_owned()),
-        },
-        None => Err(FunctionErrorKind::MissingArguments(vec![name.to_string()])),
-    }
-}
-
-fn get_usize(r: &Register, name: &str) -> Result<usize, FunctionErrorKind> {
-    match get_named_value(r, name)? {
-        NaslValue::Number(num) => {
-            if num < 0 {
-                return Err(FunctionErrorKind::WrongArgument(format!(
-                    "Argument {name} must be >= 0"
-                )));
-            }
-            Ok(num as usize)
-        }
-        _ => Err(FunctionErrorKind::WrongArgument(
-            "Wrong type for argument, expected a number".to_string(),
-        )),
-    }
-}
-
-fn get_data(r: &Register) -> Result<Vec<u8>, FunctionErrorKind> {
-    Ok((get_named_value(r, "data")?).into())
-}
-
-fn get_opt_int(r: &Register, name: &str) -> Option<i64> {
-    get_named_value(r, name)
-        .map(|val| match val {
-            NaslValue::Number(len) => Some(len),
-            _ => None,
-        })
-        .unwrap_or_default()
-}
-
 pub fn get_kb_item(context: &Context, name: &str) -> Result<Option<NaslValue>, FunctionErrorKind> {
     context
         .retriever()
@@ -127,30 +86,6 @@ pub fn get_kb_item(context: &Context, name: &str) -> Result<Option<NaslValue>, F
         })
         .map(|x| x.map(|x| x.into()))
         .map_err(|e| e.into())
-}
-
-pub fn get_pos_port(r: &Register) -> Result<u16, FunctionErrorKind> {
-    match r
-        .positional()
-        .first()
-        .ok_or(FunctionErrorKind::MissingPositionalArguments {
-            expected: 1,
-            got: 0,
-        })? {
-        NaslValue::Number(port) => {
-            if *port < 0 || *port > 65535 {
-                return Err(FunctionErrorKind::WrongArgument(format!(
-                    "{} is not a valid port number",
-                    *port
-                )));
-            }
-            Ok(*port as u16)
-        }
-        x => Err(FunctionErrorKind::WrongArgument(format!(
-            "{} is not a valid port number",
-            x
-        ))),
-    }
 }
 
 pub fn verify_port(port: i64) -> Result<u16, FunctionErrorKind> {

--- a/rust/nasl-builtin-network/src/lib.rs
+++ b/rust/nasl-builtin-network/src/lib.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-use std::fmt::Display;
+use std::{fmt::Display, net::IpAddr};
 
 use nasl_builtin_utils::{Context, FunctionErrorKind};
 use nasl_syntax::NaslValue;
@@ -14,14 +14,14 @@ pub mod socket;
 
 // 512 Bytes are typically supported by network devices. The ip header maximum size is 60 and a UDP
 // header contains 8 bytes, which must be subtracted from the max size for UDP packages.
-// TODO: Calculate the MTU dynamically
 const MTU: usize = 512 - 60 - 8;
 
 /// Standard port for networking functions
-/// @return none
 const DEFAULT_PORT: u16 = 33435;
 
-pub fn mtu() -> usize {
+// Get the max MTU possible for network communication
+// TODO: Calculate the MTU dynamically
+pub fn mtu(_: IpAddr) -> usize {
     MTU
 }
 

--- a/rust/nasl-builtin-network/src/network.rs
+++ b/rust/nasl-builtin-network/src/network.rs
@@ -42,8 +42,9 @@ fn this_host_name() -> String {
 
 /// get the maximum transition unit for the scanned host
 #[nasl_function]
-fn get_mtu() -> i64 {
-    mtu() as i64
+fn get_mtu(context: &Context) -> Result<i64, FunctionErrorKind> {
+    let target = ipstr2ipaddr(context.target())?;
+    Ok(mtu(target) as i64)
 }
 
 /// check if the currently scanned host is the localhost


### PR DESCRIPTION
Use nasl function macro for builtin socket functions and use network utility functions for parsing ports and IP strings.
Also:
- Fix for creating UDP sockets when using IPv6.
- adds an dns lookup for kdc, which is given as a hostname.

Depends on https://github.com/greenbone/openvas-scanner/pull/1693
Jira: SC-1084