### PR TITLE
Use target in builtins

### DIFF
--- a/rust/src/nasl/builtin/host/mod.rs
+++ b/rust/src/nasl/builtin/host/mod.rs
@@ -36,16 +36,16 @@ impl<'a> FromNaslValue<'a> for Hostname {
 /// Get a list of found hostnames or a IP of the current target in case no hostnames were found yet.
 #[nasl_function]
 fn get_host_names(context: &Context) -> Result<NaslValue, FnError> {
-    let hns = context.target_vhosts();
+    let hns = context.target().vhosts();
     if !hns.is_empty() {
         let hns = hns
-            .into_iter()
-            .map(|(h, _s)| NaslValue::String(h))
+            .iter()
+            .map(|(h, _s)| NaslValue::String(h.to_string()))
             .collect::<Vec<_>>();
         return Ok(NaslValue::Array(hns));
     };
     Ok(NaslValue::Array(vec![NaslValue::String(
-        context.target_ip().to_string(),
+        context.target().ip_addr().to_string(),
     )]))
 }
 
@@ -66,7 +66,7 @@ pub fn add_host_name(
 /// Get the host name of the currently scanned target. If there is no host name available, the IP of the target is returned instead.
 #[nasl_function]
 pub fn get_host_name(_register: &Register, context: &Context) -> Result<NaslValue, FnError> {
-    let vh = context.target_vhosts();
+    let vh = context.target().vhosts();
     let v = if !vh.is_empty() {
         vh.iter()
             .map(|(v, _s)| NaslValue::String(v.to_string()))
@@ -101,10 +101,10 @@ pub fn get_host_name(_register: &Register, context: &Context) -> Result<NaslValu
 /// If no virtual hosts are found yet this function always returns IP-address.
 #[nasl_function(named(hostname))]
 pub fn get_host_name_source(context: &Context, hostname: Hostname) -> String {
-    let vh = context.target_vhosts();
+    let vh = context.target().vhosts();
     if !vh.is_empty() {
-        if let Some((_, source)) = vh.into_iter().find(|(v, _)| v == &hostname.0) {
-            return source;
+        if let Some((_, source)) = vh.iter().find(|(v, _)| v == &hostname.0) {
+            return source.to_string();
         };
     }
     context.target().original_target_str().to_string()
@@ -113,7 +113,7 @@ pub fn get_host_name_source(context: &Context, hostname: Hostname) -> String {
 /// Return the target's IP address or 127.0.0.1 if not set.
 #[nasl_function]
 fn nasl_get_host_ip(context: &Context) -> Result<NaslValue, FnError> {
-    let ip = context.target_ip();
+    let ip = context.target().ip_addr();
     Ok(NaslValue::String(ip.to_string()))
 }
 

--- a/rust/src/nasl/builtin/host/mod.rs
+++ b/rust/src/nasl/builtin/host/mod.rs
@@ -82,15 +82,15 @@ pub fn get_host_name(_register: &Register, context: &Context) -> Result<NaslValu
         return Ok(NaslValue::Fork(v));
     }
 
-    let host = match context.target_orig().kind() {
+    let host = match context.target().kind() {
         TargetKind::IpAddr => {
-            let ip_addr = context.target_orig().ip_addr();
+            let ip_addr = context.target().ip_addr();
             match lookup_addr(&ip_addr) {
                 Ok(host) => host,
                 Err(_) => ip_addr.to_string(),
             }
         }
-        TargetKind::Hostname => context.target_orig().original_target_str().to_string(),
+        TargetKind::Hostname => context.target().original_target_str().to_string(),
     };
     Ok(NaslValue::String(host))
 }
@@ -107,7 +107,7 @@ pub fn get_host_name_source(context: &Context, hostname: Hostname) -> String {
             return source;
         };
     }
-    context.target_orig().original_target_str().to_string()
+    context.target().original_target_str().to_string()
 }
 
 /// Return the target's IP address or 127.0.0.1 if not set.
@@ -140,7 +140,7 @@ fn resolve_hostname_to_multiple_ips(hostname: Hostname) -> Result<NaslValue, FnE
 /// Return TRUE if the current target is an IPv6 address, else FALSE.
 #[nasl_function]
 fn target_is_ipv6(context: &Context) -> bool {
-    context.target_orig().ip_addr().is_ipv6()
+    context.target().ip_addr().is_ipv6()
 }
 
 /// Compare if two hosts are the same.

--- a/rust/src/nasl/builtin/host/mod.rs
+++ b/rust/src/nasl/builtin/host/mod.rs
@@ -5,16 +5,11 @@
 #[cfg(test)]
 mod tests;
 
-use std::{
-    net::{IpAddr, Ipv6Addr},
-    str::FromStr,
-};
-
 use dns_lookup::lookup_addr;
 use thiserror::Error;
 
-use crate::nasl::prelude::*;
 use crate::nasl::utils::hosts::resolve_hostname;
+use crate::nasl::{prelude::*, utils::context::TargetKind};
 
 #[derive(Debug, Error)]
 pub enum HostError {
@@ -50,25 +45,8 @@ fn get_host_names(context: &Context) -> Result<NaslValue, FnError> {
         return Ok(NaslValue::Array(hns));
     };
     Ok(NaslValue::Array(vec![NaslValue::String(
-        context.target().to_string(),
+        context.target_ip().to_string(),
     )]))
-}
-
-/// Return the target's IP address as IpAddr.
-pub fn get_host_ip(context: &Context) -> Result<IpAddr, FnError> {
-    let default_ip = "127.0.0.1";
-    let r_sock_addr = match context.target() {
-        x if !x.is_empty() => IpAddr::from_str(x),
-        _ => IpAddr::from_str(default_ip),
-    };
-
-    match r_sock_addr {
-        Ok(x) => Ok(x),
-        Err(e) => Err(FnError::wrong_unnamed_argument(
-            "IP address",
-            e.to_string().as_str(),
-        )),
-    }
 }
 
 ///Expands the vHosts list with the given hostname.
@@ -104,12 +82,15 @@ pub fn get_host_name(_register: &Register, context: &Context) -> Result<NaslValu
         return Ok(NaslValue::Fork(v));
     }
 
-    let host = match get_host_ip(context) {
-        Ok(ip) => match lookup_addr(&ip) {
-            Ok(host) => host,
-            Err(_) => ip.to_string(),
-        },
-        Err(_) => context.target().to_string(),
+    let host = match context.target_orig().kind() {
+        TargetKind::IpAddr => {
+            let ip_addr = context.target_orig().ip_addr();
+            match lookup_addr(&ip_addr) {
+                Ok(host) => host,
+                Err(_) => ip_addr.to_string(),
+            }
+        }
+        TargetKind::Hostname => context.target_orig().original_target_str().to_string(),
     };
     Ok(NaslValue::String(host))
 }
@@ -126,13 +107,13 @@ pub fn get_host_name_source(context: &Context, hostname: Hostname) -> String {
             return source;
         };
     }
-    context.target().to_string()
+    context.target_orig().original_target_str().to_string()
 }
 
 /// Return the target's IP address or 127.0.0.1 if not set.
 #[nasl_function]
 fn nasl_get_host_ip(context: &Context) -> Result<NaslValue, FnError> {
-    let ip = get_host_ip(context)?;
+    let ip = context.target_ip();
     Ok(NaslValue::String(ip.to_string()))
 }
 
@@ -156,16 +137,10 @@ fn resolve_hostname_to_multiple_ips(hostname: Hostname) -> Result<NaslValue, FnE
 }
 
 /// Check if the currently scanned target is an IPv6 address.
