### PR TITLE
Fix: helm chart routing does not find openvasd

### DIFF
--- a/charts/openvasd/templates/NOTES.txt
+++ b/charts/openvasd/templates/NOTES.txt
@@ -1,24 +1,23 @@
 This deployment takes a while.
 
 To verify if the rollout is complete, you can use:
-  $ kubectl rollout status --watch --timeout 600s deployment/openvasd
+  $ kubectl rollout status --watch --timeout 600s deployment/openvasd -n {{ .Release.Namespace }} 
 
 After the deployment is finished it should be available via:
 {{- if .Values.routing.enabled -}}
-{{- $svcPort := .Values.service.port -}}
 {{- $apiKey := .Values.openvasd.apikey }}
 {{- if eq .Values.openvasd.tls.certificates.deploy_server true }}
 {{- if eq .Values.openvasd.tls.certificates.deploy_client true }}
-  $ curl -vk -x HEAD https://localhost/ --key yourclientkey.rsa --cert yourclientkey.pem
+  $ curl -vk -X HEAD https://localhost/ --key yourclientkey.rsa --cert yourclientkey.pem
 {{- else }}
-  $ curl -vk -x HEAD https://localhost/ -H "X-API-KEY: {{ .apiKey }}"
+  $ curl -vk -X HEAD https://localhost/ -H "X-API-KEY: {{ .apiKey }}"
 {{- end }}
 {{- else }}
-  $ curl -vk -x HEAD https://localhost/ -H "X-API-KEY: {{ .apiKey }}"
+  $ curl -vk -X HEAD https://localhost/ -H "X-API-KEY: {{ .apiKey }}"
 {{- end }}
 {{- else }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "openvasd.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8080 to use your application"
 {{- end }}

--- a/charts/openvasd/templates/routing.yaml
+++ b/charts/openvasd/templates/routing.yaml
@@ -5,6 +5,9 @@ kind: IngressRouteTCP
 metadata:
   name: openvasd-route
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
   {{- if eq .Values.openvasd.tls.certificates.deploy_server true }}
 spec:
   entryPoints:

--- a/charts/openvasd/templates/routing.yaml
+++ b/charts/openvasd/templates/routing.yaml
@@ -4,7 +4,7 @@ apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: openvasd-route
-  namespace: openvasd
+  namespace: {{ .Release.Namespace }}
   {{- if eq .Values.openvasd.tls.certificates.deploy_server true }}
 spec:
   entryPoints:

--- a/charts/openvasd/values.yaml
+++ b/charts/openvasd/values.yaml
@@ -19,7 +19,7 @@ openvasd:
   # Sets the log level and changes the verbosity of openvasd.
   # Can be set to TRACE, DEBUG, INFO, WARNING, ERROR
   # openvasd is provided by the openvas image
-  loglevel: TRACE
+  loglevel: DEBUG
   # When set it will be the used API-KEY. It is not required when deploy_client is true.
   # apikey: changeme
   # can be either service: fill openvasd capabilities, service_notus: only notus
@@ -94,6 +94,7 @@ securityContext:
 
 service:
   type: ClusterIP
+  # type: LoadBalancer
   port: 443
 
 # enables routing.yaml


### PR DESCRIPTION
 Fix: helm chart routing does not find openvasd

To fix the issue that the routing definition cannot find the service
openvasd it has to be defined on post-install, post-upgrade instead of
on-deployment.