### PR TITLE
Revert "Use only the description functions during the feed update"

### DIFF
--- a/rust/src/feed/update/mod.rs
+++ b/rust/src/feed/update/mod.rs
@@ -11,7 +11,6 @@ use futures::{stream, Stream, StreamExt};
 use std::fs::File;
 use tracing::trace;
 
-use crate::nasl::builtin::Description;
 use crate::nasl::interpreter::{CodeInterpreter, Interpreter};
 use crate::nasl::nasl_std_functions;
 use crate::nasl::prelude::*;
@@ -109,7 +108,7 @@ where
             dispatcher: storage,
             verifier,
             feed_version_set: false,
-            executor: Executor::single(Description),
+            executor: nasl_std_functions(),
         }
     }
 

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -26,7 +26,6 @@ mod sys;
 #[cfg(test)]
 mod tests;
 
-pub use description::Description;
 pub use error::BuiltinError;
 pub use host::HostError;
 pub use knowledge_base::KBError;

--- a/rust/src/nasl/mod.rs
+++ b/rust/src/nasl/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-pub mod builtin;
+mod builtin;
 pub mod interpreter;
 pub mod syntax;
 pub mod utils;


### PR DESCRIPTION
Missing `defined_func` and possibly other necessary builtin functions broke the feed update, so this commit reverts it.
