### PR TITLE
Emit error for wrong arg order in nasl_functions.

### DIFF
--- a/rust/crates/nasl-function-proc-macro/src/codegen.rs
+++ b/rust/crates/nasl-function-proc-macro/src/codegen.rs
@@ -12,7 +12,9 @@ impl<'a> ArgsStruct<'a> {
     }
 
     fn num_required_positional(&self) -> usize {
-        self.positional().filter(|(arg, _)| !arg.optional).count()
+        self.positional()
+            .filter(|(arg, _)| arg.is_required_positional())
+            .count()
     }
 
     fn max_num_allowed_positional(&self) -> usize {

--- a/rust/crates/nasl-function-proc-macro/src/error.rs
+++ b/rust/crates/nasl-function-proc-macro/src/error.rs
@@ -48,7 +48,7 @@ impl Error {
                 "Specific type specified in receiver argument. Currently, only `&self` is supported."
             }
             ErrorKind::WrongArgumentOrder => {
-                "Argument in wrong position. Order of arguments should be: Positionals, Named, Context/Register"
+                "Argument in wrong position. Order of arguments should be: Context/Register, Positionals, Named"
             }
         }.into()
     }

--- a/rust/crates/nasl-function-proc-macro/src/error.rs
+++ b/rust/crates/nasl-function-proc-macro/src/error.rs
@@ -10,7 +10,9 @@ pub struct Error {
 
 pub enum ErrorKind {
     TooManyAttributes,
+    ArgInAttrDoesNotExist,
     OnlyNormalArgumentsAllowed,
+    WrongArgumentOrder,
     MovedReceiverType,
     MutableRefReceiverType,
     TypedRefReceiverType,
@@ -33,6 +35,9 @@ impl Error {
             ErrorKind::TooManyAttributes => {
                 "Argument is named more than once in attributes."
             }
+            ErrorKind::ArgInAttrDoesNotExist => {
+                "Argument mentioned in attribute does not exist in function signature."
+            }
             ErrorKind::MovedReceiverType => {
                 "Receiver argument is of type `self`. Currently, only `&self` receiver types are supported."
             }
@@ -41,6 +46,9 @@ impl Error {
             }
             ErrorKind::TypedRefReceiverType => {
                 "Specific type specified in receiver argument. Currently, only `&self` is supported."
+            }
+            ErrorKind::WrongArgumentOrder => {
+                "Argument in wrong position. Order of arguments should be: Positionals, Named, Context/Register"
             }
         }.into()
     }

--- a/rust/crates/nasl-function-proc-macro/src/lib.rs
+++ b/rust/crates/nasl-function-proc-macro/src/lib.rs
@@ -23,6 +23,5 @@ pub fn nasl_function(
 
 fn nasl_function_internal(function: ItemFn, attrs: Attrs) -> Result<TokenStream> {
     let args = ArgsStruct::try_parse(&function, &attrs)?;
-    attrs.verify()?;
     Ok(args.impl_nasl_function_args())
 }

--- a/rust/crates/nasl-function-proc-macro/src/types.rs
+++ b/rust/crates/nasl-function-proc-macro/src/types.rs
@@ -60,6 +60,18 @@ impl ArgKind {
             None
         }
     }
+
+    pub fn order(&self) -> usize {
+        match self {
+            ArgKind::Context => 0,
+            ArgKind::Register => 0,
+            ArgKind::Positional(_) => 1,
+            ArgKind::MaybeNamed(_, _) => 2,
+            ArgKind::Named(_) => 3,
+            ArgKind::PositionalIterator => 4,
+            ArgKind::CheckedPositionalIterator => 4,
+        }
+    }
 }
 
 pub struct NamedArg {

--- a/rust/src/nasl/builtin/knowledge_base/mod.rs
+++ b/rust/src/nasl/builtin/knowledge_base/mod.rs
@@ -18,10 +18,10 @@ use nasl_function_proc_macro::nasl_function;
 /// Only pushes unique values for the given name.
 #[nasl_function(named(name, value, expires))]
 fn set_kb_item(
+    c: &Context,
     name: NaslValue,
     value: NaslValue,
     expires: Option<NaslValue>,
-    c: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     let expires = match expires {
         Some(NaslValue::Number(x)) => Some(x),
@@ -56,7 +56,7 @@ fn set_kb_item(
 
 /// NASL function to get a knowledge base
 #[nasl_function]
-fn get_kb_item(key: &str, c: &Context) -> Result<NaslValue, FunctionErrorKind> {
+fn get_kb_item(c: &Context, key: &str) -> Result<NaslValue, FunctionErrorKind> {
     c.retriever()
         .retrieve(c.key(), Retrieve::KB(key.to_string()))
         .map(|r| {
@@ -72,11 +72,11 @@ fn get_kb_item(key: &str, c: &Context) -> Result<NaslValue, FunctionErrorKind> {
 }
 
 /// NASL function to replace a kb list
-#[nasl_function(named(name, value, expires))]
+#[nasl_function(named(name, value))]
 fn replace_kb_item(
+    c: &Context,
     name: NaslValue,
     value: NaslValue,
-    c: &Context,
 ) -> Result<NaslValue, FunctionErrorKind> {
     c.dispatcher()
         .dispatch_replace(
@@ -92,8 +92,8 @@ fn replace_kb_item(
 }
 
 /// NASL function to retrieve an item in a KB.
-#[nasl_function(named(name, value, expires))]
-fn get_kb_list(key: NaslValue, c: &Context) -> Result<NaslValue, FunctionErrorKind> {
+#[nasl_function]
+fn get_kb_list(c: &Context, key: NaslValue) -> Result<NaslValue, FunctionErrorKind> {
     c.retriever()
         .retrieve(c.key(), Retrieve::KB(key.to_string()))
         .map(|r| {

--- a/rust/src/nasl/builtin/misc/mod.rs
+++ b/rust/src/nasl/builtin/misc/mod.rs
@@ -211,7 +211,7 @@ fn localtime(secs: Option<i64>, utc: Option<NaslValue>) -> HashMap<String, NaslV
 /// This argument must be a string everything else will return False per default.
 /// Returns NaslValue::Boolean(true) when defined NaslValue::Boolean(false) otherwise.
 #[nasl_function]
-fn defined_func(fn_name: Option<Maybe<&str>>, ctx: &Context, register: &Register) -> bool {
+fn defined_func(ctx: &Context, register: &Register, fn_name: Option<Maybe<&str>>) -> bool {
     fn_name
         .and_then(Maybe::as_option)
         .map(|fn_name| match register.named(fn_name) {

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -21,6 +21,9 @@ mod report_functions;
 mod ssh;
 mod string;
 
+#[cfg(test)]
+mod tests;
+
 use crate::nasl::syntax::{Loader, NoOpLoader};
 use crate::nasl::utils::{Context, Executor, NaslVarRegister, NaslVarRegisterBuilder, Register};
 use crate::storage::{ContextKey, DefaultDispatcher, Storage};

--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -132,12 +132,12 @@ fn islocalnet(context: &Context) -> Result<bool, FunctionErrorKind> {
 /// Declares an open port on the target host
 #[nasl_function(named(port, proto))]
 fn scanner_add_port(
-    port: i64,
-    protocol: Option<&str>,
     context: &Context,
+    port: i64,
+    proto: Option<&str>,
 ) -> Result<(), FunctionErrorKind> {
     let port = verify_port(port)?;
-    let protocol = protocol.unwrap_or("tcp");
+    let protocol = proto.unwrap_or("tcp");
 
     context.dispatcher().dispatch(
         context.key(),

--- a/rust/src/nasl/builtin/regex/mod.rs
+++ b/rust/src/nasl/builtin/regex/mod.rs
@@ -97,7 +97,7 @@ fn ereg_replace(
 /// - rnul    replace the null char in the string. Default TRUE.
 ///
 /// Returns the concatenation of all lines that match. Null otherwise.
-#[nasl_function(named(string, pattern, replace, icase, rnul))]
+#[nasl_function(named(string, pattern, icase, rnul))]
 fn egrep(
     string: NaslValue,
     pattern: NaslValue,

--- a/rust/src/nasl/builtin/tests.rs
+++ b/rust/src/nasl/builtin/tests.rs
@@ -1,0 +1,35 @@
+//! This module contains tests for the nasl_function proc macro.
+//! It would be nicer to have this within the proc_macro crate itself,
+//! but testing proc_macros comes with a lot of difficulties and the tests
+//! are very easy to do here.
+
+use crate::nasl::{test_prelude::*, utils::Executor};
+
+#[nasl_function]
+fn foo1(_context: &Context, x: usize) -> usize {
+    x
+}
+
+#[nasl_function]
+fn foo2(_register: &Register, x: usize) -> usize {
+    x
+}
+
+struct Foo;
+
+function_set! {
+    Foo,
+    sync_stateless,
+    (foo1, foo2)
+}
+
+/// Tests that the `Context` and `Register` arguments,
+/// which may appear before the positional arguments,
+/// are not taken into account for determining the index
+/// of the positional arguments after them.
+#[test]
+fn context_and_register_are_ignored_in_positional_index() {
+    let mut t = TestBuilder::default().with_executor(Executor::single(Foo));
+    t.ok("foo1(5);", 5);
+    t.ok("foo2(5);", 5);
+}

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -18,6 +18,7 @@ use futures::StreamExt;
 use super::{
     builtin::ContextFactory,
     interpreter::{CodeInterpreter, InterpretErrorKind},
+    utils::Executor,
 };
 
 // The following exists to trick the trait solver into
@@ -319,6 +320,12 @@ where
     /// Return a new `TestBuilder` with the given `ContextKey`.
     pub fn with_context_key(mut self, key: ContextKey) -> Self {
         self.context_key = key;
+        self
+    }
+
+    /// Return a new `TestBuilder` with the given `Executor`.
+    pub fn with_executor(mut self, executor: Executor) -> Self {
+        self.context.functions = executor;
         self
     }
 


### PR DESCRIPTION
Jira: SC-1163.

I also fixed places where the arguments were not properly ordered. While doing so, I noticed that a few `nasl_functions` mention nonexistent args in the attrs of the macro. I turned this into a hard error, since it can lead to problems such as in `scanner_add_port`.