### PR TITLE
Seperates linting/Rust into linting/{Rust, Rust-Typos, Rust-Audit}

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,12 @@
+name: "Setup Rust Environment"
+description: "Install necessary dependencies and set up Rust stable"
+runs:
+  using: "composite"
+  steps:
+    - run: sudo apt update || true
+      shell: bash
+    - run: sudo apt-get install -y libpcap-dev
+      shell: bash
+    - run: rustup update stable && rustup default stable || rustup default stable
+      shell: bash
+

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,15 +19,25 @@ jobs:
         working-directory: rust
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update || true
-      - run: sudo apt-get install -y libpcap-dev
-      - run: rustup update stable && rustup default stable || rustup default stable 
-      - run: cargo install cargo-audit
+      - uses: ./.github/actions/setup-rust
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt --check
+  Rust-Typos:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-rust
       - run: cargo install typos-cli
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-      - name: Audit
-        run: cargo audit
       - run: typos
-      - name: Formatting
-        run: cargo fmt --check
+  Rust-Audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo install cargo-audit
+      - run: cargo audit

--- a/rust/src/nasl/builtin/cryptographic/tests/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/mod.rs
@@ -10,4 +10,3 @@ mod helper;
 mod hmac;
 mod rc4;
 mod rsa;
-

--- a/rust/src/osp/response.rs
+++ b/rust/src/osp/response.rs
@@ -13,7 +13,6 @@ use super::commands::Error;
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct StringU64(u64);
 
-
 impl From<i64> for StringU64 {
     fn from(value: i64) -> Self {
         StringU64(value as u64)
@@ -734,7 +733,6 @@ mod tests {
             _ => panic!("wrong type: {:?}", response),
         }
     }
-
 
     #[test]
     fn init_response() {


### PR DESCRIPTION
Given the nature of using NASL to identify vulnerabilities we may cannot
get rif of all audit findings. To indicate that the CI fails based on an
audit, rather than e.g. a clippy warning, cargo audit is seperated into
an own job.

Since the same may be true for typos, typos are seperated into an own
job as well.

With that change we can immediately see if a CI of a PR failed because
of audit, typos or Rust linting issues.
