### PR TITLE
Rs target handling

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2149,7 +2149,6 @@ dependencies = [
 name = "nasl-builtin-raw-ip"
 version = "0.1.0"
 dependencies = [
- "nasl-builtin-host",
  "nasl-builtin-misc",
  "nasl-builtin-std",
  "nasl-builtin-utils",

--- a/rust/examples/tcp.nasl
+++ b/rust/examples/tcp.nasl
@@ -7,7 +7,7 @@ display("is function defined: ", defined_func("open_sock_tcp"));
 sock = open_sock_tcp(34254, transport: 1);
 display("was socket created: ", !isnull(sock));
 display("fd: ", sock);
-ret = send(socket: sock, data: "foobar");
+ret = send(socket: sock, data: 'foobar');
 display("num bytes sent: ", ret);
 rec = recv(socket: sock, length: 10, min: 3);
 display(rec);

--- a/rust/examples/udp.nasl
+++ b/rust/examples/udp.nasl
@@ -7,7 +7,7 @@ display("is function defined: ", defined_func("open_sock_udp"));
 sock = open_sock_udp(34254);
 display("was socket created: ", !isnull(sock));
 display("fd: ", sock);
-ret = send(socket: sock, data: "123");
+ret = send(socket: sock, data: '123');
 display("num bytes sent: ", ret);
 rec = recv(socket: sock, length: 10);
 display(rec);

--- a/rust/models/src/target.rs
+++ b/rust/models/src/target.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+use std::net::IpAddr;
+
 use super::{credential::Credential, port::Port};
 
 pub type Host = String;

--- a/rust/nasl-builtin-host/src/lib.rs
+++ b/rust/nasl-builtin-host/src/lib.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::{net::IpAddr, str::FromStr};
-
 use nasl_builtin_utils::{error::FunctionErrorKind, lookup_keys::TARGET};
 
 use nasl_builtin_utils::{function_set, Context, ContextType, Register};
@@ -49,32 +47,6 @@ fn get_host_name(register: &Register, _: &Context) -> Result<NaslValue, Function
     resolve_hostname(register).map(NaslValue::String)
 }
 
-/// Return the target's IP address as IpAddr.
-pub fn get_host_ip(context: &Context) -> Result<IpAddr, FunctionErrorKind> {
-    let default_ip = "127.0.0.1";
-    let r_sock_addr = match context.target() {
-        x if !x.is_empty() => IpAddr::from_str(x),
-        _ => IpAddr::from_str(default_ip),
-    };
-
-    match r_sock_addr {
-        Ok(x) => Ok(x),
-        Err(e) => Err(FunctionErrorKind::wrong_unnamed_argument(
-            "IP address",
-            e.to_string().as_str(),
-        )),
-    }
-}
-
-/// Return the target's IP address or 127.0.0.1 if not set.
-fn nasl_get_host_ip(
-    _register: &Register,
-    context: &Context,
-) -> Result<NaslValue, FunctionErrorKind> {
-    let ip = get_host_ip(context)?;
-    Ok(NaslValue::String(ip.to_string()))
-}
-
 pub struct Host;
 
 function_set! {
@@ -83,6 +55,5 @@ function_set! {
     (
         get_host_name,
         get_host_names,
-        (nasl_get_host_ip, "get_host_ip")
     )
 }

--- a/rust/nasl-builtin-network/src/lib.rs
+++ b/rust/nasl-builtin-network/src/lib.rs
@@ -21,7 +21,7 @@ const DEFAULT_PORT: u16 = 33435;
 
 // Get the max MTU possible for network communication
 // TODO: Calculate the MTU dynamically
-pub fn mtu(_: IpAddr) -> usize {
+pub fn mtu(_: &IpAddr) -> usize {
     MTU
 }
 

--- a/rust/nasl-builtin-network/src/network.rs
+++ b/rust/nasl-builtin-network/src/network.rs
@@ -5,7 +5,7 @@
 use std::{net::IpAddr, process::Command};
 
 use crate::{
-    network_utils::{get_netmask_by_local_ip, get_source_ip, ipstr2ipaddr, islocalhost},
+    network_utils::{get_netmask_by_local_ip, get_source_ip, islocalhost},
     verify_port, DEFAULT_PORT,
 };
 use nasl_builtin_utils::{function_set, Context, FunctionErrorKind};
@@ -23,11 +23,9 @@ fn get_host_ip(context: &Context) -> String {
 /// Get the IP address of the current (attacking) machine depending on which network device is used
 #[nasl_function]
 fn this_host(context: &Context) -> Result<String, FunctionErrorKind> {
-    let dst = ipstr2ipaddr(context.target())?;
-
     let port: u16 = DEFAULT_PORT;
 
-    get_source_ip(dst, port).map(|ip| ip.to_string())
+    get_source_ip(context.target(), port).map(|ip| ip.to_string())
 }
 
 /// Get the host name of the current (attacking) machine
@@ -43,23 +41,21 @@ fn this_host_name() -> String {
 /// get the maximum transition unit for the scanned host
 #[nasl_function]
 fn get_mtu(context: &Context) -> Result<i64, FunctionErrorKind> {
-    let target = ipstr2ipaddr(context.target())?;
-    Ok(mtu(target) as i64)
+    Ok(mtu(context.target()) as i64)
 }
 
 /// check if the currently scanned host is the localhost
 #[nasl_function]
 fn nasl_islocalhost(context: &Context) -> Result<bool, FunctionErrorKind> {
-    let host_ip = ipstr2ipaddr(context.target())?;
-    Ok(islocalhost(host_ip))
+    Ok(islocalhost(context.target()))
 }
 
 /// Check if the target host is on the same network as the attacking host
 #[nasl_function]
 fn islocalnet(context: &Context) -> Result<bool, FunctionErrorKind> {
-    let dst = ipstr2ipaddr(context.target())?;
+    let dst = context.target();
     let src = get_source_ip(dst, DEFAULT_PORT)?;
-    let netmask = match get_netmask_by_local_ip(src)? {
+    let netmask = match get_netmask_by_local_ip(&src)? {
         Some(netmask) => netmask,
         None => return Ok(false),
     };

--- a/rust/nasl-builtin-network/src/socket.rs
+++ b/rust/nasl-builtin-network/src/socket.rs
@@ -5,7 +5,7 @@
 use std::{
     fs,
     io::{self, BufReader, Read, Write},
-    net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs, UdpSocket},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream, ToSocketAddrs, UdpSocket},
     os::fd::AsRawFd,
     sync::{Arc, RwLock},
     thread::sleep,
@@ -353,18 +353,18 @@ impl NaslSockets {
     /// - length the number of bytes that you want to read at most. recv may return before length bytes have been read: as soon as at least one byte has been received, the timeout is lowered to 1 second. If no data is received during that time, the function returns the already read data; otherwise, if the full initial timeout has not been reached, a 1 second timeout is re-armed and the script tries to receive more data from the socket. This special feature was implemented to get a good compromise between reliability and speed when openvas-scanner talks to unknown or complex protocols. Two other optional named integer arguments can twist this behavior:
     /// - min is the minimum number of data that must be read in case the “magic read function” is activated and the timeout is lowered. By default this is 0. It works together with length. More info https://lists.archive.carbon60.com/nessus/devel/13796
     /// - timeout can be changed from the default.
-    #[nasl_function(named(socket, len, min, timeout))]
+    #[nasl_function(named(socket, length, min, timeout))]
     fn recv(
         &self,
         socket: usize,
-        len: usize,
+        length: usize,
         min: Option<i64>,
         timeout: Option<i64>,
     ) -> Result<NaslValue, FunctionErrorKind> {
         let min = min
-            .map(|min| if min < 0 { len } else { min as usize })
-            .unwrap_or(len);
-        let mut data = vec![0; len];
+            .map(|min| if min < 0 { length } else { min as usize })
+            .unwrap_or(length);
+        let mut data = vec![0; length];
 
         let mut ret = Ok(NaslValue::Null);
 
@@ -386,9 +386,9 @@ impl NaslSockets {
                 }
                 if let Some(tls) = conn.tls_connection.as_mut() {
                     let mut socket = Stream::new(tls, &mut conn.socket);
-                    Self::socket_recv(&mut socket, &mut data, len, min)?;
+                    Self::socket_recv(&mut socket, &mut data, length, min)?;
                 } else {
-                    Self::socket_recv(&mut conn.socket, &mut data, len, min)?;
+                    Self::socket_recv(&mut conn.socket, &mut data, length, min)?;
                 }
 
                 if let Some(timeout) = old {
@@ -521,13 +521,13 @@ impl NaslSockets {
     #[nasl_function(named(timeout, transport, bufsz))]
     fn open_sock_tcp(
         &self,
-        context: &Context,
         port: i64,
         timeout: Option<i64>,
         transport: Option<i64>,
         bufsz: Option<i64>,
         // TODO: Extract information from custom priority string
         // priority: Option<&str>,
+        context: &Context,
     ) -> Result<NaslValue, FunctionErrorKind> {
         // Get port
         let port = verify_port(port)?;
@@ -566,14 +566,14 @@ impl NaslSockets {
                 Some(OpenvasEncaps::Auto) => {
                     // Try SSL/TLS first
                     if let Ok(fd) =
-                        self.open_sock_tcp_tls(context, addr, port, bufsz, timeout, vhost)
+                        self.open_sock_tcp_tls(addr, port, bufsz, timeout, vhost, context)
                     {
                         fds.push(self.add(fd))
                         // TODO: Set port transport
                     } else {
                         // Then try IP
                         if let Ok(fd) =
-                            self.open_sock_tcp_ip(context, addr, port, bufsz, timeout, None)
+                            self.open_sock_tcp_ip(addr, port, bufsz, timeout, None, context)
                         {
                             fds.push(self.add(fd))
                             // TODO: Set port transport
@@ -582,7 +582,7 @@ impl NaslSockets {
                 }
                 // IP
                 Some(OpenvasEncaps::Ip) => {
-                    if let Ok(fd) = self.open_sock_tcp_ip(context, addr, port, bufsz, timeout, None)
+                    if let Ok(fd) = self.open_sock_tcp_ip(addr, port, bufsz, timeout, None, context)
                     {
                         fds.push(self.add(fd))
                         // TODO: Set port transport
@@ -598,7 +598,7 @@ impl NaslSockets {
                 Some(tls_version) => match tls_version {
                     OpenvasEncaps::Tls12 | OpenvasEncaps::Tls13 => {
                         let fd =
-                            self.open_sock_tcp_tls(context, addr, port, bufsz, timeout, vhost)?;
+                            self.open_sock_tcp_tls(addr, port, bufsz, timeout, vhost, context)?;
                         fds.push(self.add(fd))
                     }
                     _ => {
@@ -619,12 +619,12 @@ impl NaslSockets {
 
     fn open_sock_tcp_ip(
         &self,
-        context: &Context,
         addr: &str,
         port: u16,
         bufsz: Option<i64>,
         timeout: Duration,
         tls_config: Option<TLSConfig>,
+        context: &Context,
     ) -> Result<NaslSocket, FunctionErrorKind> {
         let addr = ipstr2ipaddr(addr)?;
         let mut retry = super::get_kb_item(context, "timeout_retry")?
@@ -679,12 +679,12 @@ impl NaslSockets {
 
     fn open_sock_tcp_tls(
         &self,
-        context: &Context,
         addr: &str,
         port: u16,
         bufsz: Option<i64>,
         timeout: Duration,
         hostname: &str,
+        context: &Context,
     ) -> Result<NaslSocket, FunctionErrorKind> {
         let cert_path = get_kb_item(context, "SSL/cert")?
             .ok_or(FunctionErrorKind::Diagnostic(
@@ -753,20 +753,22 @@ impl NaslSockets {
             .map_err(|_| FunctionErrorKind::WrongArgument("Invalid Key".to_string()))?;
 
         self.open_sock_tcp_ip(
-            context,
             addr,
             port,
             bufsz,
             timeout,
             Some(TLSConfig { config, server }),
+            context,
         )
     }
 
     /// Open a UDP socket to the target host
     #[nasl_function]
-    fn open_sock_udp(&self, context: &Context, port: i64) -> Result<NaslValue, FunctionErrorKind> {
+    fn open_sock_udp(&self, port: i64, context: &Context) -> Result<NaslValue, FunctionErrorKind> {
         let port = verify_port(port)?;
+        dbg!(context.target());
         let addr = ipstr2ipaddr(context.target())?;
+        // let addr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
         let socket = Self::open_udp(addr, port)?;
         let fd = self.add(socket);

--- a/rust/nasl-builtin-raw-ip/Cargo.toml
+++ b/rust/nasl-builtin-raw-ip/Cargo.toml
@@ -6,19 +6,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nasl-builtin-utils = {path = "../nasl-builtin-utils"}
-nasl-syntax = {path = "../nasl-syntax"}
-nasl-builtin-host = {path = "../nasl-builtin-host"}
-nasl-builtin-misc = {path = "../nasl-builtin-misc"}
-storage = {path = "../storage"}
+nasl-builtin-utils = { path = "../nasl-builtin-utils" }
+nasl-syntax = { path = "../nasl-syntax" }
+nasl-builtin-misc = { path = "../nasl-builtin-misc" }
+storage = { path = "../storage" }
 pcap = "1.0.0"
 pnet_base = "0.33.0"
 pnet = "0.33.0"
-socket2 = {version = "0.5.2", features = ["all"]}
+socket2 = { version = "0.5.2", features = ["all"] }
 pnet_macros = "0.33.0"
 pnet_macros_support = "0.33.0"
 tracing = "0.1.40"
 
 [dev-dependencies]
-nasl-builtin-std = {path = "../nasl-builtin-std"}
-nasl-interpreter = {path = "../nasl-interpreter"}
+nasl-builtin-std = { path = "../nasl-builtin-std" }
+nasl-interpreter = { path = "../nasl-interpreter" }

--- a/rust/nasl-builtin-raw-ip/src/raw_ip_utils.rs
+++ b/rust/nasl-builtin-raw-ip/src/raw_ip_utils.rs
@@ -24,7 +24,7 @@ pub fn ipstr2ipaddr(ip_addr: &str) -> Result<IpAddr, FunctionErrorKind> {
 
 /// Tests whether a packet sent to IP is LIKELY to route through the
 /// kernel localhost interface
-pub fn islocalhost(addr: IpAddr) -> bool {
+pub fn islocalhost(addr: &IpAddr) -> bool {
     // If it is not 0.0.0.0 or doesn't start with 127.0.0.1 then it
     // probably isn't localhost
     if !addr.is_loopback() || !addr.is_unspecified() {
@@ -39,7 +39,7 @@ pub fn islocalhost(addr: IpAddr) -> bool {
 }
 
 /// Get the interface from the local ip
-pub fn get_interface_by_local_ip(local_address: IpAddr) -> Result<Device, FunctionErrorKind> {
+pub fn get_interface_by_local_ip(local_address: &IpAddr) -> Result<Device, FunctionErrorKind> {
     // This fake IP is used for matching (and return false)
     // during the search of the interface in case an interface
     // doesn't have an associated address.
@@ -56,11 +56,11 @@ pub fn get_interface_by_local_ip(local_address: IpAddr) -> Result<Device, Functi
         dst_addr: None,
     };
 
-    let ip_match = |ip: &Address| ip.addr.eq(&local_address);
+    let ip_match = |ip: &Address| ip.addr.eq(local_address);
 
     let dev = match Device::list() {
         Ok(devices) => devices.into_iter().find(|x| {
-            local_address
+            *local_address
                 == (x.addresses.clone().into_iter().find(ip_match))
                     .unwrap_or_else(|| fake_addr.to_owned())
                     .addr

--- a/rust/nasl-builtin-ssh/src/lib.rs
+++ b/rust/nasl-builtin-ssh/src/lib.rs
@@ -423,10 +423,7 @@ impl Ssh {
             }
         };
 
-        let ip_str: String = match ctx.target() {
-            x if !x.is_empty() => x.to_string(),
-            _ => "127.0.0.1".to_string(),
-        };
+        let ip_str = ctx.target().to_string();
 
         let timeout: i64 = register
             .named("timeout")
@@ -551,7 +548,7 @@ impl Ssh {
             let option = SshOption::Socket(my_sock.as_raw_fd());
 
             debug!(
-                ip_str = ip_str,
+                ip_str = ip_str.to_string(),
                 sock_fd = my_sock.as_raw_fd(),
                 nasl_sock = sock,
                 "Setting SSH fd for socket",

--- a/rust/nasl-builtin-utils/src/context.rs
+++ b/rust/nasl-builtin-utils/src/context.rs
@@ -288,7 +288,7 @@ impl Default for Register {
         Self::new()
     }
 }
-use std::collections::HashMap;
+use std::{collections::HashMap, net::IpAddr};
 type Named = HashMap<String, ContextType>;
 
 /// NaslContext is a struct to contain variables and if root declared functions
@@ -336,7 +336,7 @@ pub struct Context<'a> {
     /// key for this context. A file name or a scan id
     key: ContextKey,
     /// target to run a scan against
-    target: String,
+    target: IpAddr,
     /// Default Dispatcher
     dispatcher: &'a dyn Dispatcher,
     /// Default Retriever
@@ -351,7 +351,7 @@ impl<'a> Context<'a> {
     /// Creates an empty configuration
     pub fn new(
         key: ContextKey,
-        target: String,
+        target: IpAddr,
         dispatcher: &'a dyn Dispatcher,
         retriever: &'a dyn Retriever,
         loader: &'a dyn Loader,
@@ -394,7 +394,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get the target host
-    pub fn target(&self) -> &str {
+    pub fn target(&self) -> &IpAddr {
         &self.target
     }
 

--- a/rust/nasl-interpreter/src/include.rs
+++ b/rust/nasl-interpreter/src/include.rs
@@ -4,7 +4,10 @@
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        net::{IpAddr, Ipv4Addr},
+    };
 
     use crate::*;
 
@@ -43,6 +46,7 @@ mod tests {
         "#;
         let register = Register::default();
         let context = ContextFactory {
+            target: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             loader,
             functions: nasl_std_functions(),
             storage: storage::DefaultDispatcher::default(),

--- a/rust/nasl-interpreter/src/scanner/mod.rs
+++ b/rust/nasl-interpreter/src/scanner/mod.rs
@@ -24,6 +24,8 @@ pub use scanner_stack::ScannerStack;
 pub use scanner_stack::ScannerStackWithStorage;
 use tokio::sync::RwLock;
 
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use crate::{nasl_std_functions, scheduling::WaveExecutionPlan};
@@ -128,7 +130,10 @@ impl<S: ScannerStack> ScanDeleter for Scanner<S> {
     where
         I: AsRef<str> + Send + 'static,
     {
-        let ck = ContextKey::Scan(id.as_ref().to_string(), None);
+        let ck = ContextKey::Scan(
+            id.as_ref().to_string(),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        );
         self.stop_scan(id).await?;
         self.storage
             .remove_scan(&ck)

--- a/rust/nasl-interpreter/src/scanner/scan_runner.rs
+++ b/rust/nasl-interpreter/src/scanner/scan_runner.rs
@@ -113,6 +113,9 @@ impl<'a, Stack: ScannerStack> ScanRunner<'a, Stack> {
 
 #[cfg(test)]
 pub(super) mod tests {
+    use std::net::IpAddr;
+    use std::net::Ipv4Addr;
+
     use futures::StreamExt;
     use models::Protocol;
     use models::Scan;
@@ -322,12 +325,18 @@ exit({rc});
         let storage = DefaultDispatcher::new();
 
         let register = Register::root_initial(&initial);
-        let target = String::default();
         let functions = nasl_std_functions();
         let loader = |_: &str| code.to_string();
         let key = ContextKey::FileName(id.to_string());
 
-        let context = Context::new(key, target, &storage, &storage, &loader, &functions);
+        let context = Context::new(
+            key,
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            &storage,
+            &storage,
+            &loader,
+            &functions,
+        );
         let interpreter = CodeInterpreter::new(code, register, &context);
         for stmt in interpreter.iter_blocking() {
             if let NaslValue::Exit(_) = stmt.expect("stmt success") {
@@ -452,7 +461,7 @@ exit({rc});
         .for_each(|(p, port, enabled)| {
             dispatcher
                 .dispatch(
-                    &ContextKey::Scan("sid".into(), Some("test.host".into())),
+                    &ContextKey::Scan("sid".into(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                     Field::KB((&generate_port_kb_key(p, port), enabled).into()),
                 )
                 .expect("store kb");
@@ -466,7 +475,7 @@ exit({rc});
         let dispatcher = prepare_vt_storage(&vts);
         dispatcher
             .dispatch(
-                &ContextKey::Scan("sid".into(), Some("test.host".into())),
+                &ContextKey::Scan("sid".into(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                 Field::KB(("key/exists", 1).into()),
             )
             .expect("store kb");

--- a/rust/nasl-interpreter/src/scanner/vt_runner.rs
+++ b/rust/nasl-interpreter/src/scanner/vt_runner.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use futures::StreamExt;
 use models::{Host, Parameter, Protocol, ScanId};
 use nasl_builtin_utils::{Executor, Register};
@@ -184,7 +186,7 @@ impl<'a, Stack: ScannerStack> VTRunner<'a, Stack> {
 
     // TODO: probably better to enhance ContextKey::Scan to contain target and scan_id?
     fn generate_key(&self) -> ContextKey {
-        ContextKey::Scan(self.scan_id.clone(), Some(self.target.clone()))
+        ContextKey::Scan(self.scan_id.clone(), self.target.clone())
     }
 
     async fn get_result_kind(&self, code: &str, register: Register) -> ScriptResultKind {
@@ -227,7 +229,7 @@ impl<'a, Stack: ScannerStack> VTRunner<'a, Stack> {
             filename: self.vt.filename.clone(),
             stage: self.stage,
             kind,
-            target: self.target.clone(),
+            target: self.target.to_string(),
         })
     }
 }

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
     io,
+    net::IpAddr,
     sync::{Arc, PoisonError, RwLock},
 };
 
@@ -29,7 +30,7 @@ pub type ScanID = String;
 ///
 ///  This is necessary for target specific data, e.g. KB items that should be deleted when the
 ///  target is not scanned anymore.
-pub type Target = Option<String>;
+pub type Target = IpAddr;
 
 /// Is a key used by a Storage to find data within a certain scope.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -48,8 +49,7 @@ pub enum ContextKey {
 impl Display for ContextKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ContextKey::Scan(id, None) => write!(f, "scan_id={id}"),
-            ContextKey::Scan(id, Some(target)) => write!(f, "scan_id={id} target={target}"),
+            ContextKey::Scan(id, target) => write!(f, "scan_id={id} target={target}"),
             ContextKey::FileName(name) => write!(f, "file={name}"),
         }
     }


### PR DESCRIPTION
As many NASL functions use the IP of the currently scanned target, it is a huge benefit to have the target already as an `IpAddr`,
as it had to be parsed every time used. This also removes the Optional target String, as the default target should always be
`127.0.0.1`. Also for scans, there always must be a target IP for scanning.