### PR TITLE
Prevent misuse of `context()` on `TestBuilder`.

### DIFF
--- a/rust/src/nasl/builtin/report_functions/tests.rs
+++ b/rust/src/nasl/builtin/report_functions/tests.rs
@@ -20,8 +20,7 @@ mod tests {
         "###
         ));
         t.check_no_errors();
-        let results = t.results();
-        let context = t.context();
+        let (results, context) = t.results_and_context();
         let get_result = |index| {
             context
                 .storage()

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -216,13 +216,20 @@ where
         self.should_verify = false;
     }
 
-    /// Return the list of results returned by all the lines of
-    /// code.
+    /// Runs the given lines of code and returns the list of results.
     pub fn results(&self) -> Vec<NaslResult> {
+        self.results_and_context().0
+    }
+
+    /// Runs the given lines of code and returns the list of results
+    /// along with the `Context` used for evaluating them.
+    pub fn results_and_context(&self) -> (Vec<NaslResult>, Context) {
         futures::executor::block_on(async {
-            self.results_stream(&self.code(), &self.context())
-                .collect()
-                .await
+            let context = self.context();
+            (
+                self.results_stream(&self.code(), &context).collect().await,
+                context,
+            )
         })
     }
 
@@ -276,8 +283,7 @@ where
         })
     }
 
-    /// Get the currently set `Context`.
-    pub fn context(&self) -> Context {
+    fn context(&self) -> Context {
         self.context
             .build(self.scan_id.clone(), &self.target, self.filename.clone())
     }


### PR DESCRIPTION
The `context()` constructs a `Context` from the given data in the `TestBuilder` and returns it. As a user of `TestBuilder`, it is tempting to take the generated `Context` to set certain properties before running the test. However, in the current structure, any changes made to the context in this way will be discarded anyways, since the `Context` will be rebuilt from scratch when the code is actually executed.

There is also no way to change the behavior (for example by returning a `&mut Context`) in the current structure, because the `Context` has to be created when `context` is called, so there is no lifetime we could return, the only thing to do is to transfer ownership.

In order to prevent this misuse, this commit makes the `context` method private. A test that uses it is rewritten to use a new `results_and_context` method which returns the results of the code along with the `Context` used to obtain them.

Jira: SC-1272