### PR TITLE
Instead of implicit latest tag set the latest tag

### DIFF
--- a/.docker/prod-testing.Dockerfile
+++ b/.docker/prod-testing.Dockerfile
@@ -4,7 +4,7 @@ ARG REPOSITORY=greenbone/openvas-scanner
 ARG GVM_LIBS_VERSION=testing-edge
 
 FROM greenbone/openvas-smb:testing-edge AS openvas-smb
-FROM rust AS rust
+FROM rust:latest AS rust
 
 FROM registry.community.greenbone.net/community/gvm-libs:${GVM_LIBS_VERSION} AS build
 COPY . /source

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=edge
 # this allows to override gvm-libs for e.g. smoketests
 ARG GVM_LIBS=registry.community.greenbone.net/community/gvm-libs
 
-FROM rust AS rust
+FROM rust:latest AS rust
 
 FROM greenbone/openvas-smb AS openvas-smb
 


### PR DESCRIPTION
To combat first byte issue when trying to pull rust based on sha sum we specifiy the latest tag.
