### PR TITLE
Fix: linking issues within docker images

### DIFF
--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libhdb9-heimdal \
   libpopt0 \
   libcurl4 \
+  libcurl3-gnutls \
   libhiredis0.14 \
   zlib1g\
   && rm -rf /var/lib/apt/lists/*

--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get install --no-install-recommends --no-install-suggests -y \
   libpopt0 \
   libcurl4 \
   libhiredis1.1.0 \
+  libcurl3t64-gnutls \
   zlib1g
 RUN rm -rf /var/lib/apt/lists/*
 COPY .docker/openvas.conf /etc/openvas/

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
   libcurl3-gnutls \
   zlib1g \
   libhiredis0.14 \
+  libssh-4 \
   && rm -rf /var/lib/apt/lists/*
 COPY .docker/openvas.conf /etc/openvas/
 # must be pre built within the rust dir and moved to the bin dir


### PR DESCRIPTION
When trying to execute openvas in edge than the libssh.so.4 was missing
while when trying to execute openvas in testing as well as in oldstable
`libcurl-gnutls.so.4` was missing.
