### PR TITLE
Add: Port handling within KB and acording NASL functions

### DIFF
--- a/rust/src/nasl/builtin/network/README.md
+++ b/rust/src/nasl/builtin/network/README.md
@@ -17,13 +17,13 @@
 - recv_line
 - get_source_port
 - ftp_log_in
+- get_port_transport
+- get_host_open_port
 
 ## Missing
 
 - ftp_get_pasv_port
-- get_host_open_port
 - get_port_state
-- get_port_transport
 - get_tcp_port_state
 - get_udp_port_state
 - join_multicast_group

--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -5,7 +5,7 @@
 use std::{net::IpAddr, process::Command};
 
 use super::socket::SocketError;
-use super::{mtu, Port};
+use super::{mtu, NaslValue, Port};
 use super::{
     network_utils::{get_netmask_by_local_ip, get_source_ip, ipstr2ipaddr, islocalhost},
     DEFAULT_PORT,
@@ -13,6 +13,7 @@ use super::{
 use crate::function_set;
 use crate::nasl::utils::{Context, FnError};
 use crate::storage::{types::Primitive, Field, Kb};
+use chrono::format;
 use nasl_function_proc_macro::nasl_function;
 
 /// Get the IP address of the currently scanned host
@@ -149,6 +150,39 @@ fn scanner_add_port(context: &Context, port: Port, proto: Option<&str>) -> Resul
     Ok(())
 }
 
+#[nasl_function]
+fn get_host_open_port(context: &Context) -> i64 {
+    context.get_host_open_port().unwrap_or_default() as i64
+}
+
+#[nasl_function(named(asstring))]
+fn get_port_transport(context: &Context, port: u16, asstring: bool) -> Result<NaslValue, FnError> {
+    let transport = context.get_port_transport(port)?.unwrap_or(1);
+    let ret = if asstring {
+        let transport_str = match transport {
+            0 => "auto".to_string(),
+            1 => "IP".to_string(),
+            3 => "SSLv2".to_string(),
+            2 => "SSLv23".to_string(),
+            4 => "SSLv3".to_string(),
+            5 => "TLSv1".to_string(),
+            6 => "TLSv11".to_string(),
+            7 => "TLSv12".to_string(),
+            8 => "TLSv13".to_string(),
+            9 => "TLScustom".to_string(),
+            _ => format!(
+                "[unknown transport layer - code {} (0x{:x})]",
+                transport, transport
+            ),
+        };
+        NaslValue::String(transport_str)
+    } else {
+        NaslValue::Number(transport as i64)
+    };
+
+    Ok(ret)
+}
+
 pub struct Network;
 
 function_set! {
@@ -161,5 +195,7 @@ function_set! {
         this_host_name,
         get_mtu,
         get_host_ip,
+        get_host_open_port,
+        get_port_transport
     )
 }

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -5,11 +5,13 @@
 //! Defines the context used within the interpreter and utilized by the builtin functions
 
 use itertools::Itertools;
+use rand::seq::SliceRandom;
 
 use crate::nasl::builtin::KBError;
 use crate::nasl::syntax::{Loader, NaslValue, Statement};
 use crate::nasl::{FromNaslValue, WithErrorInfo};
-use crate::storage::{ContextKey, Dispatcher, Field, Retrieve, Retriever};
+use crate::storage::types::Primitive;
+use crate::storage::{ContextKey, Dispatcher, Field, Kb, Retrieve, Retriever};
 
 use super::error::ReturnBehavior;
 use super::hosts::resolve;
@@ -359,6 +361,10 @@ pub struct Target {
     // should be used.
     /// vhost list which resolve to the IP address and their sources.
     vhosts: Mutex<Vec<(String, String)>>,
+    // List of tcp Ports
+    ports_tcp: Vec<u16>,
+    // List of udp Ports
+    ports_udp: Vec<u16>,
 }
 
 impl Target {
@@ -386,6 +392,8 @@ impl Default for Target {
             target: String::new(),
             ip_addr: IpAddr::from_str("127.0.0.1").unwrap(),
             vhosts: Mutex::new(vec![]),
+            ports_tcp: vec![],
+            ports_udp: vec![],
         }
     }
 }
@@ -492,6 +500,23 @@ impl<'a> Context<'a> {
         self.loader
     }
 
