### PR TITLE
Change: Update gvm-libs image in prod.Dockerfile and build.Dockerfile

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,6 +1,6 @@
 ARG VERSION=edge
 
-FROM greenbone/gvm-libs:$VERSION
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION}
 LABEL deprecated="This image is deprecated and may be removed soon."
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -5,7 +5,7 @@ ARG GVM_LIBS_VERSION=oldstable
 
 FROM greenbone/openvas-smb:oldstable-edge AS openvas-smb
 
-FROM greenbone/gvm-libs:${GVM_LIBS_VERSION} AS build
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION} AS build
 COPY . /source
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
   bison \
@@ -41,7 +41,7 @@ COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION}
 ARG TARGETPLATFORM
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
   bison \

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -5,7 +5,7 @@ ARG GVM_LIBS_VERSION=testing-edge
 
 FROM greenbone/openvas-smb:testing-edge AS openvas-smb
 
-FROM greenbone/gvm-libs:${GVM_LIBS_VERSION} AS build
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION} AS build
 COPY . /source
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     bison \
@@ -41,7 +41,7 @@ COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM greenbone/gvm-libs:${GVM_LIBS_VERSION}
+FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION}
 ARG TARGETPLATFORM
 RUN apt-get update
 RUN apt-get install --no-install-recommends --no-install-suggests -y \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -4,14 +4,15 @@ ARG REPOSITORY=greenbone/openvas-scanner
 
 FROM greenbone/openvas-smb AS openvas-smb
 
-FROM greenbone/gvm-libs:$VERSION AS build
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION} AS build
 COPY . /source
 RUN sh /source/.github/install-openvas-dependencies.sh
 COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-FROM greenbone/gvm-libs:$VERSION
+
+FROM registry.community.greenbone.net/community/gvm-libs:${VERSION}
 ARG TARGETPLATFORM
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
   bison \
@@ -58,4 +59,3 @@ RUN setcap cap_net_raw,cap_net_admin+eip /usr/local/sbin/openvas
 ENV NMAP_PRIVILEGED=1
 RUN setcap cap_net_raw,cap_net_admin,cap_net_bind_service+eip /usr/bin/nmap
 CMD /usr/local/bin/openvasd
-

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -11,7 +11,6 @@ COPY --from=openvas-smb /usr/local/lib/ /usr/local/lib/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_OLD_SYNC_SCRIPT=OFF -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
 
-
 FROM registry.community.greenbone.net/community/gvm-libs:${VERSION}
 ARG TARGETPLATFORM
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
## What

Update gvm-libs image in prod.Dockerfile and build.Dockerfile

## Why

In the next release gvm-libs will be pushed to a new registry, therefore the reference needs to be updated.

## References

https://jira.greenbone.net/browse/DEVOPS-1229

## Checklist

- [ ] Tests
- [ ] PR merge commit message adjusted
