### PR TITLE
Add: Nasl builtin function ftp_get_pasv_port

### DIFF
--- a/rust/examples/socket/ftp.nasl
+++ b/rust/examples/socket/ftp.nasl
@@ -12,5 +12,7 @@ display("is function ftp_log_in defined: ", defined_func("ftp_log_in"));
 user = "dlpuser";
 pass = "rNrKYTX9g7z3RgJRmxWuGHbeu";
 display("login succeeded: ", ftp_log_in(user: user, pass: pass, socket: sock));
+port = ftp_get_pasv_port(socket: sock);
+display("pasv port: ", port);
 close(sock);
 display("end");

--- a/rust/src/nasl/builtin/network/README.md
+++ b/rust/src/nasl/builtin/network/README.md
@@ -17,12 +17,12 @@
 - recv_line
 - get_source_port
 - ftp_log_in
+- ftp_get_pasv_port
 - get_port_transport
 - get_host_open_port
 
 ## Missing
 
-- ftp_get_pasv_port
 - get_port_state
 - get_tcp_port_state
 - get_udp_port_state

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -15,6 +15,8 @@ use crate::{
     storage::items::kb::{self, KbKey},
 };
 use dns_lookup::lookup_host;
+use lazy_regex::{lazy_regex, Lazy};
+use regex::Regex;
 use rustls::ClientConnection;
 use thiserror::Error;
 
@@ -25,6 +27,9 @@ use super::{
     tls::create_tls_client,
     udp::UdpConnection,
 };
+
+static FTP_PASV: Lazy<Regex> =
+    lazy_regex!(r"227 Entering Passive Mode \((\d+),(\d+),(\d+),(\d+),(\d+),(\d+)\)");
 
 #[derive(Debug, Error)]
 pub enum SocketError {
@@ -662,6 +667,61 @@ impl NaslSockets {
             NaslSocket::Udp(_) => Err(SocketError::SupportedOnlyOnTcp("ftp_log_in".into())),
         }
     }
+
+    /// This function sets the FTP server into passive mode and returns the port
+    /// the server is listening on.
+    /// Args:
+    /// - socket: an open socket.
+    #[nasl_function(named(socket))]
+    fn ftp_get_pasv_port(&mut self, socket: usize) -> Result<NaslValue, SocketError> {
+        let conn = self.get_open_socket_mut(socket)?;
+        let conn = match conn {
+            NaslSocket::Tcp(conn) => conn,
+            NaslSocket::Udp(_) => {
+                return Err(SocketError::SupportedOnlyOnTcp("ftp_get_pasv_port".into()))
+            }
+        };
+
+        conn.write_all(b"PASV\r\n")?;
+
+        let mut data = String::new();
+        // should be `227 Entering Passive Mode (h1, h2, h3, h4, p1, p2)`
+        conn.read_line(&mut data)?;
+
+        let port = match FTP_PASV.captures(&data) {
+            None => {
+                return Err(SocketError::Diagnostic(format!(
+                    "Unexpected response from FTP server: {}",
+                    data
+                )))
+            }
+            Some(captures) => {
+                let p1 = captures
+                    .get(5)
+                    .unwrap()
+                    .as_str()
+                    .parse::<u16>()
+                    .map_err(|e| {
+                        SocketError::Diagnostic(format!(
+                            "{e}, invalid port within response: {data}"
+                        ))
+                    })?;
+                let p2 = captures
+                    .get(6)
+                    .unwrap()
+                    .as_str()
+                    .parse::<u16>()
+                    .map_err(|e| {
+                        SocketError::Diagnostic(format!(
+                            "{e}, invalid port within response: {data}"
+                        ))
+                    })?;
+                (p1 << 8) | p2
+            }
+        };
+
+        Ok(NaslValue::Number(port as i64))
+    }
 }
 
 function_set! {
@@ -678,5 +738,6 @@ function_set! {
         (NaslSockets::recv_line, "recv_line"),
         (NaslSockets::get_source_port, "get_source_port"),
         (NaslSockets::ftp_log_in, "ftp_log_in"),
+        (NaslSockets::ftp_get_pasv_port, "ftp_get_pasv_port"),
     )
 }


### PR DESCRIPTION
The `ftp_get_pasv_port` sends the ´PASV´ command to a ftp server, which sets it in passive mode and returns the corresponding port.

I used this command: `target/release/scannerctl execute script -t 44.241.66.173 examples/socket/ftp.nasl` to test the functionality. `44.241.66.173` is a public ftp server for testing.

SC-1120