-/// Return TRUE if the current target is an IPv6 address, else FALSE. In case of an error, NULL is returned.
+/// Return TRUE if the current target is an IPv6 address, else FALSE.
 #[nasl_function]
-fn target_is_ipv6(context: &Context) -> Result<bool, FnError> {
-    let target = match context.target().is_empty() {
-        true => {
-            return Err(HostError::EmptyAddress.into());
-        }
-        false => context.target(),
-    };
-    Ok(target.parse::<Ipv6Addr>().is_ok())
+fn target_is_ipv6(context: &Context) -> bool {
+    context.target_orig().ip_addr().is_ipv6()
 }
 
 /// Compare if two hosts are the same.

--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -128,7 +128,7 @@ impl ServerCertVerifier for NoVerifier {
 impl NaslHttp {
     async fn request(
         &self,
-        ip_str: &String,
+        ip_str: &str,
         port: u16,
         uri: String,
         data: String,
@@ -145,7 +145,7 @@ impl NaslHttp {
         // For HTTP/2. For older HTTP versions should not be set,
         config.alpn_protocols = vec![b"h2".to_vec()];
 
-        let server_name = ip_str.clone().to_owned().try_into().unwrap();
+        let server_name = ip_str.to_owned().try_into().unwrap();
 
         let connector = TlsConnector::from(Arc::new(config));
         let stream = TcpStream::connect(format!("{}:{}", ip_str, port))
@@ -243,10 +243,7 @@ impl NaslHttp {
             _ => 0u16,
         };
 
-        let ip_str: String = match ctx.target() {
-            x if !x.is_empty() => x.to_string(),
-            _ => "127.0.0.1".to_string(),
-        };
+        let ip_str = ctx.target_orig().original_target_str();
 
         let mut uri: String;
         if port != 80 && port != 443 {
@@ -258,7 +255,7 @@ impl NaslHttp {
         uri = format!("{}{}", uri, item);
 
         let (head, body) = self
-            .request(&ip_str, port, uri, data, method, handle)
+            .request(ip_str, port, uri, data, method, handle)
             .await?;
         handle.http_code = head.status.as_u16();
         let mut header_str = String::new();

--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -243,19 +243,19 @@ impl NaslHttp {
             _ => 0u16,
         };
 
-        let ip_str = ctx.target().original_target_str();
+        let target_str = ctx.target().original_target_str();
 
         let mut uri: String;
         if port != 80 && port != 443 {
-            uri = format!("{}://{}:{}", schema, ip_str, port);
+            uri = format!("{}://{}:{}", schema, target_str, port);
         } else {
-            uri = format!("{}://{}", schema, ip_str)
+            uri = format!("{}://{}", schema, target_str)
         }
 
         uri = format!("{}{}", uri, item);
 
         let (head, body) = self
-            .request(ip_str, port, uri, data, method, handle)
+            .request(target_str, port, uri, data, method, handle)
             .await?;
         handle.http_code = head.status.as_u16();
         let mut header_str = String::new();

--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -243,7 +243,7 @@ impl NaslHttp {
             _ => 0u16,
         };
 
-        let ip_str = ctx.target_orig().original_target_str();
+        let ip_str = ctx.target().original_target_str();
 
         let mut uri: String;
         if port != 80 && port != 443 {

--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -18,13 +18,13 @@ use nasl_function_proc_macro::nasl_function;
 /// Get the IP address of the currently scanned host
 #[nasl_function]
 fn get_host_ip(context: &Context) -> String {
-    context.target_orig().ip_addr().to_string()
+    context.target().ip_addr().to_string()
 }
 
 /// Get the IP address of the current (attacking) machine depending on which network device is used
 #[nasl_function]
 fn this_host(context: &Context) -> Result<String, SocketError> {
-    let dst = context.target_orig().ip_addr();
+    let dst = context.target().ip_addr();
 
     let port: u16 = DEFAULT_PORT;
 
@@ -46,20 +46,20 @@ fn this_host_name() -> String {
 /// get the maximum transition unit for the scanned host
 #[nasl_function]
 fn get_mtu(context: &Context) -> Result<i64, SocketError> {
-    Ok(mtu(context.target_orig().ip_addr()) as i64)
+    Ok(mtu(context.target().ip_addr()) as i64)
 }
 
 /// check if the currently scanned host is the localhost
 #[nasl_function]
 fn nasl_islocalhost(context: &Context) -> Result<bool, SocketError> {
-    let host_ip = context.target_orig().ip_addr();
+    let host_ip = context.target().ip_addr();
     Ok(islocalhost(host_ip))
 }
 
 /// Check if the target host is on the same network as the attacking host
 #[nasl_function]
 fn islocalnet(context: &Context) -> Result<bool, SocketError> {
-    let dst = context.target_orig().ip_addr();
+    let dst = context.target().ip_addr();
     let src = get_source_ip(dst, DEFAULT_PORT)?;
     let netmask = match get_netmask_by_local_ip(src)? {
         Some(netmask) => netmask,

--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -7,7 +7,7 @@ use std::{net::IpAddr, process::Command};
 use super::socket::SocketError;
 use super::{
     DEFAULT_PORT,
-    network_utils::{get_netmask_by_local_ip, get_source_ip, ipstr2ipaddr, islocalhost},
+    network_utils::{get_netmask_by_local_ip, get_source_ip, islocalhost},
 };
 use super::{NaslValue, Port, mtu};
 use crate::function_set;
@@ -18,13 +18,13 @@ use nasl_function_proc_macro::nasl_function;
 /// Get the IP address of the currently scanned host
 #[nasl_function]
 fn get_host_ip(context: &Context) -> String {
-    context.target().to_string()
+    context.target_orig().ip_addr().to_string()
 }
 
 /// Get the IP address of the current (attacking) machine depending on which network device is used
 #[nasl_function]
 fn this_host(context: &Context) -> Result<String, SocketError> {
-    let dst = ipstr2ipaddr(context.target())?;
+    let dst = context.target_orig().ip_addr();
 
     let port: u16 = DEFAULT_PORT;
 
@@ -46,21 +46,20 @@ fn this_host_name() -> String {
 /// get the maximum transition unit for the scanned host
 #[nasl_function]
 fn get_mtu(context: &Context) -> Result<i64, SocketError> {
-    let target = ipstr2ipaddr(context.target())?;
-    Ok(mtu(target) as i64)
+    Ok(mtu(context.target_orig().ip_addr()) as i64)
 }
 
 /// check if the currently scanned host is the localhost
 #[nasl_function]
 fn nasl_islocalhost(context: &Context) -> Result<bool, SocketError> {
-    let host_ip = ipstr2ipaddr(context.target())?;
+    let host_ip = context.target_orig().ip_addr();
     Ok(islocalhost(host_ip))
 }
 
 /// Check if the target host is on the same network as the attacking host
 #[nasl_function]
 fn islocalnet(context: &Context) -> Result<bool, SocketError> {
-    let dst = ipstr2ipaddr(context.target())?;
+    let dst = context.target_orig().ip_addr();
     let src = get_source_ip(dst, DEFAULT_PORT)?;
     let netmask = match get_netmask_by_local_ip(src)? {
         Some(netmask) => netmask,

--- a/rust/src/nasl/builtin/network/network_utils.rs
+++ b/rust/src/nasl/builtin/network/network_utils.rs
@@ -12,14 +12,6 @@ use std::{
 
 use super::socket::SocketError;
 
-/// Convert a string in a IpAddr
-pub fn ipstr2ipaddr(ip_addr: &str) -> Result<IpAddr, SocketError> {
-    match IpAddr::from_str(ip_addr) {
-        Ok(ip) => Ok(ip),
-        Err(_) => Err(SocketError::InvalidIpAddress(ip_addr.into())),
-    }
-}
-
 /// Convert timeout
 pub fn convert_timeout(timeout: Option<i64>) -> Option<Duration> {
     timeout

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -445,7 +445,7 @@ impl NaslSockets {
     ) -> Result<NaslValue, FnError> {
         let transport = transport.unwrap_or(-1);
 
-        let addr = context.target_orig().ip_addr();
+        let addr = context.target().ip_addr();
 
         self.wait_before_next_probe();
 
@@ -495,7 +495,7 @@ impl NaslSockets {
     /// Open a UDP socket to the target host
     #[nasl_function]
     fn open_sock_udp(&mut self, context: &Context, port: Port) -> Result<NaslValue, FnError> {
-        let addr = context.target_orig().ip_addr();
+        let addr = context.target().ip_addr();
 
         let socket = NaslSocket::Udp(UdpConnection::new(addr, port.0)?);
         let fd = self.add(socket);
@@ -572,7 +572,7 @@ impl NaslSockets {
         dport: Port,
         sport: Option<Port>,
     ) -> Result<NaslValue, FnError> {
-        let addr = context.target_orig().ip_addr();
+        let addr = context.target().ip_addr();
         self.open_priv_sock(addr, dport, sport, true)
     }
 
@@ -588,7 +588,7 @@ impl NaslSockets {
         dport: Port,
         sport: Option<Port>,
     ) -> Result<NaslValue, FnError> {
-        let addr = context.target_orig().ip_addr();
+        let addr = context.target().ip_addr();
         self.open_priv_sock(addr, dport, sport, false)
     }
 

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -21,11 +21,8 @@ use rustls::ClientConnection;
 use thiserror::Error;
 
 use super::{
-    OpenvasEncaps, Port, get_retry,
-    network_utils::{convert_timeout, ipstr2ipaddr},
-    tcp::TcpConnection,
-    tls::create_tls_client,
-    udp::UdpConnection,
+    OpenvasEncaps, Port, get_retry, network_utils::convert_timeout, tcp::TcpConnection,
+    tls::create_tls_client, udp::UdpConnection,
 };
 
 static FTP_PASV: Lazy<Regex> =
@@ -448,7 +445,7 @@ impl NaslSockets {
     ) -> Result<NaslValue, FnError> {
         let transport = transport.unwrap_or(-1);
 
-        let addr = ipstr2ipaddr(context.target())?;
+        let addr = context.target_orig().ip_addr();
 
         self.wait_before_next_probe();
 
@@ -498,7 +495,7 @@ impl NaslSockets {
     /// Open a UDP socket to the target host
     #[nasl_function]
     fn open_sock_udp(&mut self, context: &Context, port: Port) -> Result<NaslValue, FnError> {
-        let addr = ipstr2ipaddr(context.target())?;
+        let addr = context.target_orig().ip_addr();
 
         let socket = NaslSocket::Udp(UdpConnection::new(addr, port.0)?);
         let fd = self.add(socket);
@@ -575,7 +572,7 @@ impl NaslSockets {
         dport: Port,
         sport: Option<Port>,
     ) -> Result<NaslValue, FnError> {
-        let addr = ipstr2ipaddr(context.target())?;
+        let addr = context.target_orig().ip_addr();
         self.open_priv_sock(addr, dport, sport, true)
     }
 
@@ -591,7 +588,7 @@ impl NaslSockets {
         dport: Port,
         sport: Option<Port>,
     ) -> Result<NaslValue, FnError> {
-        let addr = ipstr2ipaddr(context.target())?;
+        let addr = context.target_orig().ip_addr();
         self.open_priv_sock(addr, dport, sport, false)
     }
 

--- a/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
@@ -11,8 +11,6 @@ use std::{net::Ipv4Addr, str::FromStr};
 
 use pcap::{Capture, Device};
 
-use super::super::host::get_host_ip;
-
 use super::RawIpError;
 use super::raw_ip_utils::{get_interface_by_local_ip, get_source_ip, ipstr2ipaddr};
 
@@ -359,7 +357,7 @@ fn nasl_send_arp_request(register: &Register, context: &Context) -> Result<NaslV
         }
     };
 
-    let target_ip = get_host_ip(context)?;
+    let target_ip = context.target().ip_addr();
 
     if target_ip.is_ipv6() {
         return Err(FnError::wrong_unnamed_argument(
@@ -499,7 +497,7 @@ fn nasl_send_frame(register: &Register, context: &Context) -> Result<NaslValue, 
         }
     };
 
-    let target_ip = get_host_ip(context)?;
+    let target_ip = context.target().ip_addr();
 
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;

--- a/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
@@ -14,7 +14,6 @@ use super::{
     raw_ip_utils::{get_interface_by_local_ip, get_source_ip, islocalhost},
 };
 
-use super::super::host::get_host_ip;
 use crate::nasl::builtin::misc::random_impl;
 use crate::nasl::prelude::*;
 use crate::nasl::syntax::NaslValue;
@@ -364,7 +363,7 @@ fn forge_ip_packet(
     ip_src: Option<Ipv4Addr>,
     ip_sum: Option<u16>,
 ) -> Result<NaslValue, FnError> {
-    let dst_addr = get_host_ip(configs)?;
+    let dst_addr = configs.target().ip_addr();
     if !dst_addr.is_ipv4() {
         return Err(ArgumentError::WrongArgument(
             "forge_ip_packet: No valid dst_addr could be determined via call to get_host_ip()"
@@ -1979,7 +1978,7 @@ fn nasl_tcp_ping(configs: &Context, port: Option<u16>) -> Result<NaslValue, FnEr
     };
 
     // Get the iface name, to set the capture device.
-    let target_ip = get_host_ip(configs)?;
+    let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
 
@@ -2106,7 +2105,7 @@ fn nasl_send_packet(
     let _dflt_packet_sz = length.unwrap_or_default();
 
     // Get the iface name, to set the capture device.
-    let target_ip = get_host_ip(configs)?;
+    let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
 
@@ -2183,7 +2182,7 @@ fn nasl_send_capture(
     let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT_SEC) * 1000;
 
     // Get the iface name, to set the capture device.
-    let target_ip = get_host_ip(configs)?;
+    let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let mut iface = get_interface_by_local_ip(local_ip)?;
     if !interface.is_empty() {
@@ -2241,7 +2240,7 @@ fn forge_ip_v6_packet(
     ip6_src: Option<Ipv6Addr>,
     ip6_dst: Option<Ipv6Addr>,
 ) -> Result<NaslValue, FnError> {
-    let dst_addr = get_host_ip(configs)?;
+    let dst_addr = configs.target().ip_addr();
     if !dst_addr.is_ipv6() {
         return Err(FnError::wrong_unnamed_argument(
             "IPv6",
@@ -3178,7 +3177,7 @@ fn nasl_tcp_v6_ping(configs: &Context, port: Option<u16>) -> Result<NaslValue, F
     };
 
     // Get the iface name, to set the capture device.
-    let target_ip = get_host_ip(configs)?;
+    let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
 
@@ -3298,7 +3297,7 @@ fn nasl_send_v6packet(
     let _dflt_packet_sz = length.unwrap_or_default();
 
     // Get the iface name, to set the capture device.
-    let target_ip = get_host_ip(configs)?;
+    let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
 

--- a/rust/src/nasl/builtin/report_functions/mod.rs
+++ b/rust/src/nasl/builtin/report_functions/mod.rs
@@ -49,7 +49,7 @@ impl Reporting {
             Some("udp") => Protocol::UDP,
             _ => Protocol::TCP,
         };
-        let target = context.target_orig();
+        let target = context.target();
         let hostname = target.hostname();
         let ip_address = target.ip_addr();
         let result = models::Result {

--- a/rust/src/nasl/builtin/report_functions/mod.rs
+++ b/rust/src/nasl/builtin/report_functions/mod.rs
@@ -49,12 +49,14 @@ impl Reporting {
             Some("udp") => Protocol::UDP,
             _ => Protocol::TCP,
         };
+        let target = context.target_orig();
+        let hostname = target.hostname();
+        let ip_address = target.ip_addr();
         let result = models::Result {
             id: self.id(),
             r_type: typus,
-            ip_address: Some(context.target().to_string()),
-            // TODO: where to get hostname? is it only vhost relevant?
-            hostname: None,
+            ip_address: Some(ip_address.to_string()),
+            hostname,
             oid: Some(context.scan().0.clone()),
             port,
             protocol: Some(protocol),

--- a/rust/src/nasl/builtin/report_functions/tests.rs
+++ b/rust/src/nasl/builtin/report_functions/tests.rs
@@ -37,8 +37,8 @@ mod tests {
         let create_expected = |id, port, protocol| models::Result {
             id,
             r_type: result_type.clone(),
-            ip_address: Some(context.target().to_string()),
-            hostname: None,
+            ip_address: Some(context.target_orig().ip_addr().to_string()),
+            hostname: Some("".into()),
             oid: Some(context.scan().0.clone()),
             port,
             protocol: Some(protocol),

--- a/rust/src/nasl/builtin/report_functions/tests.rs
+++ b/rust/src/nasl/builtin/report_functions/tests.rs
@@ -37,7 +37,7 @@ mod tests {
         let create_expected = |id, port, protocol| models::Result {
             id,
             r_type: result_type.clone(),
-            ip_address: Some(context.target_orig().ip_addr().to_string()),
+            ip_address: Some(context.target().ip_addr().to_string()),
             hostname: Some("".into()),
             oid: Some(context.scan().0.clone()),
             port,

--- a/rust/src/nasl/builtin/ssh/mod.rs
+++ b/rust/src/nasl/builtin/ssh/mod.rs
@@ -152,7 +152,7 @@ impl Ssh {
         let port = port
             .filter(|_| socket.is_none())
             .unwrap_or(DEFAULT_SSH_PORT);
-        let ip = *ctx.target_ip();
+        let ip = ctx.target().ip_addr();
         let timeout = timeout.map(Duration::from_secs);
         let keytype = keytype
             .map(|keytype| keytype.0)

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -450,6 +450,15 @@ impl Target {
     pub fn kind(&self) -> &TargetKind {
         &self.kind
     }
+
+    /// Return the hostname that this `Target` was constructed with
+    /// or None otherwise
+    pub(crate) fn hostname(&self) -> Option<String> {
+        match self.kind {
+            TargetKind::Hostname => Some(self.original_target_str.clone()),
+            TargetKind::IpAddr => None,
+        }
+    }
 }
 
 impl From<Target> for CtxTarget {

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -379,7 +379,7 @@ pub struct Target {
 
 /// Specifies whether the string given to `Target` was a hostname
 /// or an ip address.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TargetKind {
     Hostname,
     IpAddr,
@@ -443,6 +443,10 @@ impl Target {
         &self.original_target_str
     }
 
+    pub fn ip_addr(&self) -> IpAddr {
+        self.ip_addr
+    }
+
     pub fn kind(&self) -> &TargetKind {
         &self.kind
     }
@@ -469,6 +473,10 @@ impl CtxTarget {
 
     fn ip_addr(&self) -> &IpAddr {
         &self.target.ip_addr
+    }
+
+    fn target(&self) -> &Target {
+        &self.target
     }
 }
 
@@ -588,6 +596,11 @@ impl<'a> Context<'a> {
 
     pub fn filename(&self) -> &PathBuf {
         &self.filename
+    }
+
+    // TODO rename to target
+    pub fn target_orig(&self) -> &Target {
+        self.target.target()
     }
 
     /// Get the target (hostname or ip address).

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -607,14 +607,8 @@ impl<'a> Context<'a> {
         &self.filename
     }
 
-    // TODO rename to target
-    pub fn target_orig(&self) -> &Target {
+    pub fn target(&self) -> &Target {
         self.target.target()
-    }
-
-    /// Get the target (hostname or ip address).
-    pub fn target(&self) -> &str {
-        self.target.original_target_str()
     }
 
     /// Get the ip address of the target.


### PR DESCRIPTION
Use the `Target` field of `Context` in all builtins to ensure consistency and to actually use the hostname resolution.

Jira: SC-1289

