### PR TITLE
Add: markdown code block langs

### DIFF
--- a/rust/doc/faq/progress-calculation.md
+++ b/rust/doc/faq/progress-calculation.md
@@ -2,7 +2,7 @@
 
 The required information for the progress calculation will be always provided by `openvasd`, via the route `scan/{scan-id}/status`.
 You get a json object which looks like as following:
-```
+```json
 {
   "start_time": 1709111465,
   "end_time": 1709111496,
@@ -42,7 +42,7 @@ In this case, a resume scan with some finished hosts, should not start with a pr
 Then, imagine that the scan of example above, with an initial target of 15 hosts, was stopped/interrupted and you want to resume it. It has an already finished hosts. This hosts is added to the list of `excluded hosts`.
 At the beginning of the resumed scan you have:
 
-```
+```json
 {
   "start_time": 1709111465,
   "end_time": 1709111496,

--- a/rust/doc/faq/resume-scan.md
+++ b/rust/doc/faq/resume-scan.md
@@ -6,7 +6,7 @@ To do that, you start a scan, collect all results with the type `host_end`, and 
 
 As an example, we create a scan to scan the hosts `127.0.0.1`, `localhost` with the following `scan.json`:
 
-```
+```json
 {
   "target": {
     "hosts": [
@@ -45,14 +45,14 @@ As an example, we create a scan to scan the hosts `127.0.0.1`, `localhost` with 
 
 we create the scan and start it:
 
-```
+```sh
 curl -k --cert $CERT --key $KEY "https://localhost/scans" -d @scan.json
 curl -k --cert $CERT --key $KEY "https://localhost/scans/$ID" -d "{ \"action\": \"start\"}"
 curl -k --cert $CERT --key $KEY "https://localhost/scans/$ID" 
 ```
 
 The results contain something like:
-```
+```json
 ...
   {
     "id": 2,
@@ -67,13 +67,13 @@ The type `host_end` indicates that a host was scanned.
 
 
 Then we stop it:
-```
+```sh
 curl -k --cert $CERT --key $KEY "https://localhost/scans/$ID" -d "{ \"action\": \"stop\"}"
 ```
 
 We assume that when we stopped it, it just scanned `127.0.0.1`, so we create a scan with it excluded in hosts:
 
-```
+```json
 {
   "target": {
     "hosts": [
@@ -114,7 +114,7 @@ We assume that when we stopped it, it just scanned `127.0.0.1`, so we create a s
 
 when creating the new scan and starting it, it should not scan `127.0.0.1` again.
 
-```
+```sh
 curl -k --cert $CERT --key $KEY "https://localhost/scans" -d @scan.json
 curl -k --cert $CERT --key $KEY "https://localhost/scans/$ID" -d "{ \"action\": \"start\"}"
 curl -k --cert $CERT --key $KEY "https://localhost/scans/$ID" 

--- a/rust/doc/misc/progress-calculation-details.md
+++ b/rust/doc/misc/progress-calculation-details.md
@@ -39,7 +39,7 @@ The same happens with a dead hosts when it is found as dead during the scan. The
 Suppose a target with 15 hosts and 3 from the list are excluded. `openvas` found a total of 12 hosts. Also, during the alive test scan with `Boreas`, or even during the scan, 2 hosts where found dead.
 One hosts is already scanned, and 2 hosts are currently being scanned.
 
-```
+```json
 {
   "start_time": 1709111465,
   "end_time": 1709111496,
@@ -80,7 +80,7 @@ In this case, a resume scan with some finished hosts, should not start with a pr
 Then, imagine that the scan of example above, with an initial target of 15 hosts, was stopped/interrupted and you want to resume it. It has an already finished hosts. This hosts is added to the list of `excluded hosts`.
 At the beginning of the resumed scan you have:
 
-```
+```json
 {
   "start_time": 1709111465,
   "end_time": 1709111496,
@@ -96,7 +96,6 @@ At the beginning of the resumed scan you have:
     ]
   }
 }
-
 ``` 
 
 As you already know the amount of finished hosts, you use this value for the progress calculation. You have to add the finished hosts to the total amount of hosts and the add them also to the `count_alive`, because in the end, they were already scanned and finished.

--- a/rust/src/feed/README.md
+++ b/rust/src/feed/README.md
@@ -21,7 +21,7 @@ Also, implements a `signature verifier` for checking the signature of the sha256
 
 ### Example
 
-```rs,no_run
+```rust,no_run
 use scannerlib::nasl::FSPluginLoader;
 // needs to be path that contains a sha256sums file otherwise
 // it will throw an exception.

--- a/rust/src/nasl/builtin/README.md
+++ b/rust/src/nasl/builtin/README.md
@@ -6,7 +6,7 @@ To use the std functions it is recommended to use the defined `ContextFactory` a
 
 All you have to do as a user is to create the builder
 
-```
+```rs
 let cb = scannerlib::nasl::ContextFactory::default();
 ```
 
@@ -14,7 +14,7 @@ and set all but the functions. This will use the InMemoryStorage as well as an e
 
 For production use cases it is recommended to use new method and include a key and a storage:
 
-```
+```rs
 let loader = scannerlib::nasl::FSPluginLoader::new("/feed");
 let storage = scannerlib::storage::inmemory::InMemoryStorage::default();
 let cb = scannerlib::nasl::ContextFactory::new(loader, storage);
@@ -46,7 +46,7 @@ For this purpose, it is possible to add predefined variables to the Register. Th
 
 All you have to do is to create a builder for the register:
 
-```
+```rs
 let mut register = scannerlib::nasl::RegisterBuilder::build();
 ```
 

--- a/rust/src/nasl/builtin/README.md
+++ b/rust/src/nasl/builtin/README.md
@@ -6,7 +6,7 @@ To use the std functions it is recommended to use the defined `ContextFactory` a
 
 All you have to do as a user is to create the builder
 
-```rs
+```rust
 let cb = scannerlib::nasl::ContextFactory::default();
 ```
 
@@ -14,7 +14,7 @@ and set all but the functions. This will use the InMemoryStorage as well as an e
 
 For production use cases it is recommended to use new method and include a key and a storage:
 
-```rs
+```rust
 let loader = scannerlib::nasl::FSPluginLoader::new("/feed");
 let storage = scannerlib::storage::inmemory::InMemoryStorage::default();
 let cb = scannerlib::nasl::ContextFactory::new(loader, storage);
@@ -46,7 +46,7 @@ For this purpose, it is possible to add predefined variables to the Register. Th
 
 All you have to do is to create a builder for the register:
 
-```rs
+```rust
 let mut register = scannerlib::nasl::RegisterBuilder::build();
 ```
 

--- a/rust/src/nasl/builtin/cryptographic/README.md
+++ b/rust/src/nasl/builtin/cryptographic/README.md
@@ -6,7 +6,7 @@ It is part of the std lib which is proven by the tests.
 
 To use this module you have to initiate Cryptographic and look for the function:
 
-```
+```rs
 let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
     .push_register(nasl_builtin_cryptographic::Cryptographic)
     .build();

--- a/rust/src/nasl/builtin/cryptographic/README.md
+++ b/rust/src/nasl/builtin/cryptographic/README.md
@@ -6,7 +6,7 @@ It is part of the std lib which is proven by the tests.
 
 To use this module you have to initiate Cryptographic and look for the function:
 
-```rs
+```rust
 let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
     .push_register(nasl_builtin_cryptographic::Cryptographic)
     .build();

--- a/rust/src/nasl/builtin/description/README.md
+++ b/rust/src/nasl/builtin/description/README.md
@@ -4,7 +4,7 @@ It is part of the std which is proven in the tests.
 
 To use this module you have to initiate `Description` and look for the function:
 
-```rs
+```rust
 let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
     .push_register(nasl_builtin_description::Description)
     .build();

--- a/rust/src/nasl/builtin/description/README.md
+++ b/rust/src/nasl/builtin/description/README.md
@@ -4,7 +4,7 @@ It is part of the std which is proven in the tests.
 
 To use this module you have to initiate `Description` and look for the function:
 
-```
+```rs
 let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
     .push_register(nasl_builtin_description::Description)
     .build();

--- a/rust/src/nasl/interpreter/README.md
+++ b/rust/src/nasl/interpreter/README.md
@@ -17,7 +17,7 @@ An interpreter requires:
 
 ## Example
 
-```rs
+```rust
 use scannerlib::nasl::interpreter::{CodeInterpreter};
 use scannerlib::nasl::prelude::*;
 use scannerlib::storage::ScanID;

--- a/rust/src/nasl/interpreter/README.md
+++ b/rust/src/nasl/interpreter/README.md
@@ -17,7 +17,7 @@ An interpreter requires:
 
 ## Example
 
-```
+```rs
 use scannerlib::nasl::interpreter::{CodeInterpreter};
 use scannerlib::nasl::prelude::*;
 use scannerlib::storage::ScanID;

--- a/rust/src/nasl/syntax/README.md
+++ b/rust/src/nasl/syntax/README.md
@@ -9,7 +9,7 @@ Each statement is self contained and it is expected to be executed iteratively a
 
 ## Usage
 
-```rs
+```rust
 use scannerlib::nasl::syntax::{Statement, SyntaxError};
 let statements =
 scannerlib::nasl::syntax::parse("a = 23;b = 1;")

--- a/rust/src/nasl/syntax/README.md
+++ b/rust/src/nasl/syntax/README.md
@@ -9,7 +9,7 @@ Each statement is self contained and it is expected to be executed iteratively a
 
 ## Usage
 
-```
+```rs
 use scannerlib::nasl::syntax::{Statement, SyntaxError};
 let statements =
 scannerlib::nasl::syntax::parse("a = 23;b = 1;")

--- a/rust/src/storage/infisto/README.md
+++ b/rust/src/storage/infisto/README.md
@@ -6,7 +6,7 @@ Is a library to store data on to disk and fetch elements from that rather than l
 
 Caches the last files idx files into memory.
 
-```
+```rs
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_cached";
@@ -24,7 +24,7 @@ store.remove(name).unwrap();
 
 Encryptes the given data with chacha20 before storing it.
 
-```
+```rs
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_crypt";
@@ -44,7 +44,7 @@ store.remove(name).unwrap();
 
 Instead of loading all elements at once it allows to fetch single elements when required.
  
-```
+```rs
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_iter";

--- a/rust/src/storage/infisto/README.md
+++ b/rust/src/storage/infisto/README.md
@@ -6,7 +6,7 @@ Is a library to store data on to disk and fetch elements from that rather than l
 
 Caches the last files idx files into memory.
 
-```rs
+```rust
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_cached";
@@ -24,7 +24,7 @@ store.remove(name).unwrap();
 
 Encryptes the given data with chacha20 before storing it.
 
-```rs
+```rust
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_crypt";
@@ -44,7 +44,7 @@ store.remove(name).unwrap();
 
 Instead of loading all elements at once it allows to fetch single elements when required.
  
-```rs
+```rust
 use scannerlib::storage::infisto::IndexedByteStorage;
 let base = "/tmp/openvasd/storage";
 let name = "readme_iter";

--- a/rust/src/storage/infisto/json/README.md
+++ b/rust/src/storage/infisto/json/README.md
@@ -74,7 +74,7 @@ Transforms a NVT to the json structure:
 
 To create a single json element per dispatch you can use the JsonStorage with a writer of your choice:
 
-```
+```rs
 let mut buf = Vec::with_capacity(1208);
 let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut buf);
 ```
@@ -83,7 +83,7 @@ let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut buf);
 
 To create an array for elements per dispatch call:
 
-```
+```rs
 let mut buf = Vec::with_capacity(1208);
 let mut ja = scannerlib::storage::infisto::json::ArrayWrapper::new(&mut buf);
 let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut ja);

--- a/rust/src/storage/infisto/json/README.md
+++ b/rust/src/storage/infisto/json/README.md
@@ -74,7 +74,7 @@ Transforms a NVT to the json structure:
 
 To create a single json element per dispatch you can use the JsonStorage with a writer of your choice:
 
-```rs
+```rust
 let mut buf = Vec::with_capacity(1208);
 let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut buf);
 ```
@@ -83,7 +83,7 @@ let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut buf);
 
 To create an array for elements per dispatch call:
 
-```rs
+```rust
 let mut buf = Vec::with_capacity(1208);
 let mut ja = scannerlib::storage::infisto::json::ArrayWrapper::new(&mut buf);
 let dispatcher = scannerlib::storage::infisto::json::JsonStorage::new(&mut ja);


### PR DESCRIPTION
**What**:

Add languages to \`\`\` blocks in Markdown files in the Rust tree.

**Why**:

Enables syntax highlighting.

