### PR TITLE
Fix crash during feed transform .

### DIFF
--- a/rust/src/storage/infisto/json/mod.rs
+++ b/rust/src/storage/infisto/json/mod.rs
@@ -135,7 +135,8 @@ impl<S: Write> Dispatcher<FileName> for JsonStorage<S> {
 impl<S: Write> Dispatcher<FeedVersion> for JsonStorage<S> {
     type Item = String;
     fn dispatch(&self, _: FeedVersion, _: Self::Item) -> Result<(), StorageError> {
-        unimplemented!()
+        // TODO: Feed information is currently not written to the output json
+        Ok(())
     }
 }
 


### PR DESCRIPTION
After #1813, the feed transform into json would crash due to a `unimplemented!()` in the dispatching of `FeedVersion` to the storage.

This reverts back to the state before #1813, where the feed version information would simply not be exported to json.

Jira: SC-1287