### PR TITLE
Fix `exit` behavior in scannerctl

### DIFF
--- a/rust/src/scannerctl/interpret/mod.rs
+++ b/rust/src/scannerctl/interpret/mod.rs
@@ -134,11 +134,8 @@ where
             .build(ContextKey::Scan(self.scan_id.clone(), target));
         let register = RegisterBuilder::build();
         let code = self.load(script)?;
-        let results: Vec<_> = CodeInterpreter::new(&code, register, &context)
-            .stream()
-            .collect()
-            .await;
-        for result in results {
+        let mut results = CodeInterpreter::new(&code, register, &context).stream();
+        while let Some(result) = results.next().await {
             let r = match result {
                 Ok(x) => x,
                 Err(e) => match &e.kind {


### PR DESCRIPTION
Running a script like

```
display("foo");
exit(3);
display("bar");
```

with `scannerctl execute script` would result in "foo" and "bar" being printed. This was because all statements were interpreted first, their respective results collected into a `Vec` and `scannerctl` would then iterate over the results and log them. This is clearly not the intended behavior, since it causes all side effects in the builtin functions to run regardless of whether the script exits or not.

This commit fixes this bug by iterating over the results that the stream returns and exiting when `NaslValue::Exit` is encountered, causing any subsequent statements not to run.