### PR TITLE
Ignore RUSTSEC-2023-0071 in cargo audit

### DIFF
--- a/rust/.cargo/audit.toml
+++ b/rust/.cargo/audit.toml
@@ -1,0 +1,4 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071" # This cannot currently be patched. For more information, see: https://rustsec.org/advisories/RUSTSEC-2023-0071
+]


### PR DESCRIPTION
This vulnerability has been around since 2023 and cannot currently be patched. A separate ticket, SC-1217, exists to track this vulnerability.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
