### PR TITLE
Improve various error messages

### DIFF
--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -164,7 +164,8 @@ where
     let helper = VHelper::new(gnupghome);
 
     let sign_path = path.as_ref().to_path_buf().join("sha256sums.asc");
-    let mut sig_file = File::open(sign_path).unwrap();
+    let mut sig_file = File::open(&sign_path)
+        .unwrap_or_else(|e| panic!("Could not find signature at {sign_path:?}. {e}"));
     let mut signature = Vec::new();
     let _ = sig_file.read_to_end(&mut signature);
 

--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -39,7 +39,7 @@ pub enum Error {
     #[error("Incorrect feed.")]
     /// Corrupt sums file
     SumsFileCorrupt(Hasher),
-    #[error("Unable to load the file.")]
+    #[error("Unable to load file: {0}")]
     /// Unable to load the file
     LoadError(#[from] LoadError),
     #[error("Invalid hash for file with key '{key}'. Expected '{expected}', found '{actual}'.")]

--- a/rust/src/openvasd/config.rs
+++ b/rust/src/openvasd/config.rs
@@ -333,9 +333,10 @@ impl Config {
 
     fn from_file<P>(path: P) -> Self
     where
-        P: AsRef<std::path::Path> + std::fmt::Display,
+        P: AsRef<std::path::Path> + std::fmt::Display + std::fmt::Debug,
     {
-        let config = std::fs::read_to_string(path).unwrap();
+        let config = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("Failed to read openvasd config from file: {path:?}. {e}"));
         toml::from_str(&config).unwrap()
     }
 

--- a/rust/src/storage/redis/dberror.rs
+++ b/rust/src/storage/redis/dberror.rs
@@ -47,7 +47,7 @@ impl From<RedisError> for DbError {
             | ErrorKind::InvalidClientConfig
             | ErrorKind::Moved
             | ErrorKind::Ask => DbError::ConfigurationError(err.to_string()),
-            ErrorKind::IoError => DbError::PoisonedLock(err.to_string()),
+            ErrorKind::IoError => DbError::IoError(err.to_string()),
             ErrorKind::TypeError
             | ErrorKind::ClientError
             | ErrorKind::CrossSlot


### PR DESCRIPTION
Tiny improvement in `openvasd` and `scannerctl` error messages which weren't as helpful as they could be:

Example error message before:
```
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Error message after:
```
thread 'main' panicked at src/openvasd/config.rs:339:33:
Failed to read openvasd config from file: "openvasd.toml". No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
 