### PR TITLE
Fix: VT preferences

### DIFF
--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -113,7 +113,7 @@ where
                         let value_aux: String = if class == *"checkbox" {
                             bool_to_str(&pref.value)
                         } else {
-                            value
+                            pref.value.to_string()
                         };
 
                         pref_list.insert(


### PR DESCRIPTION
When checking the preferences for VTs set by the user, it used the value provided by the script itself instead the one provided by the user (except for type checkbox), so many values were not set to an empty string.

SC-1211
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
