### PR TITLE
Fix: scannerctl subcommand

### DIFF
--- a/rust/src/scannerctl/osp/mod.rs
+++ b/rust/src/scannerctl/osp/mod.rs
@@ -133,7 +133,7 @@ where
 }
 
 pub async fn run(root: &clap::ArgMatches) -> Option<Result<(), CliError>> {
-    let (args, _) = crate::get_args_set_logging(root, "ospd")?;
+    let (args, _) = crate::get_args_set_logging(root, "osp")?;
 
     let feed = match args.get_one::<PathBuf>("path") {
         Some(feed) => {


### PR DESCRIPTION
**What**:
Fix: scannerctl subcommand
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
scannerctl is broken
<!-- Why are these changes necessary? -->

**How**:
`target/debug/scannerctl osp -p $PLUGINSPATH -b ~/start_scans_meta_fullfast.xml`
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
