### PR TITLE
Fix newly merged PRs due to edition bump

### DIFF
--- a/rust/benches/interpreter.rs
+++ b/rust/benches/interpreter.rs
@@ -1,9 +1,7 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use futures::StreamExt;
-use scannerlib::{
-    nasl::{ContextFactory, Register, interpreter::ForkingInterpreter},
-    storage::ContextKey,
-};
+use scannerlib::nasl::{ContextFactory, Register, interpreter::ForkingInterpreter};
+use scannerlib::storage::ScanID;
 
 pub fn run_interpreter_in_description_mode(c: &mut Criterion) {
     let code = include_str!("../data/nasl_syntax/simple_parse.nasl");
@@ -13,7 +11,7 @@ pub fn run_interpreter_in_description_mode(c: &mut Criterion) {
             futures::executor::block_on(async {
                 let register = Register::root_initial(&variables);
                 let context_factory = ContextFactory::default();
-                let context = context_factory.build(ContextKey::FileName("test.nasl".to_string()));
+                let context = context_factory.build(ScanID("test.nasl".to_string()), "", "".into());
                 let parser = ForkingInterpreter::new(&code, register, &context);
                 let _: Vec<_> = black_box(parser.stream().collect().await);
             });

--- a/rust/benches/interpreter.rs
+++ b/rust/benches/interpreter.rs
@@ -1,7 +1,7 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use futures::StreamExt;
 use scannerlib::{
-    nasl::{interpreter::ForkingInterpreter, ContextFactory, Register},
+    nasl::{ContextFactory, Register, interpreter::ForkingInterpreter},
     storage::ContextKey,
 };
 

--- a/rust/src/openvasd/controller/entry.rs
+++ b/rust/src/openvasd/controller/entry.rs
@@ -701,8 +701,8 @@ pub mod client {
         Client::authenticated(scanner, storage)
     }
 
-    pub async fn fails_to_fetch_results(
-    ) -> Client<LambdaScanner, Arc<ResultCatcher<inmemory::Storage<crate::crypt::ChaCha20Crypt>>>>
+    pub async fn fails_to_fetch_results()
+    -> Client<LambdaScanner, Arc<ResultCatcher<inmemory::Storage<crate::crypt::ChaCha20Crypt>>>>
     {
         use crate::file::tests::example_feeds;
         let storage = crate::storage::inmemory::Storage::default();


### PR DESCRIPTION
This was necessary due to the rust 2024 changes which made rustfmt change the way that the newly merged PR was formatted.
