### PR TITLE
Fix: Never type fallback change

### DIFF
--- a/rust/feed-verifier/src/main.rs
+++ b/rust/feed-verifier/src/main.rs
@@ -58,7 +58,7 @@ fn get(con: &mut redis::Connection) -> RedisResult<HashMap<String, Vec<String>>>
         redis::Cmd::new()
             .arg("SELECT")
             .arg(i.to_string())
-            .query(con)?;
+            .query::<()>(con)?;
         let result = get_all(con)?;
         if result.len() > 1 {
             return Ok(result);

--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -621,7 +621,7 @@ impl RedisCtx {
             .cmd("SELECT")
             .arg(self.db)
             .ignore()
-            .query(&mut self.kb.as_mut().expect("Valid redis connection"))?;
+            .query::<()>(&mut self.kb.as_mut().expect("Valid redis connection"))?;
         Ok(())
     }
 
@@ -629,7 +629,7 @@ impl RedisCtx {
     pub fn delete_namespace(&mut self) -> RedisStorageResult<()> {
         Cmd::new()
             .arg("FLUSHDB")
-            .query(&mut self.kb.as_mut().expect("Valid redis connection"))?;
+            .query::<()>(&mut self.kb.as_mut().expect("Valid redis connection"))?;
         self.release_namespace()?;
         Ok(())
     }
@@ -638,13 +638,14 @@ impl RedisCtx {
     pub fn flush_namespace(&mut self) -> RedisStorageResult<()> {
         Cmd::new()
             .arg("FLUSHDB")
-            .query(&mut self.kb.as_mut().expect("Valid redis connection"))?;
+            .query::<()>(&mut self.kb.as_mut().expect("Valid redis connection"))?;
         Ok(())
     }
 
     //Wrapper function to avoid accessing kb member directly.
     pub fn set_value<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
-        self.kb
+        () = self
+            .kb
             .as_mut()
             .expect("Valid redis connection")
             .set(key, val)?;


### PR DESCRIPTION
**What**:
Fix: Never type fallback change
Jira: SC-1127
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Never type (!) to any type (`never-to-any`) coercions fall back to never type (!) rather than to unit type (()).

<!-- Why are these changes necessary? -->

**How**:
Replace `stable` with `nightly` in the `rust-toolchain` file and run `cargo build`


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