+    pub fn set_single_kb_item<T: Into<Primitive>>(
+        &self,
+        name: &str,
+        value: T,
+    ) -> Result<(), FnError> {
+        self.dispatcher
+            .dispatch_replace(
+                &self.key,
+                Field::KB(Kb {
+                    key: name.to_string(),
+                    value: value.into(),
+                    expire: None,
+                }),
+            )
+            .map_err(|e| e.into())
+    }
+
     /// Return a single item from the knowledge base.
     /// If multiple entries are found (which would result
     /// in forking the interpreter), return an error.
@@ -508,22 +533,85 @@ impl<'a> Context<'a> {
         let val = self
             .get_single_kb_item_inner(name)
             .map_err(|e| e.with(ReturnBehavior::ExitScript))?;
-        T::from_nasl_value(&val)
+        T::from_nasl_value(&val.into())
     }
 
-    fn get_single_kb_item_inner(&self, name: &str) -> Result<NaslValue, FnError> {
+    fn get_single_kb_item_inner(&self, name: &str) -> Result<Primitive, FnError> {
         let result = self
             .retriever()
             .retrieve(&self.key, Retrieve::KB(name.to_string()))?;
         let single_item = result
             .filter_map(|field| match field {
-                Field::KB(kb) => Some(kb.value.into()),
+                Field::KB(kb) => Some(kb.value),
                 _ => None,
             })
             .at_most_one()
             .map_err(|_| KBError::MultipleItemsFound(name.to_string()))?
             .ok_or_else(|| KBError::ItemNotFound(name.to_string()))?;
         Ok(single_item)
+    }
+
+    fn get_kb_item_pattern(&self, pattern: &str) -> Result<Vec<Kb>, FnError> {
+        let result = self
+            .retriever()
+            .retrieve_pattern(&self.key, Retrieve::KB(pattern.to_string()))?;
+        let items = result
+            .filter_map(|field| match field {
+                Field::KB(kb) => Some(kb),
+                _ => None,
+            })
+            .collect();
+        Ok(items)
+    }
+
+    /// Sets the state of a port
+    pub fn set_port_transport(&self, port: u16, transport: usize) -> Result<(), FnError> {
+        self.set_single_kb_item(&format!("Port/TCP/{}", port), transport)
+    }
+
+    pub fn get_port_transport(&self, port: u16) -> Result<Option<i64>, FnError> {
+        self.get_single_kb_item_inner(&format!("Port/TCP/{}", port))
+            .map(|x| match x {
+                Primitive::Number(n) => Some(n),
+                _ => None,
+            })
+    }
+
+    /// Don't always return the first open port, otherwise
+    /// we might get bitten by OSes doing active SYN flood
+    /// countermeasures. Also, avoid returning 80 and 21 as
+    /// open ports, as many transparent proxies are acting for these...
+    pub fn get_host_open_port(&self) -> Result<u16, FnError> {
+        let mut open21 = false;
+        let mut open80 = false;
+        let ports: Vec<u16> = self
+            .get_kb_item_pattern("Ports/tcp/*")?
+            .iter()
+            .filter_map(|x| {
+                x.key.split('/').last().and_then(|x| {
+                    if x == "21" {
+                        open21 = true;
+                        None
+                    } else if x == "80" {
+                        open80 = true;
+                        None
+                    } else {
+                        x.parse::<u16>().ok()
+                    }
+                })
+            })
+            .collect();
+
+        let ret = if ports.len() != 0 {
+            *ports.choose(&mut rand::thread_rng()).unwrap()
+        } else if open21 {
+            21
+        } else if open80 {
+            80
+        } else {
+            0
+        };
+        Ok(ret)
     }
 }
 

--- a/rust/src/openvasd/storage/mod.rs
+++ b/rust/src/openvasd/storage/mod.rs
@@ -488,6 +488,14 @@ where
         self.underlying_storage().retrieve(key, scope)
     }
 
+    fn retrieve_pattern(
+        &self,
+        key: &ContextKey,
+        scope: Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
+        self.underlying_storage().retrieve_pattern(key, scope)
+    }
+
     fn retrieve_by_field(&self, field: Field, scope: Retrieve) -> FieldKeyResult {
         // We should never try to return results without an ID
         self.underlying_storage().retrieve_by_field(field, scope)

--- a/rust/src/storage/item.rs
+++ b/rust/src/storage/item.rs
@@ -956,6 +956,14 @@ where
         self.dispatcher.retrieve(key, scope)
     }
 
