### PR TITLE
Interpreter benchmark

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -160,3 +160,7 @@ harness = false
 [[bench]]
 name = "nasl_syntax_parse"
 harness = false
+
+[[bench]]
+name = "interpreter"
+harness = false

--- a/rust/benches/interpreter.rs
+++ b/rust/benches/interpreter.rs
@@ -1,0 +1,25 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use futures::StreamExt;
+use scannerlib::{
+    nasl::{interpreter::CodeInterpreter, ContextFactory, Register},
+    storage::ContextKey,
+};
+
+pub fn run_interpreter_in_description_mode(c: &mut Criterion) {
+    let code = include_str!("../data/nasl_syntax/simple_parse.nasl");
+    let variables = vec![("description".to_owned(), true.into())];
+    c.bench_function("interpreter", |b| {
+        b.iter(|| {
+            futures::executor::block_on(async {
+                let register = Register::root_initial(&variables);
+                let context_factory = ContextFactory::default();
+                let context = context_factory.build(ContextKey::FileName("test.nasl".to_string()));
+                let parser = CodeInterpreter::new(&code, register, &context);
+                let _: Vec<_> = black_box(parser.stream().collect().await);
+            });
+        })
+    });
+}
+
+criterion_group!(benches, run_interpreter_in_description_mode);
+criterion_main!(benches);

--- a/rust/src/feed/mod.rs
+++ b/rust/src/feed/mod.rs
@@ -19,6 +19,7 @@ pub use update::Update;
 pub use verify::check_signature;
 pub use verify::Error as VerifyError;
 pub use verify::FileNameLoader;
+pub use verify::HashSumFileItem;
 pub use verify::HashSumNameLoader;
 pub use verify::Hasher;
 pub use verify::NaslFileFinder;

--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -322,6 +322,7 @@ impl<'a> Iterator for HashSumNameLoader<'a> {
 }
 
 /// Contains all information  necessary to do a hash sum check
+#[derive(Clone)]
 pub struct HashSumFileItem<'a> {
     file_name: String,
     hashsum: String,

--- a/rust/src/scanner/mod.rs
+++ b/rust/src/scanner/mod.rs
@@ -40,7 +40,6 @@ use running_scan::{RunningScan, RunningScanHandle};
 use scanner_stack::DefaultScannerStack;
 
 // This is a fake implementation of the ScannerStack trait and is only used for testing purposes.
-#[cfg(debug_assertions)]
 pub mod fake {
     use super::*;
 


### PR DESCRIPTION
1. Adds a benchmark for the interpreter.
2. Changes the behavior of the `CodeInterpreter` to treat `NaslValue::Exit` as a reason to not return any further statements, so that this behavior does not have to be handled explicitly on every call site.
