### PR TITLE
`nasl_function!` / `TestBuilder` ergonomics

### DIFF
--- a/rust/crates/nasl-function-proc-macro/src/codegen.rs
+++ b/rust/crates/nasl-function-proc-macro/src/codegen.rs
@@ -120,7 +120,9 @@ impl<'a> ArgsStruct<'a> {
         let fn_args_names = self.get_fn_args_names();
         let call_expr = match self.receiver_type {
             ReceiverType::None => quote! { #mangled_ident(#fn_args_names) },
-            ReceiverType::RefSelf => quote! { self.#mangled_ident(#fn_args_names) },
+            ReceiverType::RefSelf | ReceiverType::RefMutSelf => {
+                quote! { self.#mangled_ident(#fn_args_names) }
+            }
         };
         let await_ = match asyncness {
             Some(_) => quote! { .await },
@@ -176,6 +178,7 @@ impl<'a> ArgsStruct<'a> {
         let self_arg = match self.receiver_type {
             ReceiverType::None => quote! {},
             ReceiverType::RefSelf => quote! {&self,},
+            ReceiverType::RefMutSelf => quote! {&mut self,},
         };
         let inputs = quote! {
             #self_arg

--- a/rust/crates/nasl-function-proc-macro/src/error.rs
+++ b/rust/crates/nasl-function-proc-macro/src/error.rs
@@ -14,7 +14,6 @@ pub enum ErrorKind {
     OnlyNormalArgumentsAllowed,
     WrongArgumentOrder,
     MovedReceiverType,
-    MutableRefReceiverType,
     TypedRefReceiverType,
 }
 
@@ -40,9 +39,6 @@ impl Error {
             }
             ErrorKind::MovedReceiverType => {
                 "Receiver argument is of type `self`. Currently, only `&self` receiver types are supported."
-            }
-            ErrorKind::MutableRefReceiverType => {
-                "Receiver argument is of type `&mut self`. Currently, only `&self` receiver types are supported."
             }
             ErrorKind::TypedRefReceiverType => {
                 "Specific type specified in receiver argument. Currently, only `&self` is supported."

--- a/rust/crates/nasl-function-proc-macro/src/parse.rs
+++ b/rust/crates/nasl-function-proc-macro/src/parse.rs
@@ -152,13 +152,13 @@ impl ReceiverType {
                     if rec.reference.is_none() {
                         return make_err(ErrorKind::MovedReceiverType);
                     }
-                    // `&mut self`
-                    else if rec.mutability.is_some() {
-                        return make_err(ErrorKind::MutableRefReceiverType);
-                    }
                     // e.g. `self: Box<Self>`
                     else if rec.colon_token.is_some() {
                         return make_err(ErrorKind::TypedRefReceiverType);
+                    }
+                    // `&mut self`
+                    else if rec.mutability.is_some() {
+                        ReceiverType::RefMutSelf
                     } else {
                         ReceiverType::RefSelf
                     }

--- a/rust/crates/nasl-function-proc-macro/src/types.rs
+++ b/rust/crates/nasl-function-proc-macro/src/types.rs
@@ -23,6 +23,7 @@ pub struct ArgsStruct<'a> {
 pub enum ReceiverType {
     None,
     RefSelf,
+    RefMutSelf,
 }
 
 pub struct Arg<'a> {

--- a/rust/src/nasl/mod.rs
+++ b/rust/src/nasl/mod.rs
@@ -31,6 +31,7 @@ pub use prelude::*;
 pub mod test_prelude {
     pub use super::prelude::*;
     pub use super::test_utils::check_code_result;
+    pub use super::test_utils::DefaultTestBuilder;
     pub use super::test_utils::TestBuilder;
     pub use crate::check_code_result_matches;
     pub use crate::check_err_matches;

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -122,6 +122,8 @@ pub struct TestBuilder<L: Loader, S: Storage> {
     should_verify: bool,
 }
 
+pub type DefaultTestBuilder = TestBuilder<NoOpLoader, DefaultDispatcher>;
+
 impl Default for TestBuilder<NoOpLoader, DefaultDispatcher> {
     fn default() -> Self {
         Self {

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -145,8 +145,8 @@ where
     S: Storage,
 {
     #[track_caller]
-    fn add_line(&mut self, line: &str, val: TestResult) -> &mut Self {
-        self.lines.push(line.to_string());
+    fn add_line(&mut self, line: impl Into<String>, val: TestResult) -> &mut Self {
+        self.lines.push(line.into());
         self.results.push(val.into());
         self
     }
@@ -158,7 +158,7 @@ where
     /// t.ok("x = 3;", 3);
     /// ```
     #[track_caller]
-    pub fn ok(&mut self, line: &str, val: impl ToNaslResult) -> &mut Self {
+    pub fn ok(&mut self, line: impl Into<String>, val: impl ToNaslResult) -> &mut Self {
         self.add_line(line, TestResult::Ok(val.to_nasl_result().unwrap()))
     }
 
@@ -175,7 +175,7 @@ where
     #[track_caller]
     pub fn check(
         &mut self,
-        line: &str,
+        line: impl Into<String>,
         f: impl Fn(NaslResult) -> bool + 'static + Clone,
     ) -> &mut Self {
         self.add_line(line, TestResult::GenericCheck(Box::new(f)))
@@ -183,7 +183,7 @@ where
 
     /// Run a `line` of NASL code without checking its result.
     #[track_caller]
-    pub fn run(&mut self, line: &str) -> &mut Self {
+    pub fn run(&mut self, line: impl Into<String>) -> &mut Self {
         self.add_line(line, TestResult::None)
     }
 

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -281,8 +281,8 @@ where
                 }
                 TestResult::GenericCheck(_) => {
                     panic!(
-                        "Check failed at {}.\nIn code \"{}\".",
-                        reference.location, self.lines[line_count]
+                        "Check failed at {}.\nIn code \"{}\". Found result: {:?}",
+                        reference.location, self.lines[line_count], result
                     );
                 }
                 TestResult::None => unreachable!(),
@@ -359,10 +359,10 @@ pub fn check_code_result(code: &str, expected: impl ToNaslResult) {
 /// perform a check on the line of code using a new `TestBuilder`.
 #[macro_export]
 macro_rules! check_err_matches {
-    ($t: ident, $code: literal, $pat: pat $(,)?) => {
+    ($t: ident, $code: expr, $pat: pat $(,)?) => {
         $t.check($code, |e| matches!(e, Err($pat)));
     };
-    ($code: literal, $pat: pat $(,)?) => {
+    ($code: expr, $pat: pat $(,)?) => {
         let mut t = $crate::nasl::test_utils::TestBuilder::default();
         t.check($code, |e| matches!(e, Err($pat)));
     };
@@ -372,7 +372,7 @@ macro_rules! check_err_matches {
 /// and that the inner value matches a pattern.
 #[macro_export]
 macro_rules! check_code_result_matches {
-    ($code: literal, $pat: pat) => {
+    ($code: expr, $pat: pat) => {
         let mut t = $crate::nasl::test_utils::TestBuilder::default();
         t.check($code, |val| matches!(val, Ok($pat)));
     };

--- a/rust/src/nasl/utils/function/from_nasl_value.rs
+++ b/rust/src/nasl/utils/function/from_nasl_value.rs
@@ -101,9 +101,10 @@ macro_rules! impl_from_nasl_value_for_numeric_type {
                     NaslValue::Number(num) => Ok(<$ty>::try_from(*num).map_err(|_| {
                         FunctionErrorKind::WrongArgument("Expected positive number.".into())
                     })?),
-                    _ => Err(FunctionErrorKind::WrongArgument(
-                        "Expected a number.".to_string(),
-                    )),
+                    e => Err(FunctionErrorKind::WrongArgument(format!(
+                        "Expected a number, found '{}'.",
+                        e
+                    ))),
                 }
             }
         }


### PR DESCRIPTION
**What**:

Improve a few small things around the `nasl_function` proc macro and the `TestBuilder` to make usage slightly more ergonomic and improve emitted error messages.

- Allow taking `&mut` in `nasl_function!`. The underlying logic was enabled by #1731, but needed to actually be supported by the macro itself.
- Allow taking anything that can be turned into a string instead of just literals in the `TestBuilder` functions, so that we can do things like `t.ok(format!("ssh_connect(..., port: {})", port));` which was previously not possible
- Improve error messages. In particular, `check_err_matches!` will now emit the expected pattern instead of just mentioning that whatever we got did not match.
- Emit an error as soon as any line in the `TestBuilder` fails to meet its expected result instead of continuing the script with (possibly faulty) values before an error is emitted.
