### PR TITLE
Adds retry_* convenience functions to Retriever

### DIFF
--- a/rust/src/storage/mod.rs
+++ b/rust/src/storage/mod.rs
@@ -172,6 +172,8 @@ pub enum StorageError {
     /// Informs the caller to retry the call
     #[error("There was a temporary issue while reading: {0}")]
     Retry(String),
+    #[error("Retries exhausted")]
+    RetryExhausted,
     /// The connection to a DB was lost.
     ///
     /// The default solution in those cases are most of the times to try a reconnect.


### PR DESCRIPTION
When working on parts that don't necesseraly run through the interpreter it can be handy to not having to write the retry functionality when trying to retrieve information from a storage device.

For those cases the new functions:

- retry_retrieve
- retry_retrieve_by_field
- retry_retrieve_by_fields

are introduced.
