### PR TITLE
Add snapshot testing for statement parsing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -266,6 +266,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -658,6 +664,18 @@ name = "configparser"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57e3272f0190c3f1584272d613719ba5fc7df7f4942fe542e63d949cf3a649b"
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "const-oid"
@@ -1074,6 +1092,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1819,6 +1843,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "ron",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,6 +2137,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3094,6 +3138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3469,7 @@ dependencies = [
  "hyper 1.5.1",
  "hyper-rustls 0.27.3",
  "hyper-util",
+ "insta",
  "itertools 0.12.1",
  "lazy-regex",
  "lazy_static",
@@ -3740,6 +3796,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -107,6 +107,7 @@ members = ["crates/smoketest", "crates/nasl-function-proc-macro"]
 tracing-test = "0.2.5"
 criterion = "0"
 once_cell = "1.20.1"
+insta = { version = "1.41.1", features = ["ron"] }
 
 [features]
 dep-graph-parallel = ["rayon", "crossbeam-channel"]

--- a/rust/src/nasl/syntax/snapshots/statement_add.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_add.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a + 1

--- a/rust/src/nasl/syntax/snapshots/statement_array.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_array.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a[1]

--- a/rust/src/nasl/syntax/snapshots/statement_assign.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_assign.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a = 1

--- a/rust/src/nasl/syntax/snapshots/statement_assign_return.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_assign_return.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+--a

--- a/rust/src/nasl/syntax/snapshots/statement_block.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_block.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+{ ... }

--- a/rust/src/nasl/syntax/snapshots/statement_break.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_break.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+break

--- a/rust/src/nasl/syntax/snapshots/statement_call.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_call.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a();

--- a/rust/src/nasl/syntax/snapshots/statement_continue.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_continue.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+continue

--- a/rust/src/nasl/syntax/snapshots/statement_declare.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_declare.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+local_var a

--- a/rust/src/nasl/syntax/snapshots/statement_div.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_div.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a / 1

--- a/rust/src/nasl/syntax/snapshots/statement_exit.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_exit.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+exit(0);

--- a/rust/src/nasl/syntax/snapshots/statement_for.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_for.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+for (i = 0; i < 10; i++) { a }

--- a/rust/src/nasl/syntax/snapshots/statement_foreach.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_foreach.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+foreach a(b) {c}

--- a/rust/src/nasl/syntax/snapshots/statement_function_declaration.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_function_declaration.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+function a((b)) { ... }

--- a/rust/src/nasl/syntax/snapshots/statement_if.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_if.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+if (a) b else c

--- a/rust/src/nasl/syntax/snapshots/statement_include.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_include.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+include("test.inc");

--- a/rust/src/nasl/syntax/snapshots/statement_modulo.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_modulo.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a % 1

--- a/rust/src/nasl/syntax/snapshots/statement_mul.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_mul.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a * 1

--- a/rust/src/nasl/syntax/snapshots/statement_named_parameter.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_named_parameter.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a: b

--- a/rust/src/nasl/syntax/snapshots/statement_no_op.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_no_op.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+NoOp

--- a/rust/src/nasl/syntax/snapshots/statement_parameter.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_parameter.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+(a, b)

--- a/rust/src/nasl/syntax/snapshots/statement_primitive.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_primitive.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+1

--- a/rust/src/nasl/syntax/snapshots/statement_repeat.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_repeat.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+repeat a until b

--- a/rust/src/nasl/syntax/snapshots/statement_return.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_return.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+return 0;

--- a/rust/src/nasl/syntax/snapshots/statement_return_assign.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_return_assign.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a++

--- a/rust/src/nasl/syntax/snapshots/statement_sub.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_sub.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a - 1

--- a/rust/src/nasl/syntax/snapshots/statement_variable.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_variable.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+a

--- a/rust/src/nasl/syntax/snapshots/statement_while.snap
+++ b/rust/src/nasl/syntax/snapshots/statement_while.snap
@@ -1,0 +1,6 @@
+---
+source: src/nasl/syntax/statement.rs
+expression: stmt
+snapshot_kind: text
+---
+while (a) {b}

--- a/rust/src/nasl/syntax/token.rs
+++ b/rust/src/nasl/syntax/token.rs
@@ -6,11 +6,15 @@
 use std::fmt::Display;
 use std::ops::Range;
 
+#[cfg(test)]
+use serde::{Deserialize, Serialize};
+
 use super::cursor::Cursor;
 use crate::storage::item::ACT;
 
 /// Identifies if number is base10, base 8, hex or binary
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 pub enum Base {
     /// Base 2: contains 01 is defined by 0b e.g.: `0b010101`
     Binary,
@@ -60,6 +64,7 @@ impl Base {
 
 /// Is used to identify which Category type is unclosed
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 pub enum UnclosedCategory {
     /// Is a unclosed String.
     String,
@@ -121,6 +126,7 @@ impl Display for IdentifierType {
 
 /// Unless Dynamic those are reserved words that cannot be reused otherwise.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 pub enum IdentifierType {
     /// function declaration
     Function,
@@ -201,6 +207,7 @@ make_keyword_matcher! {
 
 /// Is used to identify a Token
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 pub enum Category {
     /// `(`
     LeftParen,
@@ -396,6 +403,7 @@ impl Display for Category {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Contains the TokenType as well as the position.
+#[cfg_attr(test, derive(Serialize, Deserialize))]
 pub struct Token {
     /// The category or kind of a token
     pub category: Category,

--- a/rust/src/nasl/utils/README.md
+++ b/rust/src/nasl/utils/README.md
@@ -7,6 +7,11 @@ This section briefly describes how to handle errors that occur during builtin fu
 
 
 ```rust
+
+type ArgumentError = String;
+struct InternalError {};
+type BuiltinError = &'static str;
+
 pub enum FnErrorKind {
     Argument(ArgumentError),
     Internal(InternalError),
@@ -26,6 +31,8 @@ As stated above, the metadata (return value, retryable) on how to handle a speci
 ### Return behavior
 The return behavior of a given error specifies how an error should be handled during execution. This is specified by the following type:
 ```rust
+use scannerlib::nasl::NaslValue;
+
 enum ReturnBehavior {
     ExitScript,
     ReturnValue(NaslValue),
@@ -34,32 +41,45 @@ enum ReturnBehavior {
 When the interpreter encounters an error with `ReturnBehavior::ExitScript` behavior, it will unsurprisingly exit the script. If it encounters an error with `ReturnBehavior::ReturnValue(val)`, it will return `val` and continue execution.
 
 In the corresponding `From` impls, the `Argument` and `Internal` variants of `FnError` are automatically constructed with `ReturnBehavior::ExitScript`, meaning that they abort execution of the script. The `Builtin` variant is constructed with `ReturnBehavior::ReturnValue(NaslValue::Null)` by default, but this value can easily be overwritten when the error is created, for example:
-```rust
+```rust,compile_fail
+
+use scannerlib::nasl::prelude::*;
+use scannerlib::nasl::builtin::http::HttpError;
+
+let handle = "/vts".to_string();
+
 HttpError::HandleIdNotFound(handle).with(ReturnValue(-1))
 ```
 
 ### Retry behavior
 Certain errors can be flagged as being solvable by retrying the operation that caused them. This is represented by a `retryable` boolean on `FnError`, which is `false` by default for all variants except for a specific internal error in the storage. However, this default behavior can be overwritten at error creation if needed, for example
-```rust
-HttpError::ConnectionFailed(...).with(Retryable)
+```rust,compile_fail
+
+use scannerlib::nasl::prelude::*;
+use scannerlib::nasl::builtin::http::HttpError;
+
+HttpError::IO(std::io::ErrorKind::ConnectionReset).with(Retryable)
 ```
 I also added a small test to make sure that the interpreter does actually retry retryable errors.
 
 ## How to add a new error type for a builtin module
 1. Add a custom error type for the builtin module. These can be of arbitrary form but a typical error type might look like
 ```rust
+use scannerlib::nasl::prelude::*;
+use thiserror::Error;
+
 #[derive(Debug, Error)]
 enum FooError {
     #[error("Bar occurred.")]
     Bar,
     #[error("Baz occurred. Here is some more data: {0}")]
-    Baz(SomeData),
+    Baz(String),
 }
 ```
 This helps with keeping the error messages all in one place to ensure a common form.
 
 2. Add this builtin error as a variant of the `BuiltinError` type described above.
-```rust
+```rust,compile_fail
 enum BuiltinError {
     ...
     Foo(FooError),
@@ -68,12 +88,12 @@ enum BuiltinError {
 ```
 
 3. For convenience, some `From` impls and `TryFrom` impls can make the error type easier to use by enabling use of the question mark operator. I added a tiny macro that implements these traits (because the implementations are usually trivial), so this comes down to one line too:
-```
+```compile_fail
 builtin_error_variant!(Foo, FooError);
 ```
 
 This is all that is needed to make this error usable in NASL functions:
-```rust
+```rust,compile_fail
 fn check(a: usize) -> Result<(), FooError> {
     if a == 0 {
         Err(FooError::Bar)
@@ -92,7 +112,7 @@ fn foo(a: usize) -> Result<usize, FnError> {
 
 As a side note, NASL functions can also return any concrete `impl Into<FnError>` directly, so for this case we can also write
 
-```rust
+```rust,compile_fail
 #[nasl_function]
 fn foo(a: usize) -> Result<usize, FooError> {
     if a == 0 { 
@@ -106,7 +126,7 @@ fn foo(a: usize) -> Result<usize, FooError> {
 
 Note that the above `From` impls that are automatically written by the `builtin_error_variant!` macro can also be manually implemented if one wants to specify defaults for a specific error variant. For example
 
-```rust
+```rust,compile_fail
 impl From<FooError> for FnError {
     fn from(e: FooError) -> FnError {
         match e {

--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -97,7 +97,7 @@ where
 
                 // prepare vt preferences
                 for pref in &vt.parameters {
-                    if let Some((prefid, class, name, value)) =
+                    if let Some((prefid, class, name, _value)) =
                         nvt.preferences.iter().find_map(|p| {
                             if let Some(i) = p.id {
                                 if i as u16 == pref.id {


### PR DESCRIPTION
For statements it is hard to write any unit tests, as a statement is a rather complex struct also containing some meta information. It is much easier to test the statement parsing, looking at the generated statement and review it instead.