### PR TITLE
Fix warnings and clippy lints

### DIFF
--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -199,10 +199,10 @@ impl NaslHttp {
     }
 
     /// Perform request with the given method.
-    async fn http2_req<'a>(
+    async fn http2_req(
         &self,
         register: &Register,
-        ctx: &Context<'a>,
+        ctx: &Context<'_>,
         method: Method,
     ) -> Result<NaslValue, FnError> {
         let handle_id = match register.named("handle") {

--- a/rust/src/nasl/builtin/ssh/tests/mod.rs
+++ b/rust/src/nasl/builtin/ssh/tests/mod.rs
@@ -117,7 +117,7 @@ fn userauth(t: &mut DefaultTestBuilder) {
 #[tokio::test]
 async fn ssh_userauth() {
     run_test(
-        |mut t| {
+        |t| {
             t.ok(
                 format!(r#"session_id = ssh_connect(port: {});"#, PORT),
                 MIN_SESSION_ID,
@@ -147,7 +147,7 @@ async fn ssh_userauth() {
 #[cfg_attr(feature = "nasl-builtin-libssh", ignore)]
 async fn ssh_request_exec() {
     run_test(
-        |mut t| {
+        |t| {
             t.ok(
                 format!(r#"session_id = ssh_connect(port: {});"#, PORT),
                 MIN_SESSION_ID,

--- a/rust/src/nasl/interpreter/assign.rs
+++ b/rust/src/nasl/interpreter/assign.rs
@@ -171,7 +171,7 @@ impl Interpreter<'_> {
     }
 }
 
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     /// Assign a right value to a left value. Return either the
     /// previous or the new value, based on the order.
     pub async fn assign(

--- a/rust/src/nasl/interpreter/call.rs
+++ b/rust/src/nasl/interpreter/call.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use super::InterpretErrorKind;
 
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     pub async fn call(
         &mut self,
         statement: &Statement,

--- a/rust/src/nasl/interpreter/interpreter.rs
+++ b/rust/src/nasl/interpreter/interpreter.rs
@@ -137,10 +137,10 @@ impl<'a> Interpreter<'a> {
         Some(self)
     }
 
-    async fn execute_statements<'b>(
+    async fn execute_statements(
         &self,
         key: &str,
-        inter: &mut Interpreter<'b>,
+        inter: &mut Interpreter<'_>,
         stmt: Result<Statement, SyntaxError>,
     ) -> InterpretResult {
         match stmt {

--- a/rust/src/nasl/interpreter/loop_extension.rs
+++ b/rust/src/nasl/interpreter/loop_extension.rs
@@ -12,7 +12,7 @@ use super::interpreter::InterpretResult;
 
 /// Note that for all loops, we do not
 /// change the context, as the current NASL also does not change it too.
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     /// Interpreting a NASL for loop. A NASL for loop is built up with the
     /// following:
     ///

--- a/rust/src/nasl/interpreter/operator.rs
+++ b/rust/src/nasl/interpreter/operator.rs
@@ -9,7 +9,7 @@ use crate::nasl::interpreter::{error::InterpretError, interpreter::InterpretResu
 
 use crate::nasl::syntax::NaslValue;
 
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     async fn execute(
         &mut self,
         stmts: &[Statement],
@@ -106,7 +106,7 @@ macro_rules! minus_left_right_data {
     }};
 }
 
-impl<'a> Interpreter<'a> {
+impl Interpreter<'_> {
     /// Return the result of a NASL operator.
     pub async fn operator(
         &mut self,

--- a/rust/src/notus/vts.rs
+++ b/rust/src/notus/vts.rs
@@ -125,10 +125,7 @@ where
                 full_name,
             } => {
                 // Parse package from full name
-                let package = match P::from_full_name(full_name) {
-                    Some(pkg) => pkg,
-                    None => return None,
-                };
+                let package = P::from_full_name(full_name)?;
                 // Create Vulnerability Test Entry
                 Some((
                     package.get_name(),
@@ -147,10 +144,7 @@ where
                 name,
             } => {
                 // Parse package from name and full version
-                let package = match P::from_name_and_full_version(name, full_version) {
-                    Some(pkg) => pkg,
-                    None => return None,
-                };
+                let package = P::from_name_and_full_version(name, full_version)?;
                 // Create Vulnerability Test Entry
                 Some((
                     package.get_name(),
@@ -165,14 +159,8 @@ where
             }
             FixedPackage::ByRange { range, name } => {
                 // Parse both packages from name and full version
-                let start = match P::from_name_and_full_version(name, &range.start) {
-                    Some(pkg) => pkg,
-                    None => return None,
-                };
-                let end = match P::from_name_and_full_version(name, &range.end) {
-                    Some(pkg) => pkg,
-                    None => return None,
-                };
+                let start = P::from_name_and_full_version(name, &range.start)?;
+                let end = P::from_name_and_full_version(name, &range.end)?;
                 // Create Vulnerability Test Entry
                 Some((
                     start.get_name(),

--- a/rust/src/openvasd/controller/mod.rs
+++ b/rust/src/openvasd/controller/mod.rs
@@ -58,7 +58,7 @@ fn retrieve_and_reset(id: Arc<RwLock<ClientIdentifier>>) -> ClientIdentifier {
     cci
 }
 
-pub async fn run<'a, S, DB>(
+pub async fn run<S, DB>(
     mut ctx: Context<S, DB>,
     config: &config::Config,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>

--- a/rust/src/openvasd/response.rs
+++ b/rust/src/openvasd/response.rs
@@ -220,7 +220,7 @@ impl Response {
                     return;
                 };
             }
-            if value.map(|v| send(SendState::Bytes(false, v))).any(|x| x) {
+            if value.any(|v| send(SendState::Bytes(false, v))) {
                 return;
             }
 

--- a/rust/src/scanner/running_scan.rs
+++ b/rust/src/scanner/running_scan.rs
@@ -113,7 +113,7 @@ impl<S: ScannerStack> RunningScan<S> {
         .map_err(make_scheduling_error)
     }
 
-    async fn run_to_completion<'a>(&self, runner: ScanRunner<'a, S>) -> Phase {
+    async fn run_to_completion(&self, runner: ScanRunner<'_, S>) -> Phase {
         let mut end_phase = Phase::Succeeded;
         let mut stream = Box::pin(runner.stream());
         while let Some(it) = stream.next().await {

--- a/rust/src/scannerctl/osp/start_scan.rs
+++ b/rust/src/scannerctl/osp/start_scan.rs
@@ -25,9 +25,10 @@ pub struct Target {
     pub credentials: Option<Credentials>,
 }
 
-impl Into<Vec<models::Credential>> for Credentials {
-    fn into(self) -> Vec<models::Credential> {
-        self.credential
+impl From<Credentials> for Vec<models::Credential> {
+    fn from(other: Credentials) -> Self {
+        other
+            .credential
             .into_iter()
             .flatten()
             .map(|x| {

--- a/rust/src/scheduling/mod.rs
+++ b/rust/src/scheduling/mod.rs
@@ -116,9 +116,9 @@ pub trait ExecutionPlaner {
     ///
     /// If the second value (parameter) is None it indicates that this script in indirectly loaded
     /// and was not explicitly mentioned in the Scan.
-    fn execution_plan<'a, E>(
+    fn execution_plan<E>(
         &self,
-        ids: &'a Scan,
+        ids: &Scan,
     ) -> Result<impl Iterator<Item = ConcurrentVTResult>, VTError>
     where
         E: ExecutionPlan;
@@ -208,9 +208,9 @@ impl<T> ExecutionPlaner for T
 where
     T: Retriever + ?Sized,
 {
-    fn execution_plan<'a, E>(
+    fn execution_plan<E>(
         &self,
-        scan: &'a Scan,
+        scan: &Scan,
     ) -> Result<impl Iterator<Item = ConcurrentVTResult>, VTError>
     where
         E: ExecutionPlan,


### PR DESCRIPTION
Fixes new compiler warnings and clippy lints, along with some unnoticed ones and some that only occurred in experimental builds which are not part of CI