+    fn retrieve_pattern(
+        &self,
+        key: &ContextKey,
+        scope: Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
+        self.dispatcher.retrieve_pattern(key, scope)
+    }
+
     fn retrieve_by_field(
         &self,
         field: Field,

--- a/rust/src/storage/json/mod.rs
+++ b/rust/src/storage/json/mod.rs
@@ -139,7 +139,7 @@ where
             // currently not supported
             storage::Retrieve::NVT(_)
             | storage::Retrieve::NotusAdvisory(_)
-            | storage::Retrieve::Result(_) => Box::new([].into_iter()),
+            | storage::Retrieve::Result(_) => unimplemented!(),
             storage::Retrieve::KB(s) => Box::new({
                 let kbs = self.kbs.lock().map_err(StorageError::from)?;
                 let kbs = kbs.clone();
@@ -164,6 +164,26 @@ where
         _: storage::Retrieve,
     ) -> storage::FieldKeyResult {
         Ok(Box::new([].into_iter()))
+    }
+
+    fn retrieve_pattern(
+        &self,
+        _: &ContextKey,
+        scope: storage::Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = storage::Field>>, StorageError> {
+        match scope {
+            storage::Retrieve::KB(s) => {
+                let kbs = self.kbs.lock().map_err(StorageError::from)?;
+                let ret = kbs
+                    .clone()
+                    .into_iter()
+                    .filter(move |x| storage::match_pattern(&x.key, &s))
+                    .map(|x| storage::Field::KB(x.clone()));
+                let ret = Box::new(ret);
+                Ok(ret)
+            }
+            _ => unimplemented!(),
+        }
     }
 }
 

--- a/rust/src/storage/redis/connector.rs
+++ b/rust/src/storage/redis/connector.rs
@@ -763,6 +763,26 @@ where
         })
     }
 
+    fn retrieve_pattern(
+        &self,
+        _: &ContextKey,
+        scope: storage::Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = storage::Field>>, StorageError> {
+        match scope {
+            storage::Retrieve::KB(s) => {
+                let kbs = self.kbs.lock().map_err(StorageError::from)?;
+                let ret = kbs
+                    .clone()
+                    .into_iter()
+                    .filter(move |x| storage::match_pattern(&x.key, &s))
+                    .map(|x| storage::Field::KB(x.clone()));
+                let ret = Box::new(ret);
+                Ok(ret)
+            }
+            _ => unimplemented!(),
+        }
+    }
+
     fn retrieve_by_field(
         &self,
         _field: Field,

--- a/rust/src/storage/retrieve.rs
+++ b/rust/src/storage/retrieve.rs
@@ -138,6 +138,13 @@ pub trait Retriever: Send + Sync {
         retry(|| self.retrieve(key, scope.clone()), max_tries)
     }
 
+    /// Get all items with a given pattern
+    fn retrieve_pattern(
+        &self,
+        key: &ContextKey,
+        scope: Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError>;
+
     /// Returns all vts as an iterator
     fn vts(&self) -> Result<Box<dyn Iterator<Item = Nvt>>, StorageError> {
         Ok(Box::new(
@@ -225,6 +232,14 @@ impl Retriever for NoOpRetriever {
     }
 
     fn retrieve_by_fields(&self, _: Vec<Field>, _: Retrieve) -> FieldKeyResult {
+        Ok(Box::new(vec![].into_iter()))
+    }
+
+    fn retrieve_pattern(
+        &self,
+        _: &ContextKey,
+        _: Retrieve,
+    ) -> Result<Box<dyn Iterator<Item = Field>>, StorageError> {
         Ok(Box::new(vec![].into_iter()))
     }
 }


### PR DESCRIPTION
This PR contains an extension of the retriever trait to also be able to get kb items with a pattern. This is needed in order to get a list of all open ports of a target, as they are saved within the kb.

Additionally added the following NASL builtin functions:
- get_host_open_port
- get_port_transport

When creating an socket, now the according transport used is entered into the kb