### PR TITLE
Fix nasl_function taking self/&mut self as arg.

### DIFF
--- a/rust/nasl-function-proc-macro/src/error.rs
+++ b/rust/nasl-function-proc-macro/src/error.rs
@@ -11,6 +11,9 @@ pub struct Error {
 pub enum ErrorKind {
     TooManyAttributes,
     OnlyNormalArgumentsAllowed,
+    MovedReceiverType,
+    MutableRefReceiverType,
+    TypedRefReceiverType,
 }
 
 impl Error {
@@ -25,11 +28,20 @@ impl Error {
     pub fn message(&self) -> String {
         match self.kind {
             ErrorKind::OnlyNormalArgumentsAllowed => {
-                "Only normal identifier arguments are allowed on the function.".into()
+                "Only normal identifier arguments are allowed on the function."
             }
             ErrorKind::TooManyAttributes => {
-                "Argument is named more than once in attributes.".into()
+                "Argument is named more than once in attributes."
             }
-        }
+            ErrorKind::MovedReceiverType => {
+                "Receiver argument is of type `self`. Currently, only `&self` receiver types are supported."
+            }
+            ErrorKind::MutableRefReceiverType => {
+                "Receiver argument is of type `&mut self`. Currently, only `&self` receiver types are supported."
+            }
+            ErrorKind::TypedRefReceiverType => {
+                "Specific type specified in receiver argument. Currently, only `&self` is supported."
+            }
+        }.into()
     }
 }


### PR DESCRIPTION
# What

The `nasl_function` macro does not complain about functions that take `self` or `&mut self` as the receiver argument in the function signature. This doesn't really make sense with the current system and was in fact ignored by the macro which generated a `&self` function anyways. This could potentially lead to oversights now that cause issues once we actually support `&mut self` arguments (`self` is very unlikely to be supported because it doesn't really make sense).
This PR fixes this.

Jira: SC-1151
