### PR TITLE
Remove upload artifacts from compile action

### DIFF
--- a/.github/actions/compile-aarch64/action.yml
+++ b/.github/actions/compile-aarch64/action.yml
@@ -24,9 +24,3 @@ runs:
       shell: bash
     - run: mv rust/target/aarch64-unknown-linux-gnu/release/feed-verifier assets/linux/arm64/feed-verifier
       shell: bash
-    - name: archive
-      uses: actions/upload-artifact@v4
-      with:
-        name: rs-binaries
-        path: assets/*
-        retention-days: 1

--- a/.github/actions/compile-x86_64/action.yml
+++ b/.github/actions/compile-x86_64/action.yml
@@ -25,9 +25,3 @@ runs:
       shell: bash
     - run: mv rust/target/x86_64-unknown-linux-gnu/release/feed-verifier assets/linux/amd64/feed-verifier
       shell: bash
-    - name: archive
-      uses: actions/upload-artifact@v4
-      with:
-        name: rs-binaries
-        path: assets/*
-        retention-days: 1

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/compile-x86_64
+      - name: archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: rs-binaries
+          path: assets/*
+          retention-days: 1
   build-image:
     runs-on: self-hosted-generic
     steps:


### PR DESCRIPTION
As github actions does not allow reusing the same
identifier for uploading artifacts it is removed
from the compile action to allow compiling x86_64
and aarch64 successionally.