### PR TITLE
Fix: improve scannerctl for using redis as storage.

### DIFF
--- a/rust/redis-storage/src/connector.rs
+++ b/rust/redis-storage/src/connector.rs
@@ -707,9 +707,12 @@ impl CacheDispatcher<RedisCtx> {
     pub fn as_dispatcher(
         redis_url: &str,
         selector: &[NameSpaceSelector],
+        force_flush: bool,
     ) -> RedisStorageResult<PerItemDispatcher<CacheDispatcher<RedisCtx>>> {
         let cache = Self::init(redis_url, selector)?;
-        cache.flushdb()?;
+        if force_flush {
+            cache.flushdb()?
+        };
         Ok(PerItemDispatcher::new(cache))
     }
 

--- a/rust/scannerctl/src/feed/mod.rs
+++ b/rust/scannerctl/src/feed/mod.rs
@@ -99,13 +99,16 @@ pub fn run(root: &clap::ArgMatches) -> Option<Result<(), CliError>> {
             if !loadup_notus_only {
                 let path = get_vts_path("vts-path", args);
 
-                let dispatcher =
-                    redis_storage::CacheDispatcher::as_dispatcher(&redis, FEEDUPDATE_SELECTOR)
-                        .map_err(StorageError::from)
-                        .map_err(|e| CliError {
-                            kind: e.into(),
-                            filename: format!("{path:?}"),
-                        });
+                let dispatcher = redis_storage::CacheDispatcher::as_dispatcher(
+                    &redis,
+                    FEEDUPDATE_SELECTOR,
+                    true,
+                )
+                .map_err(StorageError::from)
+                .map_err(|e| CliError {
+                    kind: e.into(),
+                    filename: format!("{path:?}"),
+                });
                 ret = match dispatcher
                     .and_then(|dispatcher| update::run(dispatcher, path, signature_check))
                 {
@@ -131,13 +134,16 @@ pub fn run(root: &clap::ArgMatches) -> Option<Result<(), CliError>> {
                     }
                 };
 
-                let dispatcher =
-                    redis_storage::CacheDispatcher::as_dispatcher(&redis, NOTUSUPDATE_SELECTOR)
-                        .map_err(StorageError::from)
-                        .map_err(|e| CliError {
-                            kind: e.into(),
-                            filename: format!("{path:?}"),
-                        });
+                let dispatcher = redis_storage::CacheDispatcher::as_dispatcher(
+                    &redis,
+                    NOTUSUPDATE_SELECTOR,
+                    true,
+                )
+                .map_err(StorageError::from)
+                .map_err(|e| CliError {
+                    kind: e.into(),
+                    filename: format!("{path:?}"),
+                });
                 ret = match dispatcher.and_then(|dispatcher| {
                     notusupdate::update::run(dispatcher, path, signature_check)
                 }) {


### PR DESCRIPTION
**What**:
Check the current feed version and only loads it up if it is empty or outdated. Currently, it takes too long for running a single script, if scannerctl is called with the parameter --path.

Also, add the command line  option to pass the redis url.
Jira: SC-1145

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It takes to long if --path argument is given. 
<!-- Why are these changes necessary? -->

**How**:
`scannerctl execute script --redis=unix:///var/run/redis-openvas/redis.sock -p /home/jnicola/install/var/lib/openvas/plugins some_script.nasl`
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
