### PR TITLE
Fix: setting stack buffer to NULL

### DIFF
--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -398,10 +398,11 @@ plugin_timeout (nvti_t *nvti)
 static int
 get_available_memory ()
 {
-  char buf[8192] = NULL;
+  char buf[8192];
   char *hit = NULL;
   FILE *fd = NULL;
   size_t len;
+  memset (buf, 0, sizeof (buf));
 
   fd = fopen ("/proc/meminfo", "r");
   if (fd == NULL)
@@ -411,7 +412,11 @@ get_available_memory ()
     }
   len = fread (buf, 1, sizeof (buf) - 1, fd);
   fclose (fd);
-  if (len == 0 || buf == NULL)
+  // if len is less then 0, then there was an error reading the file
+  // and we should check errno. Currently it is ignored because
+  // the caller just wants to know if memory is available and we asumme
+  // that there is none on error.
+  if (len <= 0)
     {
       g_warning ("Couldn't read /proc/meminfo");
       return 0;


### PR DESCRIPTION
Since buffer within pluginlaunch.c is within the stack it cannot be NULL. This fixes that oversight.

I'm unsure why we even double check for the buffer to be empty when it is already indicated by len of fread.