### PR TITLE
Fix clippy lints for 1.83 and experimental build

### DIFF
--- a/rust/src/feed/transpile/mod.rs
+++ b/rust/src/feed/transpile/mod.rs
@@ -160,7 +160,7 @@ struct FunctionNameMatcher<'a> {
     parameter: Option<&'a [FindParameter]>,
 }
 
-impl<'a> FunctionNameMatcher<'a> {
+impl FunctionNameMatcher<'_> {
     fn is_function(&self, s: &Statement) -> bool {
         match s.kind() {
             StatementKind::Exit(..) => self.name.map(|x| x == "exit").unwrap_or(true),
@@ -190,7 +190,7 @@ impl<'a> FunctionNameMatcher<'a> {
     }
 }
 
-impl<'a> Matcher for FunctionNameMatcher<'a> {
+impl Matcher for FunctionNameMatcher<'_> {
     fn matches(&self, s: &Statement) -> bool {
         if !self.is_function(s) {
             return false;
@@ -644,9 +644,9 @@ pub struct FeedReplacer<'a> {
     replace: &'a [ReplaceCommand],
 }
 
-impl<'a> FeedReplacer<'a> {
+impl FeedReplacer<'_> {
     /// Creates a new FeedReplacer
-    pub fn new<S>(root: S, replace: &'a [ReplaceCommand]) -> FeedReplacer<'_>
+    pub fn new<S>(root: S, replace: &[ReplaceCommand]) -> FeedReplacer
     where
         S: AsRef<str>,
     {
@@ -670,7 +670,7 @@ impl<'a> FeedReplacer<'a> {
     }
 }
 
-impl<'a> Iterator for FeedReplacer<'a> {
+impl Iterator for FeedReplacer<'_> {
     type Item = Result<Option<(String, String)>, TranspileError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -329,7 +329,7 @@ pub struct HashSumFileItem<'a> {
     reader: &'a FSPluginLoader,
 }
 
-impl<'a> HashSumFileItem<'a> {
+impl HashSumFileItem<'_> {
     /// Verifies Hashsum
     pub fn verify(&self) -> Result<(), Error> {
         let hashsum = self.hasher.hash(

--- a/rust/src/nasl/builtin/cert/mod.rs
+++ b/rust/src/nasl/builtin/cert/mod.rs
@@ -286,7 +286,7 @@ impl NaslCerts {
     ///
     /// - issuer Returns the issuer.  The returned value is a string in
     ///             rfc-2253 format.
-
+    ///
     /// - subject Returns the subject. The returned value is a string in
     ///              rfc-2253 format.  To query the subjectAltName the
     ///              named parameters @a idx with values starting at 1 can

--- a/rust/src/nasl/builtin/cryptographic/bf_cbc.rs
+++ b/rust/src/nasl/builtin/cryptographic/bf_cbc.rs
@@ -76,7 +76,6 @@ where
 /// The return value is an array a with a[0] being the encrypted data and
 /// a[1] the new initialization vector to use for the next part of the
 /// data.
-
 fn bf_cbc_encrypt(register: &Register, _: &Context) -> Result<NaslValue, FunctionErrorKind> {
     cbc::<Blowfish>(register, Crypt::Encrypt)
 }

--- a/rust/src/nasl/builtin/host/mod.rs
+++ b/rust/src/nasl/builtin/host/mod.rs
@@ -48,7 +48,7 @@ fn get_host_names(context: &Context) -> Result<NaslValue, FunctionErrorKind> {
 }
 
 /// Return the target's IP address as IpAddr.
-fn get_host_ip(context: &Context) -> Result<IpAddr, FunctionErrorKind> {
+pub fn get_host_ip(context: &Context) -> Result<IpAddr, FunctionErrorKind> {
     let default_ip = "127.0.0.1";
     let r_sock_addr = match context.target() {
         x if !x.is_empty() => IpAddr::from_str(x),

--- a/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
@@ -2300,7 +2300,7 @@ fn nasl_send_capture(
             let frame = EthernetPacket::new(packet.data).ok_or_else(|| {
                 FunctionErrorKind::Dirty("No possible to create a packet from buffer".to_string())
             })?;
-            return Ok(NaslValue::Data(frame.payload().to_vec()));
+            Ok(NaslValue::Data(frame.payload().to_vec()))
         }
         Err(_) => Ok(NaslValue::Null),
     }

--- a/rust/src/nasl/builtin/ssh/mod.rs
+++ b/rust/src/nasl/builtin/ssh/mod.rs
@@ -250,7 +250,7 @@ impl Ssh {
     /// If the private key is protected, its passphrase is taken from the
     /// named argument "passphrase" or, if not given, taken from the KB
     /// ("Secret/SSH/passphrase").
-
+    ///
     /// Note that the named argument "publickey" and the KB item
     /// ("Secret/SSH/publickey") are ignored - they are not longer required
     /// because they can be derived from the private key.

--- a/rust/src/nasl/interpreter/assign.rs
+++ b/rust/src/nasl/interpreter/assign.rs
@@ -39,7 +39,7 @@ fn prepare_dict(left: NaslValue) -> HashMap<String, NaslValue> {
     }
 }
 
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     fn save(&mut self, idx: usize, key: &str, value: NaslValue) {
         self.register_mut()
             .add_to_index(idx, key, ContextType::Value(value));

--- a/rust/src/nasl/interpreter/declare.rs
+++ b/rust/src/nasl/interpreter/declare.rs
@@ -18,7 +18,7 @@ pub(crate) trait DeclareFunctionExtension {
     ) -> InterpretResult;
 }
 
-impl<'a> DeclareFunctionExtension for Interpreter<'a> {
+impl DeclareFunctionExtension for Interpreter<'_> {
     fn declare_function(
         &mut self,
         name: &Token,
@@ -46,7 +46,7 @@ pub(crate) trait DeclareVariableExtension {
     fn declare_variable(&mut self, scope: &Token, stmts: &[Statement]) -> InterpretResult;
 }
 
-impl<'a> DeclareVariableExtension for Interpreter<'a> {
+impl DeclareVariableExtension for Interpreter<'_> {
     fn declare_variable(&mut self, scope: &Token, stmts: &[Statement]) -> InterpretResult {
         let mut add = |key: &str| {
             let value = ContextType::Value(NaslValue::Null);

--- a/rust/src/nasl/syntax/grouping_extension.rs
+++ b/rust/src/nasl/syntax/grouping_extension.rs
@@ -20,7 +20,7 @@ pub(crate) trait Grouping {
     fn parse_grouping(&mut self, token: Token) -> Result<(End, Statement), SyntaxError>;
 }
 
-impl<'a> Grouping for Lexer<'a> {
+impl Grouping for Lexer<'_> {
     fn parse_paren(&mut self, token: Token) -> Result<Statement, SyntaxError> {
         let (end, right) = self.statement(0, &|cat| cat == &Category::RightParen)?;
 

--- a/rust/src/nasl/syntax/keyword_extension.rs
+++ b/rust/src/nasl/syntax/keyword_extension.rs
@@ -22,7 +22,7 @@ pub(crate) trait Keywords {
     ) -> Result<(End, Statement), SyntaxError>;
 }
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     fn parse_declaration(&mut self, token: Token) -> Result<Statement, SyntaxError> {
         let (end, params) = self.parse_comma_group(Category::Semicolon)?;
         match end {
@@ -425,7 +425,7 @@ impl<'a> Lexer<'a> {
     }
 }
 
-impl<'a> Keywords for Lexer<'a> {
+impl Keywords for Lexer<'_> {
     fn parse_keyword(
         &mut self,
         keyword: IdentifierType,

--- a/rust/src/nasl/syntax/lexer.rs
+++ b/rust/src/nasl/syntax/lexer.rs
@@ -348,7 +348,7 @@ impl<'a> Lexer<'a> {
     }
 }
 
-impl<'a> Iterator for Lexer<'a> {
+impl Iterator for Lexer<'_> {
     type Item = Result<Statement, SyntaxError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/src/nasl/syntax/prefix_extension.rs
+++ b/rust/src/nasl/syntax/prefix_extension.rs
@@ -34,7 +34,7 @@ fn prefix_binding_power(token: &Token) -> Result<u8, SyntaxError> {
     }
 }
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
     fn parse_variable(&mut self, token: Token) -> Result<(End, Statement), SyntaxError> {
         if !matches!(
             token.category(),
@@ -110,7 +110,7 @@ impl<'a> Lexer<'a> {
     }
 }
 
-impl<'a> Prefix for Lexer<'a> {
+impl Prefix for Lexer<'_> {
     fn prefix_statement(
         &mut self,
         token: Token,

--- a/rust/src/nasl/syntax/token.rs
+++ b/rust/src/nasl/syntax/token.rs
@@ -743,7 +743,7 @@ macro_rules! two_symbol_token {
     };
 }
 
-impl<'a> Iterator for Tokenizer<'a> {
+impl Iterator for Tokenizer<'_> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -11,7 +11,7 @@ use super::hosts::resolve;
 use super::{executor::Executor, lookup_keys::FC_ANON_ARGS};
 
 /// Contexts are responsible to locate, add and delete everything that is declared within a NASL plugin
-
+///
 /// Represents a Value within the NaslContext
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ContextType {
@@ -171,7 +171,7 @@ impl Register {
     }
 
     /// Finds a named ContextType
-    pub fn named<'a>(&'a self, name: &'a str) -> Option<&ContextType> {
+    pub fn named<'a>(&'a self, name: &'a str) -> Option<&'a ContextType> {
         self.blocks
             .last()
             .and_then(|x| x.named(self, name))
@@ -179,7 +179,7 @@ impl Register {
     }
 
     /// Finds a named ContextType with index
-    pub fn index_named<'a>(&'a self, name: &'a str) -> Option<(usize, &ContextType)> {
+    pub fn index_named<'a>(&'a self, name: &'a str) -> Option<(usize, &'a ContextType)> {
         self.blocks.last().and_then(|x| x.named(self, name))
     }
 
@@ -321,7 +321,7 @@ impl NaslContext {
         &'a self,
         registrat: &'a Register,
         name: &'a str,
-    ) -> Option<(usize, &ContextType)> {
+    ) -> Option<(usize, &'a ContextType)> {
         // first check local
         match self.defined.get(name) {
             Some(ctx) => Some((self.id, ctx)),

--- a/rust/src/nasl/utils/function/from_nasl_value.rs
+++ b/rust/src/nasl/utils/function/from_nasl_value.rs
@@ -21,7 +21,7 @@ impl<'a> FromNaslValue<'a> for &'a NaslValue {
     }
 }
 
-impl<'a> FromNaslValue<'a> for String {
+impl FromNaslValue<'_> for String {
     fn from_nasl_value(value: &NaslValue) -> Result<Self, FunctionErrorKind> {
         match value {
             NaslValue::String(string) => Ok(string.to_string()),

--- a/rust/src/openvas/cmd.rs
+++ b/rust/src/openvas/cmd.rs
@@ -7,9 +7,10 @@ use std::{
     io::Result,
     process::{Child, Command},
 };
+
 /// This module provides functions to call the openvas executable for different
 /// purposes, e.g. start or stopping a scan.
-
+///
 /// Check if it is possible to start openvas.
 pub fn check() -> bool {
     Command::new("openvas").spawn().is_ok()

--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -27,7 +27,7 @@ pub enum ScanCommand<'a> {
 type Result<T> = std::result::Result<T, Error>;
 type Writer = quick_xml::Writer<Cursor<Vec<u8>>>;
 
-impl<'a> ScanCommand<'a> {
+impl ScanCommand<'_> {
     fn as_byte_response(
         scan_id: &str,
         element_name: &str,

--- a/rust/src/osp/response.rs
+++ b/rust/src/osp/response.rs
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for StringF32 {
         D: serde::Deserializer<'de>,
     {
         struct MyVisitor;
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = StringF32;
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("string")
@@ -107,7 +107,7 @@ impl<'de> Deserialize<'de> for StringU64 {
         D: serde::Deserializer<'de>,
     {
         struct MyVisitor;
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = StringU64;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/rust/src/scheduling/mod.rs
+++ b/rust/src/scheduling/mod.rs
@@ -147,7 +147,7 @@ pub type ConcurrentVTResult = Result<ConcurrentVT, VTError>;
 /// data.
 /// See: issues/63063 impl Trait in type aliases is unstable
 /// type ExecutionPlanerResult = Result<impl Iterator<Item = ConcurrentVTResult>, VTError>;
-
+///
 /// Is used by a ExecutionPlaner to order VTs in a specific manner and be returned.
 ///
 /// It is meant to be used as an Iterator by the caller of ExecutionPlaner while the

--- a/rust/src/storage/redis/connector.rs
+++ b/rust/src/storage/redis/connector.rs
@@ -278,7 +278,7 @@ pub trait RedisAddAdvisory: RedisWrapper {
     /// Add an NVT in the redis cache.
     ///
     /// The NVT metadata is stored in two different keys:
-
+    ///
     /// - 'nvt:<OID>': stores the general metadata ordered following the KbNvtPos indexes
     /// - 'oid:<OID>:prefs': stores the plugins preferences, including the script_timeout
     ///   (which is especial and uses preferences id 0)
@@ -479,11 +479,11 @@ pub trait RedisAddNvt: RedisWrapper {
         // The string ", " is not accepted as reference value, since it will misunderstood
         // as ref separator.
 
-        return (
+        (
             cves.iter().as_ref().join(", "),
             bids.iter().as_ref().join(", "),
             xrefs.iter().as_ref().join(", "),
-        );
+        )
     }
 
     /// Transforms prefs to string representation {id}:{name}:{id}:{default} so that it can be stored into redis
@@ -509,7 +509,7 @@ pub trait RedisAddNvt: RedisWrapper {
     /// Add an NVT in the redis cache.
     ///
     /// The NVT metadata is stored in two different keys:
-
+    ///
     /// - 'nvt:<OID>': stores the general metadata ordered following the KbNvtPos indexes
     /// - 'oid:<OID>:prefs': stores the plugins preferences, including the script_timeout
     ///   (which is especial and uses preferences id 0)


### PR DESCRIPTION
Mostly two lints:
1. non-elided lifetimes in impl blocks
2. empty lines after (or within docstrings).

Also fixes a tiny issue with the `experimental` feature gate not building since #1758 