### PR TITLE
Fix: scan progress for openvas scanner type.

### DIFF
--- a/rust/models/src/host_info.rs
+++ b/rust/models/src/host_info.rs
@@ -14,6 +14,7 @@ pub struct HostInfoBuilder {
     pub alive: u64,
     pub queued: u64,
     pub finished: u64,
+    pub scanning: Option<HashMap<String, i32>>,
 }
 
 impl HostInfoBuilder {
@@ -25,7 +26,8 @@ impl HostInfoBuilder {
             alive: self.alive,
             queued: self.queued,
             finished: self.finished,
-            scanning: HashMap::new(),
+            scanning: self.scanning,
+            remaining_vts_per_host: HashMap::new(),
         }
     }
 }
@@ -43,9 +45,16 @@ pub struct HostInfo {
     alive: u64,
     queued: u64,
     finished: u64,
+    // Hosts that are currently being scanned. The second entry is the host
+    // scan progress. Required for Openvas Scanner type
+    #[cfg_attr(
+        feature = "serde_support",
+        serde(skip_serializing_if = "Option::is_none")
+    )]
+    scanning: Option<HashMap<String, i32>>,
     // Hosts that are currently being scanned. The second entry is the number of
     // remaining VTs for this host.
-    scanning: HashMap<String, usize>,
+    remaining_vts_per_host: HashMap<String, usize>,
 }
 
 impl HostInfo {
@@ -53,24 +62,24 @@ impl HostInfo {
         Self {
             all: hosts.len() as u64,
             queued: hosts.len() as u64,
-            scanning: hosts.iter().map(|host| (host.clone(), num_vts)).collect(),
+            remaining_vts_per_host: hosts.iter().map(|host| (host.clone(), num_vts)).collect(),
             ..Default::default()
         }
     }
 
     pub fn register_finished_script(&mut self, target: &Host) {
-        if let Some(num_vts) = self.scanning.get_mut(target) {
+        if let Some(num_vts) = self.remaining_vts_per_host.get_mut(target) {
             *num_vts -= 1;
             if *num_vts == 0 {
                 self.finished += 1;
                 self.queued -= 1;
-                self.scanning.remove(target);
+                self.remaining_vts_per_host.remove(target);
             }
         }
     }
 
     pub fn finish(&mut self) {
-        self.scanning.clear();
+        self.remaining_vts_per_host.clear();
         assert_eq!(self.queued, 0);
     }
 
@@ -83,20 +92,33 @@ impl HostInfo {
     }
 
     pub fn update_with(mut self, other: &HostInfo) -> Self {
-        // total hosts value is sent once
+        // total hosts value is sent once and only once must be updated
         if other.all != 0 {
             self.all = other.all;
         }
-        // excluded hosts value is sent once
+        // excluded hosts value is sent once and only once must be updated
         if self.excluded == 0 {
             self.excluded = other.excluded;
         }
-        // if new dead/alive/finished hosts are found during the scan,
+        // new dead/alive/finished hosts are found during the scan.
         // the new count must be added to the previous one
         self.dead += other.dead;
         self.alive += other.alive;
         self.finished += other.finished;
-        self.scanning = other.scanning.clone();
+
+        // Update each single host status. Remove it if finished.
+        // Openvas doesn't keep the previous progress. Therefore
+        // the values already stored in Openvasd must be updated
+        // and never completely replaced.
+        let mut hs = other.scanning.clone().unwrap_or_default();
+        for (host, progress) in self.scanning.clone().unwrap_or_default().iter() {
+            if *progress == 100 || *progress == -1 {
+                hs.remove(host);
+            } else {
+                hs.insert(host.to_string(), *progress);
+            }
+        }
+        self.scanning = Some(hs);
         self
     }
 }

--- a/rust/openvas/src/openvas.rs
+++ b/rust/openvas/src/openvas.rs
@@ -321,6 +321,7 @@ impl ScanResultFetcher for Scanner {
                     alive: all_results.count_alive as u64,
                     queued: 0,
                     finished: all_results.count_alive as u64,
+                    scanning: Some(all_results.host_status.clone()),
                 }
                 .build();
 
@@ -367,7 +368,6 @@ impl ScanResultFetcher for Scanner {
                         .map(|r| models::Result::from(r).clone())
                         .collect(),
                 };
-
                 // If the scan finished, release. Openvas "finished" status is translated todo
                 // Succeeded. It is necessary to read the exit code to know if it failed.
                 if status == Phase::Succeeded {

--- a/rust/osp/src/response.rs
+++ b/rust/osp/src/response.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 //! # Responses of OSPD commands
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use serde::{de::Visitor, Deserialize};
 
@@ -588,6 +588,12 @@ impl From<Scan> for models::Status {
             ScanStatus::Interrupted => models::Phase::Failed,
         };
 
+        let mut scanning: HashMap<String, i32> = HashMap::new();
+        if let Some(i) = &value.host_info {
+            for host in &i.host {
+                scanning.insert(host.name.clone(), 0);
+            }
+        }
         models::Status {
             status: phase,
             start_time: value.start_time.map(|s| s.0),
@@ -603,6 +609,9 @@ impl From<Scan> for models::Status {
                         - host_info.count_alive.content.0
                         - host_info.host.len() as u64,
                     finished: host_info.count_alive.content.0,
+                    // Not used by OSP but necessary for Openvas and Openvasd
+                    // scanner types respectively
+                    scanning: Some(scanning),
                 }
                 .build()
             }),


### PR DESCRIPTION
**What**:
- Scan progress for openvas scanner type:
  - SC-1161
  - SC-1159

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
it was always 0% until end of the scans. Openvas doesn't keep the scan progress. Therefore, the Openvasd scan progress must not be overwritten, but updated.

<!-- Why are these changes necessary? -->

**How**:
Run a scan with openvas type and check status
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
