### PR TITLE
Run clang-format from ubuntu-latest

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -116,7 +116,7 @@ static struct csc_hook_s *csc_hooks;
 /**
  * determine the openvas_connection* from the openvas fd
  */
-#define OVAS_CONNECTION_FROM_FD(fd) (connections + ((fd) -OPENVAS_FD_OFF))
+#define OVAS_CONNECTION_FROM_FD(fd) (connections + ((fd) - OPENVAS_FD_OFF))
 
 /**
  * Same as perror(), but prefixes the data by our pid.

--- a/nasl/byteorder.h
+++ b/nasl/byteorder.h
@@ -106,8 +106,8 @@ it also defines lots of intermediate macros, just ignore those :-)
 
 #define SVAL(buf, pos) (PVAL (buf, pos) | PVAL (buf, (pos) + 1) << 8)
 #define IVAL(buf, pos) (SVAL (buf, pos) | SVAL (buf, (pos) + 2) << 16)
-#define SSVALX(buf, pos, val)                          \
-  (CVAL_NC (buf, pos) = (unsigned char) ((val) &0xFF), \
+#define SSVALX(buf, pos, val)                           \
+  (CVAL_NC (buf, pos) = (unsigned char) ((val) & 0xFF), \
    CVAL_NC (buf, pos + 1) = (unsigned char) ((val) >> 8))
 #define SIVALX(buf, pos, val) \
   (SSVALX (buf, pos, val & 0xFFFF), SSVALX (buf, pos + 2, val >> 16))
@@ -150,7 +150,7 @@ it also defines lots of intermediate macros, just ignore those :-)
 #endif /* CAREFUL_ALIGNMENT */
 
 /* now the reverse routines - these are used in nmb packets (mostly) */
-#define SREV(x) ((((x) &0xFF) << 8) | (((x) >> 8) & 0xFF))
+#define SREV(x) ((((x) & 0xFF) << 8) | (((x) >> 8) & 0xFF))
 #define IREV(x) ((SREV (x) << 16) | (SREV ((x) >> 16)))
 
 #define RSVAL(buf, pos) SREV (SVAL (buf, pos))

--- a/nasl/nasl_cert.c
+++ b/nasl/nasl_cert.c
@@ -65,7 +65,7 @@
    + xtoi_1 ((const unsigned char *) (p) + 1))
 
 /* Convert N to a hex digit.  N must be in the range 0..15.  */
-#define tohex(n) ((n) < 10 ? ((n) + '0') : (((n) -10) + 'A'))
+#define tohex(n) ((n) < 10 ? ((n) + '0') : (((n) - 10) + 'A'))
 
 /* This object is used to keep track of KSBA certificate objects.
    Because they are pointers they can't be mapped easily to the NASL

--- a/nasl/smb.h
+++ b/nasl/smb.h
@@ -81,7 +81,7 @@ typedef struct _smb_iconv_t
                   char **outbuf, size_t *outbytesleft);
   void *cd_direct, *cd_pull, *cd_push;
   char *from_name, *to_name;
-} * smb_iconv_t;
+} *smb_iconv_t;
 
 /* string manipulation flags - see clistr.c and srvstr.c */
 #define STR_TERMINATE 1

--- a/nasl/time.c
+++ b/nasl/time.c
@@ -32,9 +32,10 @@
  */
 
 #ifndef TIME_T_MIN
-#define TIME_T_MIN                       \
-  ((time_t) 0 < (time_t) -1 ? (time_t) 0 \
-                            : ~(time_t) 0 << (sizeof (time_t) * CHAR_BIT - 1))
+#define TIME_T_MIN           \
+  ((time_t) 0 < (time_t) - 1 \
+     ? (time_t) 0            \
+     : ~(time_t) 0 << (sizeof (time_t) * CHAR_BIT - 1))
 #endif
 #ifndef TIME_T_MAX
 #define TIME_T_MAX LONG_MAX


### PR DESCRIPTION
Fixes the recent failure of the C-linting action due to a difference in clang-format versions