### PR TITLE
Remove: generation of result with scritp run duration.

### DIFF
--- a/nasl/nasl_init.c
+++ b/nasl/nasl_init.c
@@ -79,7 +79,6 @@ static init_func libfuncs[] = {
   {"script_xref", script_xref},
   {"script_tag", script_tag},
   {"vendor_version", nasl_vendor_version},
-  {"generate_host_stats", nasl_generate_host_stats},
   {"update_table_driven_lsc_data", nasl_update_table_driven_lsc_data},
   {"get_preference", nasl_get_preference},
   {"safe_checks", safe_checks},
@@ -565,7 +564,7 @@ func_is_internal (const char *name)
 }
 
 char *
-nasl_version ()
+nasl_version (void)
 {
   static char vers[sizeof (OPENVASLIB_VERSION) + 1];
   strncpy (vers, OPENVASLIB_VERSION, sizeof (vers) - 1);

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -1055,51 +1055,6 @@ nasl_get_preference (lex_ctxt *lexic)
 }
 
 tree_cell *
-nasl_generate_host_stats (lex_ctxt *lexic)
-{
-  tree_cell *retc;
-  struct script_infos *script_infos = lexic->script_infos;
-  kb_t kb = script_infos->key;
-  GString *data = g_string_new ("");
-  struct kb_item *stats = NULL, *stats_tmp = NULL;
-  int first = 1;
-
-  stats = kb_item_get_pattern (kb, "general/script_stats*");
-  stats_tmp = stats;
-
-  g_string_append_c (data, '[');
-  while (stats_tmp)
-    {
-      char **spl = g_strsplit (stats_tmp->v_str, "/", 0);
-      char *buf = NULL;
-
-      if (!first)
-        g_string_append_c (data, ',');
-
-      buf = g_strdup_printf ("{\"%s\": {\"start\": %s, \"stop\": %s}}", spl[0],
-                             spl[1], spl[2]);
-
-      g_string_append (data, buf);
-      g_strfreev (spl);
-      g_free (buf);
-
-      stats_tmp = stats_tmp->next;
-      if (first)
-        first = 0;
-    }
-  g_string_append_c (data, ']');
-
-  kb_item_free (stats);
-
-  retc = alloc_typed_cell (CONST_STR);
-  retc->x.str_val = strdup (data->str);
-  retc->size = data->len;
-  g_string_free (data, TRUE);
-
-  return retc;
-}
-
-tree_cell *
 nasl_vendor_version (lex_ctxt *lexic)
 {
   tree_cell *retc;

--- a/nasl/nasl_scanner_glue.h
+++ b/nasl/nasl_scanner_glue.h
@@ -118,7 +118,4 @@ nasl_vendor_version (lex_ctxt *);
 tree_cell *
 nasl_update_table_driven_lsc_data (lex_ctxt *);
 
-tree_cell *
-nasl_generate_host_stats (lex_ctxt *);
-
 #endif

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -73,7 +73,7 @@ const char *hostname = NULL;
  * @return 1 if reached, 0 if not reached or no set.
  */
 static int
-max_nvt_timeouts_reached ()
+max_nvt_timeouts_reached (void)
 {
   static int vts_timeouts_counter = 0;
   int max_vts_timeouts = 0;


### PR DESCRIPTION
**What**:
Remove: generation of result with scritp run duration. Revert part of #1774 
Also, fix warning about functions without prototype, adding  to the function signature

Jira: SC-1206
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
After internal talk, it was decide to keep only the dump file and to not generate an extra result, extending the nasl lib with a new function, which also requires a nasl script for generating the results.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
