### PR TITLE
Fix logging of used openvasd storage.

### DIFF
--- a/rust/openvasd/src/storage/file.rs
+++ b/rust/openvasd/src/storage/file.rs
@@ -17,7 +17,6 @@ use infisto::{
 };
 use models::{Scan, Status};
 use tokio::task::spawn_blocking;
-use tracing::{info, warn};
 
 use crate::crypt::ChaCha20Crypt;
 
@@ -408,7 +407,6 @@ impl FromConfigAndFeeds for Storage<ChaCha20IndexFileStorer<IndexedFileStorer>> 
         config: &Config,
         feeds: Vec<FeedHash>,
     ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-        info!("using in file storage. Sensitive data will be encrypted stored on disk.");
         // If this is even being called, we can assume we have a key
         let key = config.storage.fs.key.as_ref().unwrap();
         Ok(file::encrypted(&config.storage.fs.path, key, feeds)?)
@@ -420,9 +418,6 @@ impl FromConfigAndFeeds for Storage<IndexedFileStorer> {
         config: &Config,
         feeds: Vec<FeedHash>,
     ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
-        warn!(
-            "using in file storage. Sensitive data will be stored on disk without any encryption."
-        );
         Ok(file::unencrypted(&config.storage.fs.path, feeds)?)
     }
 }

--- a/rust/openvasd/src/storage/inmemory.rs
+++ b/rust/openvasd/src/storage/inmemory.rs
@@ -6,7 +6,6 @@ use std::{collections::HashSet, sync::RwLock};
 
 use super::*;
 use tokio::task::JoinSet;
-use tracing::info;
 
 #[derive(Clone, Debug, Default)]
 struct Progress {
@@ -288,7 +287,6 @@ where
         _: &Config,
         feeds: Vec<FeedHash>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        info!("using in memory store. No sensitive data will be stored on disk.");
         Ok(inmemory::Storage::new(E::default(), feeds))
     }
 }

--- a/rust/openvasd/src/storage/redis.rs
+++ b/rust/openvasd/src/storage/redis.rs
@@ -12,7 +12,6 @@ use redis_storage::{
 };
 use storage::{item::PerItemDispatcher, Dispatcher, Field};
 use tokio::{sync::RwLock, task::JoinSet};
-use tracing::info;
 
 use crate::{config::Config, controller::ClientHash, storage::FeedType};
 use models::scanner::ScanResults;
@@ -341,7 +340,6 @@ where
         config: &Config,
         feeds: Vec<FeedHash>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        info!(url = config.storage.redis.url, "using redis");
         Ok(Self::new(
             T::from_config_and_feeds(config, feeds.clone())?,
             config.storage.redis.url.clone(),


### PR DESCRIPTION
Jira: SC-1162

**What**:

Previously, openvasd would print "using inmemory storage" before redis was used, due to the way the redis storage internally uses the inmemory storage type. 

Fixed by logging the storage type at the openvasd entry point.