### PR TITLE
Fix: openvasd doesn't support empty passphrase for usk crendential

### DIFF
--- a/rust/src/models/credential.rs
+++ b/rust/src/models/credential.rs
@@ -30,7 +30,7 @@ impl Credential {
             credential_type: self.credential_type.map_password(f)?,
         })
     }
- 
+
     /// Gets the password of the credential.
     pub fn password(&self) -> &str {
         match &self.credential_type {

--- a/rust/src/models/credential.rs
+++ b/rust/src/models/credential.rs
@@ -30,19 +30,6 @@ impl Credential {
             credential_type: self.credential_type.map_password(f)?,
         })
     }
-
-    /// Gets the password of the credential.
-    pub fn password(&self) -> &str {
-        match &self.credential_type {
-            CredentialType::UP { password, .. } => password,
-            CredentialType::USK { password, .. } => match password {
-                None => "",
-                Some(p) => p,
-            },
-            CredentialType::SNMP { password, .. } => password,
-            CredentialType::KRB5 { password, .. } => password,
-        }
-    }
 }
 
 impl Default for Credential {

--- a/rust/src/nasl/interpreter/call.rs
+++ b/rust/src/nasl/interpreter/call.rs
@@ -161,7 +161,8 @@ get_kb_item("host");
             .results()
             .into_iter()
             .skip(4)
-            .filter_map(|x| x.ok())
+            // .filter_map(|x| x.ok())
+            .map(|x| x.unwrap())
             .collect();
 
         assert_eq!(

--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -443,7 +443,7 @@ where
                         ));
                         credential_preferences.push(format!(
                             "{OID_SSH_AUTH}:2:password:SSH key passphrase:|||{}",
-                            password
+                            password.unwrap_or_default()
                         ));
                         credential_preferences.push(format!(
                             "{OID_SSH_AUTH}:4:file:SSH private key:|||{}",

--- a/rust/src/openvasd/storage/inmemory.rs
+++ b/rust/src/openvasd/storage/inmemory.rs
@@ -484,9 +484,12 @@ mod tests {
     fn password(c: &Credential) -> &str {
         match &c.credential_type {
             CredentialType::UP { password, .. }
-            | CredentialType::USK { password, .. }
             | CredentialType::SNMP { password, .. }
             | CredentialType::KRB5 { password, .. } => password,
+            CredentialType::USK { password, .. } => match password {
+                Some(p) => p,
+                None => "",
+            }
         }
     }
 

--- a/rust/src/openvasd/storage/inmemory.rs
+++ b/rust/src/openvasd/storage/inmemory.rs
@@ -489,7 +489,7 @@ mod tests {
             CredentialType::USK { password, .. } => match password {
                 Some(p) => p,
                 None => "",
-            }
+            },
         }
     }
 

--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -308,7 +308,11 @@ fn write_credentials(scan: &Scan, writer: &mut Writer) -> Result<()> {
                         privilege,
                     } => {
                         write_str_element(writer, "username", username)?;
-                        write_str_element(writer, "password", password)?;
+                        write_str_element(
+                            writer,
+                            "password",
+                            password.clone().unwrap_or_default().as_ref()
+                        )?;
                         write_str_element(writer, "private", private_key)?;
                         if let Some(p) = privilege {
                             write_str_element(writer, "priv_username", &p.username)?;

--- a/rust/src/osp/commands.rs
+++ b/rust/src/osp/commands.rs
@@ -311,7 +311,7 @@ fn write_credentials(scan: &Scan, writer: &mut Writer) -> Result<()> {
                         write_str_element(
                             writer,
                             "password",
-                            password.clone().unwrap_or_default().as_ref()
+                            password.clone().unwrap_or_default().as_ref(),
                         )?;
                         write_str_element(writer, "private", private_key)?;
                         if let Some(p) = privilege {

--- a/rust/src/scannerctl/osp/start_scan.rs
+++ b/rust/src/scannerctl/osp/start_scan.rs
@@ -581,10 +581,7 @@ impl From<models::Credential> for Credential {
                 privilege,
             } => {
                 credentials.push(("username".to_string(), username));
-                credentials.push((
-                    "password".to_string(),
-                    password.unwrap_or_default()
-                ));
+                credentials.push(("password".to_string(), password.unwrap_or_default()));
                 credentials.push(("private".to_string(), private_key));
                 if let Some(p) = privilege {
                     credentials.push(("priv_username".to_string(), p.username));

--- a/rust/src/scannerctl/osp/start_scan.rs
+++ b/rust/src/scannerctl/osp/start_scan.rs
@@ -50,7 +50,7 @@ impl From<Credentials> for Vec<models::Credential> {
                 let kind = match &x.kind as &str {
                     "usk" => CredentialType::USK {
                         username,
-                        password,
+                        password: Some(password),
                         private_key: key("private", &x.credentials),
                         privilege,
                     },
@@ -581,7 +581,10 @@ impl From<models::Credential> for Credential {
                 privilege,
             } => {
                 credentials.push(("username".to_string(), username));
-                credentials.push(("password".to_string(), password));
+                credentials.push((
+                    "password".to_string(),
+                    password.unwrap_or_default()
+                ));
                 credentials.push(("private".to_string(), private_key));
                 if let Some(p) = privilege {
                     credentials.push(("priv_username".to_string(), p.username));


### PR DESCRIPTION
**What**:
Fix openvasd doesn't support empty passphrase for usk crendential
SC-1233
Close #1831
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
With an empty password the scan is stored but when the start command is sent, I got the following:
`2025-02-11T15:15:21.349117Z  WARN openvasd::controller::results: results sync failed e=storage error occurred: serialization error`

If the password field is not sent at all, the scan is even not stored, with the following response:
`{"line":1,"column":799,"message":"missing field password at line 1 column 799"}`
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
