### PR TITLE
Use community.greenbone.net for CI docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,8 @@ on: [workflow_call]
 jobs:
   C:
     runs-on: self-hosted-generic
-    container: greenbone/gvm-libs:stable
+    container:
+      image: registry.community.greenbone.net/community/gvm-libs:stable
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    container: greenbone/gvm-libs:edge
+    container:
+      image: registry.community.greenbone.net/community/gvm-libs:edge
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -134,7 +134,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     container:
-      image: greenbone/gvm-libs:stable
+      image: registry.community.greenbone.net/community/gvm-libs:stable
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,8 @@ on: [workflow_call]
 jobs:
   C:
     runs-on: self-hosted-generic
-    container: greenbone/gvm-libs:stable
+    container:
+      image: registry.community.greenbone.net/community/gvm-libs:stable
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies


### PR DESCRIPTION
All CI running on the dockerhub containers is currently broken. This fixes it by pointing to the community containers.

Jira: SC-1273