### PR TITLE
Fix: Convert scanner style bools to OSP style

### DIFF
--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -189,9 +189,9 @@ fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     for p in &scan.scan_preferences {
         writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
         let value = match p.value.as_ref() {
-          "yes" => "1",
-          "no" => "0",
-          v => v,
+            "yes" => "1",
+            "no" => "0",
+            v => v,
         };
         writer.write_event(Event::Text(BytesText::new(value)))?;
         writer.write_event(Event::End(BytesEnd::new(&p.id)))?;

--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -188,13 +188,12 @@ fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     writer.write_event(Event::Start(BytesStart::new("scanner_params")))?;
     for p in &scan.scan_preferences {
         writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
-        let mut value = p.value.as_str();
-        if value == "yes" {
-          value = "1";
-        } else if value == "no" {
-          value = "0";
-        }
-        writer.write_event(Event::Text(BytesText::new(&value)))?;
+        let value = match p.value.as_ref() {
+          "yes" => "1",
+          "no" => "0",
+          v => v,
+        };
+        writer.write_event(Event::Text(BytesText::new(value)))?;
         writer.write_event(Event::End(BytesEnd::new(&p.id)))?;
     }
 

--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -188,7 +188,13 @@ fn write_scanner_prefs(scan: &Scan, writer: &mut Writer) -> Result<()> {
     writer.write_event(Event::Start(BytesStart::new("scanner_params")))?;
     for p in &scan.scan_preferences {
         writer.write_event(Event::Start(BytesStart::new(&p.id)))?;
-        writer.write_event(Event::Text(BytesText::new(&p.value)))?;
+        let mut value = p.value.as_str();
+        if value == "yes" {
+          value = "1";
+        } else if value == "no" {
+          value = "0";
+        }
+        writer.write_event(Event::Text(BytesText::new(&value)))?;
         writer.write_event(Event::End(BytesEnd::new(&p.id)))?;
     }
 


### PR DESCRIPTION
**What**:

Convert scanner style `yes`/`no` boolean preferences to OSP style `1`/`0` before sending the preferences to ospd.

**Why**:

I had to do this to get scans to run (using the `openvasd-integration` branch of gvmd). Maybe helps someone else.

**How**:

With Rust openvas-scanner `main` branch, I  start a Full and Fast task in GSA. The task sits in `Requested` and I see `Invalid safe_checks value` in the openvasd logs:

```
2025-01-13T22:56:25.950648Z WARN openvasd::scheduling: unable to start, removing from queue and set status to failed. Verify that scan using the API scan_id=1a0299e6-8b6f-428f-9405-7baa393511b4 e=Unexpected issue: InvalidResponse(Status { text: "Invalid safe_checks value", code: StringU64(400) })
```

openvasd.toml includes:
```
mode = "service"
[scanner]
type = "ospd"
[storage]
type = "inmemory"
```

With the PR the scan starts and runs to completion.

**References**:

Similar conversion is done in `launch_osp_openvas_task` in [manage.c#L2815](https://github.com/greenbone/gvmd/blob/main/src/manage.c#L2815) in gvmd.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
