### PR TITLE
Fix: `get_version()` of packages containing the epoch

### DIFF
--- a/rust/src/notus/packages/ebuild.rs
+++ b/rust/src/notus/packages/ebuild.rs
@@ -10,8 +10,7 @@ use super::{Package, PackageVersion};
 #[derive(Debug, PartialEq, Clone)]
 pub struct EBuild {
     name: String,
-    full_name: String,
-    full_version: PackageVersion,
+    version: PackageVersion,
 }
 
 impl PartialOrd for EBuild {
@@ -20,11 +19,7 @@ impl PartialOrd for EBuild {
             return None;
         }
 
-        if self.full_version == other.full_version {
-            return Some(Ordering::Equal);
-        }
-
-        self.full_version.partial_cmp(&other.full_version)
+        self.version.partial_cmp(&other.version)
     }
 }
 
@@ -54,8 +49,7 @@ impl Package for EBuild {
 
         Some(EBuild {
             name,
-            full_name: full_name.to_string(),
-            full_version: PackageVersion(full_version),
+            version: PackageVersion(full_version),
         })
     }
 
@@ -65,14 +59,10 @@ impl Package for EBuild {
         }
         let name = name.trim();
         let full_version = full_version.trim();
-        let mut full_name = name.to_owned();
-        full_name.push('-');
-        full_name.push_str(full_version);
 
         Some(EBuild {
             name: name.to_string(),
-            full_name,
-            full_version: PackageVersion(full_version.to_string()),
+            version: PackageVersion(full_version.to_string()),
         })
     }
 
@@ -81,7 +71,7 @@ impl Package for EBuild {
     }
 
     fn get_version(&self) -> String {
-        self.full_version.0.clone()
+        self.version.0.clone()
     }
 }
 


### PR DESCRIPTION
Fix: `get_version()` of packages containing the epoch resulted in a leading `0:`

The leading `0:` is confusing when in the compared version this is not contained, even though it means the same thing, as a missing epoch is the same as `0`.

Additionally this contains a small refractoring of the package modules of notus, which removes duplicated data within the package struct. `full_version` contained the information of different version parts in a single string. This is now generated on demand from the available information with `get_version()`.

The following test failed in the old implementation as, the `get_version()` returned the following string `0:0.60.6.1-18.3.1.x86_64`.
```rust
let package = Rpm::from_full_name("libaspell15-0.60.6.1-18.3.1.x86_64").unwrap();
assert_eq!(package.epoch, 0);
assert_eq!(package.arch, "x86_64");
assert_eq!(package.name, "libaspell15");
assert_eq!(package.version, PackageVersion("0.60.6.1".to_string()));
assert_eq!(package.release, PackageVersion("18.3.1".to_string()));
assert_eq!(package.get_version(), "0.60.6.1-18.3.1.x86_64");
```

Jira: SC-1199
