### PR TITLE
Transport value for sockets

### DIFF
--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -427,36 +427,49 @@ fn open_sock_tcp_vhost(
     port: u16,
     vhost: &str,
     transport: i64,
-) -> Result<Option<NaslSocket>, SocketError> {
-    if transport < 0 {
-        // TODO: Get port transport and open connection depending on it
-        todo!()
-    }
+) -> Result<Option<NaslSocket>, FnError> {
+    let mut transport = if transport.is_negative() {
+        context.get_port_transport(port)?.unwrap_or(1)
+    } else {
+        transport
+    };
+    let mut set_transport = false;
     let tls = match OpenvasEncaps::from_i64(transport) {
         // Auto Detection
         Some(OpenvasEncaps::Auto) => {
+            set_transport = true;
             // Try SSL/TLS first
-            make_tls_client_connection(context, vhost)
+            let tls = make_tls_client_connection(context, vhost);
+            if tls.is_some() {
+                transport = OpenvasEncaps::TlsCustom as i64;
+            } else {
+                // Try TCP
+                transport = OpenvasEncaps::Ip as i64;
+            }
+            tls
         }
         // IP
         Some(OpenvasEncaps::Ip) => None,
         // Unsupported transport layer
         None | Some(OpenvasEncaps::Max) => {
-            return Err(SocketError::UnsupportedTransportLayerUnknown(transport));
+            return Err(SocketError::UnsupportedTransportLayerUnknown(transport).into());
         }
         // TLS/SSL
         Some(tls_version) => match tls_version {
             OpenvasEncaps::Tls12 | OpenvasEncaps::Tls13 => {
                 make_tls_client_connection(context, vhost)
             }
-            _ => return Err(SocketError::UnsupportedTransportLayerTlsVersion(transport)),
+            _ => return Err(SocketError::UnsupportedTransportLayerTlsVersion(transport).into()),
         },
     };
-    Ok(
-        TcpConnection::connect(addr, port, tls, timeout, bufsz, get_retry(context))
-            .map(|tcp| NaslSocket::Tcp(Box::new(tcp)))
-            .ok(),
-    )
+
+    let conn = TcpConnection::connect(addr, port, tls, timeout, bufsz, get_retry(context))
+        .map(|tcp| NaslSocket::Tcp(Box::new(tcp)))
+        .ok();
+    if set_transport {
+        context.set_port_transport(port, transport as usize)?;
+    }
+    Ok(conn)
 }
 
 /// Open a TCP socket to the target host.

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -780,7 +780,6 @@ impl<'a> Context<'a> {
             _ => Err(KBError::MultipleItemsFound(key.to_string()).into()),
         }
     }
-    // TODO: Check which KbKey is used for Port Transport
     /// Sets the state of a port
     pub fn set_port_transport(&self, port: u16, transport: usize) -> Result<(), FnError> {
         self.set_single_kb_item(
@@ -790,7 +789,7 @@ impl<'a> Context<'a> {
     }
 
     pub fn get_port_transport(&self, port: u16) -> Result<Option<i64>, FnError> {
-        self.get_single_kb_item_inner(&KbKey::Port(kb::Port::Tcp(port.to_string())))
+        self.get_single_kb_item_inner(&KbKey::Transport(kb::Transport::Tcp(port.to_string())))
             .map(|x| match x {
                 KbItem::Number(n) => Some(n),
                 _ => None,

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -783,7 +783,7 @@ impl<'a> Context<'a> {
     /// Sets the state of a port
     pub fn set_port_transport(&self, port: u16, transport: usize) -> Result<(), FnError> {
         self.set_single_kb_item(
-            KbKey::Port(kb::Port::Tcp(port.to_string())),
+            KbKey::Transport(kb::Transport::Tcp(port.to_string())),
             KbItem::Number(transport as i64),
         )
     }

--- a/rust/src/storage/items/kb.rs
+++ b/rust/src/storage/items/kb.rs
@@ -171,7 +171,7 @@ impl Display for KbKey {
             KbKey::Port(Port::Tcp(port)) => write!(f, "Ports/tcp/{port}"),
             KbKey::Port(Port::Udp(port)) => write!(f, "Ports/udp/{port}"),
 
-            KbKey::Transport(Transport::Tcp(transport)) => write!(f, "Transport/TCP/{transport}"),
+            KbKey::Transport(Transport::Tcp(transport)) => write!(f, "Transports/TCP/{transport}"),
             KbKey::Transport(Transport::Ssl) => write!(f, "Transport/SSL"),
 
             KbKey::Internals(Internals::Results) => write!(f, "internal/results"),


### PR DESCRIPTION
This commit corrects the KB Item used for Port transport and also reading the transport from the KB, in case no transport was given. For Auto Transport the used transport is now set within the KB, after a connection is successfully established.
