### PR TITLE
Add test to verify dependencies

### DIFF
--- a/.docker/railguards/README.md
+++ b/.docker/railguards/README.md
@@ -1,0 +1,12 @@
+# Railguards
+
+As long as openvas is a distributed monolith in
+- greenbone/gvm-libs
+- greenbone/openvas-smb
+- greenbone/openvas-scanner
+
+we need to verify that the dependencies play nicely together on our target:
+
+- debian:stable
+
+**WARNING** The Dockerfiles within this folder are not meant to be used outside of this very specific test case.

--- a/.docker/railguards/debian_stable.Dockerfile
+++ b/.docker/railguards/debian_stable.Dockerfile
@@ -1,0 +1,27 @@
+# This Dockerfile is not meant to be actually used, it is meant for testing
+# the integrity when building:
+# - gvm-libs
+# - openvas-smb
+# - openvas-scanner
+#
+# together from a main branch.
+#
+# If it builds without error everything is as expected.
+FROM debian:stable
+# CLONE gvm-libs
+# CLONE openvas-smb
+# Install dependencies
+# check ld
+COPY . /source
+RUN apt update && apt install -y git
+RUN bash /source/.devcontainer/github-clone.sh greenbone/gvm-libs
+RUN bash /source/.devcontainer/github-clone.sh greenbone/openvas-smb
+# tests implicitely if there are dependencies conflicts
+RUN sh /workspaces/greenbone/gvm-libs/.github/install-dependencies.sh
+RUN sh /workspaces/greenbone/openvas-smb/.github/install-openvas-smb-dependencies.sh
+RUN sh /source/.github/install-openvas-dependencies.sh
+# build everything
+RUN sh /source/.devcontainer/build-cmake-project.sh /workspaces/greenbone/gvm-libs
+RUN sh /source/.devcontainer/build-cmake-project.sh /workspaces/greenbone/openvas-smb
+RUN sh /source/.devcontainer/build-cmake-project.sh /source
+

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -7,6 +7,21 @@ on:
 # It depends on build.yml that is controlled via control.yml
 #
 jobs:
+  # Tests that gvm-libs, openvas-smb and openvas dependencies work together and
+  # that openvas is buildable and integrates openvas-smb when available
+  distributed-monolith-railguard:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - debian_stable
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t test -f .docker/railguards/${{matrix.system}}.Dockerfile .
+      - run: docker run --rm test ldd /usr/local/sbin/openvas
+      - run: docker run --rm test ldd /usr/local/sbin/openvas | grep libopenvas_wmiclient
+      - run: docker rmi test || true
   # TESTS that are possible before pushing an image
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Checks if the dependencies of:
- gvm-libs
- openvas-smb
- openvas-scanner
play nicely together and double checks that
openvas-smb is linked to the openvas binary.
