### PR TITLE
Fix: mark scan as failed on fetch result errors

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -346,7 +346,6 @@ paths:
                   description: "Schema of a list of results response"
                 get results 0-3:
                   $ref: "#/components/examples/scan_results"
-
         "400":
           description: "Bad range format"
         "404":

--- a/rust/src/openvasd/scheduling.rs
+++ b/rust/src/openvasd/scheduling.rs
@@ -265,7 +265,12 @@ where
                     };
                 }
                 Err(e) => {
-                    tracing::warn!(%scan_id, %e, "unable to fetch results");
+                    // TODO: set scan to failed and inform entry to return 500 instead of 200
+                    // Also may remove from running
+                    tracing::warn!(%scan_id, %e, "unable to fetch results, setting scan to failed");
+                    let mut status = self.db.get_status(&scan_id).await?;
+                    status.status = Phase::Failed;
+                    self.db.update_status(&scan_id, status).await?;
                 }
             };
         }

--- a/rust/src/scanner/mod.rs
+++ b/rust/src/scanner/mod.rs
@@ -39,6 +39,166 @@ use crate::storage::{ContextKey, DefaultDispatcher};
 use running_scan::{RunningScan, RunningScanHandle};
 use scanner_stack::DefaultScannerStack;
 
+// This is a fake implementation of the ScannerStack trait and is only used for testing purposes.
+#[cfg(debug_assertions)]
+pub mod fake {
+    use super::*;
+
+    type StartScan = Arc<Box<dyn Fn(Scan) -> Result<(), Error> + Send + Sync + 'static>>;
+    type CanStartScan = Arc<Box<dyn Fn(&Scan) -> bool + Send + Sync + 'static>>;
+    type StopScan = Arc<Box<dyn Fn(&str) -> Result<(), Error> + Send + Sync + 'static>>;
+    type DeleteScan = Arc<Box<dyn Fn(&str) -> Result<(), Error> + Send + Sync + 'static>>;
+    type FetchResults =
+        Arc<Box<dyn Fn(&str) -> Result<ScanResults, Error> + Send + Sync + 'static>>;
+
+    /// A fake implementation of the ScannerStack trait.
+    ///
+    /// This is useful for testing the Scanner implementation.
+    pub struct LambdaScannerBuilder {
+        start_scan: StartScan,
+        can_start_scan: CanStartScan,
+        stop_scan: StopScan,
+        delete_scan: DeleteScan,
+        fetch_results: FetchResults,
+    }
+
+    impl Default for LambdaScannerBuilder {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl LambdaScannerBuilder {
+        pub fn new() -> Self {
+            Self {
+                start_scan: Arc::new(Box::new(|_| Ok(()))),
+                can_start_scan: Arc::new(Box::new(|_| true)),
+                stop_scan: Arc::new(Box::new(|_| Ok(()))),
+                delete_scan: Arc::new(Box::new(|_| Ok(()))),
+                fetch_results: Arc::new(Box::new(|_| Ok(ScanResults::default()))),
+            }
+        }
+
+        pub fn with_start_scan<F>(mut self, f: F) -> Self
+        where
+            F: Fn(Scan) -> Result<(), Error> + Send + Sync + 'static,
+        {
+            self.start_scan = Arc::new(Box::new(f));
+            self
+        }
+
+        pub fn with_can_start_scan<F>(mut self, f: F) -> Self
+        where
+            F: Fn(&Scan) -> bool + Send + Sync + 'static,
+        {
+            self.can_start_scan = Arc::new(Box::new(f));
+            self
+        }
+
+        pub fn with_stop_scan<F>(mut self, f: F) -> Self
+        where
+            F: Fn(&str) -> Result<(), Error> + Send + Sync + 'static,
+        {
+            self.stop_scan = Arc::new(Box::new(f));
+            self
+        }
+
+        pub fn with_delete_scan<F>(mut self, f: F) -> Self
+        where
+            F: Fn(&str) -> Result<(), Error> + Send + Sync + 'static,
+        {
+            self.delete_scan = Arc::new(Box::new(f));
+            self
+        }
+
+        pub fn with_fetch_results<F>(mut self, f: F) -> Self
+        where
+            F: Fn(&str) -> Result<super::ScanResults, Error> + Send + Sync + 'static,
+        {
+            self.fetch_results = Arc::new(Box::new(f));
+            self
+        }
+
+        pub fn build(self) -> LambdaScanner {
+            LambdaScanner {
+                start_scan: self.start_scan,
+                can_start_scan: self.can_start_scan,
+                stop_scan: self.stop_scan,
+                delete_scan: self.delete_scan,
+                fetch_results: self.fetch_results,
+            }
+        }
+    }
+
+    pub struct LambdaScanner {
+        start_scan: StartScan,
+        can_start_scan: CanStartScan,
+        stop_scan: StopScan,
+        delete_scan: DeleteScan,
+        fetch_results: FetchResults,
+    }
+
+    #[async_trait]
+    impl ScanStarter for LambdaScanner {
+        async fn start_scan(&self, scan: Scan) -> Result<(), Error> {
+            let start_scan = self.start_scan.clone();
+            tokio::task::spawn_blocking(move || (start_scan)(scan))
+                .await
+                .unwrap()
+        }
+
+        async fn can_start_scan(&self, scan: &Scan) -> bool {
+            let can_start_scan = self.can_start_scan.clone();
+            let scan = scan.clone();
+            tokio::task::spawn_blocking(move || (can_start_scan)(&scan))
+                .await
+                .unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl ScanStopper for LambdaScanner {
+        async fn stop_scan<I>(&self, id: I) -> Result<(), Error>
+        where
+            I: AsRef<str> + Send + 'static,
+        {
+            let stop_scan = self.stop_scan.clone();
+            let id = id.as_ref().to_string();
+            tokio::task::spawn_blocking(move || (stop_scan)(&id))
+                .await
+                .unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl ScanDeleter for LambdaScanner {
+        async fn delete_scan<I>(&self, id: I) -> Result<(), Error>
+        where
+            I: AsRef<str> + Send + 'static,
+        {
+            let delete_scan = self.delete_scan.clone();
+            let id = id.as_ref().to_string();
+            tokio::task::spawn_blocking(move || (delete_scan)(&id))
+                .await
+                .unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl ScanResultFetcher for LambdaScanner {
+        async fn fetch_results<I>(&self, id: I) -> Result<super::ScanResults, Error>
+        where
+            I: AsRef<str> + Send + 'static,
+        {
+            let fetch_results = self.fetch_results.clone();
+            let id = id.as_ref().to_string();
+            tokio::task::spawn_blocking(move || (fetch_results)(&id))
+                .await
+                .unwrap()
+        }
+    }
+}
+
 /// Allows starting, stopping and managing the results of new scans.
 pub struct Scanner<S: ScannerStack> {
     running: Arc<RwLock<HashMap<String, RunningScanHandle>>>,


### PR DESCRIPTION
Updated error handling in `get_results` to mark scans as failed if errors occur during result fetch.

Added `LambdaScannerBuilder` for testing error scenarios in fetch results.

This partially fixes things mentioned in https://github.com/greenbone/openvas-scanner/issues/1744

SC-1185