### PR TITLE
Fix: on fork unallowed access to heap

### DIFF
--- a/nasl/nasl_krb5.c
+++ b/nasl/nasl_krb5.c
@@ -245,10 +245,6 @@ tree_cell *
 nasl_okrb5_gss_init (lex_ctxt *lexic)
 {
   (void) lexic;
-  if (cached_gss_context != NULL)
-    {
-      okrb5_gss_free_context (cached_gss_context);
-    }
   cached_gss_context = okrb5_gss_init_context ();
   if (cached_gss_context == NULL)
     {


### PR DESCRIPTION
When nasl_okrb5_gss_init was already called when a script gets forked which calls `krb5_gss_init` freeing an already allocated pointer within that process has the potential to run into:
```
lib  nasl-Message: 14:45:13.824: krb5_gss_init
munmap_chunk(): invalid pointer
lib  nasl-Message: 14:45:13.978: krb5_gss_init
munmap_chunk(): invalid pointer
```

as the forked process is not allowed to manipulate this pointer address.

For that reason releasing memory when calling `krb5_gss_init` is removed although it can potentially leak memory when called incorrectly.

NOTE: a cleaner solution could be to reset all pointers within nasl_krb5 when forking does happen. This however would require a concept to register `cleanup` functions somewhere before and execute them before a fork syscall gets called.
