### PR TITLE
Fix: enable-get-scans

### DIFF
--- a/rust/src/openvasd/config.rs
+++ b/rust/src/openvasd/config.rs
@@ -422,8 +422,10 @@ impl Config {
                 clap::Arg::new("enable-get-scans")
                     .env("ENABLE_GET_SCANS")
                     .long("enable-get-scans")
-                    .action(ArgAction::SetTrue)
-                    .help("enable get scans endpoint"),
+                    .num_args(0..=1)
+                    .value_parser(clap::builder::BoolValueParser::new())
+                    .default_missing_value("true")
+                    .help("enable get scans endpoint. Default 'true'."),
             )
             .arg(
                 clap::Arg::new("api-key")


### PR DESCRIPTION
**What**:
Don't overwrite the setting in the configuration file, if it is not passed via command line. 
Jira: SC-1165

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The ArgAction::SetTrue will be set always set to `false` if the option is not given. This cause clap to overwrite the setting in the config file.

<!-- Why are these changes necessary? -->

**How**:
Run openvasd with the option in the command line and in the configuration file. The configuration file is overwritten with Clap setting
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
