### PR TITLE
Fix: error output on scannerctl syntax check

### DIFF
--- a/rust/src/nasl/syntax/error.rs
+++ b/rust/src/nasl/syntax/error.rs
@@ -46,7 +46,7 @@ pub enum ErrorKind {
 #[error("{kind}")]
 pub struct SyntaxError {
     /// A human readable reason why this error is returned
-    kind: ErrorKind,
+    pub kind: ErrorKind,
     pub(crate) line: u32,
     pub(crate) file: String,
 }

--- a/rust/src/nasl/syntax/token.rs
+++ b/rust/src/nasl/syntax/token.rs
@@ -436,11 +436,7 @@ impl Token {
 
 impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}:{} {}",
-            self.line_column.0, self.line_column.1, self.category
-        )
+        write!(f, "'{}'", self.category,)
     }
 }
 
@@ -448,6 +444,16 @@ impl Token {
     /// Returns the Category
     pub fn category(&self) -> &Category {
         &self.category
+    }
+
+    /// Returns the line number of the token
+    pub fn line(&self) -> usize {
+        self.line_column.0
+    }
+
+    /// Returns the column number of the token
+    pub fn column(&self) -> usize {
+        self.line_column.1
     }
 
     /// Returns true when an Token is faulty

--- a/rust/src/scannerctl/error.rs
+++ b/rust/src/scannerctl/error.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
 use feed::VerifyError;
@@ -62,10 +63,18 @@ impl CliErrorKind {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("{kind} ({filename})")]
 pub struct CliError {
     pub filename: String,
     pub kind: CliErrorKind,
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.filename.is_empty() {
+            write!(f, "{}: ", self.filename)?;
+        }
+        write!(f, "{}", self.kind)
+    }
 }
 
 impl CliError {


### PR DESCRIPTION
This changes the error output of
scannerctl syntax check
from: `Unclosed token: 8:1 {`
to:
`/var/lib/openvas/plugins/adaptbb_detect.nasl:8:1: Unclosed token: '{'` 

which makes it a lot easier to identify where an syntax error occured.