### PR TITLE
Fix: solve issue when using cmake>4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.10)
 
 message ("-- Configuring the Scanner...")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if (NOT CMAKE_BUILD_TYPE MATCHES "Release")
     add_custom_target (revisiontag ALL)
 
     # creates gitversion.h using cmake script
-    add_custom_command (TARGET revisiontag COMMAND ${CMAKE_COMMAND}
+    add_custom_command (TARGET revisiontag POST_BUILD COMMAND ${CMAKE_COMMAND}
                         -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
                         -P ${CMAKE_SOURCE_DIR}/cmake/GetGit.cmake)
 


### PR DESCRIPTION
**What**:
Solve issue when using cmake>4.0
Closes #1889 
Jira: SC-1296
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Cmake v4.0 or later don't work anymore with deprecated stuff from cmake version < 3.5. Also, it triggers a warning if the minimum version is set to somethink <3.10.

Therefore, setting the minimum required version to 3.10.

I have tested with version 4.0.1 and cmake works as expected, so nothing else to be changed beside the version. Also, we need to support at least cmake 3.18, the one in Debian Bullseye, one of our supported base systems.

<!-- Why are these changes necessary? -->

**How**:
Install cmake 4.0 or later and try to compile from sources.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
