### PR TITLE
Change default ospd.sock to ospd-openvas.sock path

### DIFF
--- a/rust/src/openvasd/config.rs
+++ b/rust/src/openvasd/config.rs
@@ -110,7 +110,7 @@ pub struct OspdWrapper {
 impl Default for OspdWrapper {
     fn default() -> Self {
         OspdWrapper {
-            socket: PathBuf::from("/var/run/ospd/ospd.sock"),
+            socket: PathBuf::from("/var/run/ospd/ospd-openvas.sock"),
             read_timeout: None,
         }
     }
@@ -655,7 +655,7 @@ mod tests {
         assert_eq!(config.scheduler.check_interval, Duration::from_millis(500));
         assert_eq!(
             config.scanner.ospd.socket,
-            PathBuf::from("/var/run/ospd/ospd.sock")
+            PathBuf::from("/var/run/ospd/ospd-openvas.sock")
         );
         assert!(config.scanner.ospd.read_timeout.is_none());
 


### PR DESCRIPTION
Changes the default path of the ospd-openvas socket as it is not ospd.sock but /var/run/ospd/ospd-openvas.sock