### PR TITLE
Fix: Host details port for tls results

### DIFF
--- a/rust/src/osp/response.rs
+++ b/rust/src/osp/response.rs
@@ -368,18 +368,24 @@ pub struct ScanResult {
 
 impl From<&ScanResult> for crate::models::ResultType {
     fn from(sr: &ScanResult) -> Self {
-        match (sr.name.as_str(), &sr.result_type) {
-            ("HOST_START", ResultType::Log) => crate::models::ResultType::HostStart,
-            ("HOST_END", ResultType::Log) => crate::models::ResultType::HostEnd,
-            ("DEADHOST", ResultType::Log) => crate::models::ResultType::DeadHost,
-            ("Host Details", ResultType::Log) => crate::models::ResultType::HostDetail,
-            (_, ResultType::Log) => crate::models::ResultType::Log,
-            (_, ResultType::Alarm) => crate::models::ResultType::Alarm,
-            (_, ResultType::Error) => crate::models::ResultType::Error,
-            (_, ResultType::HostStart) => crate::models::ResultType::HostStart,
-            (_, ResultType::HostEnd) => crate::models::ResultType::HostEnd,
+        match (
+            sr.port.clone().unwrap_or("".to_string()).as_str(),
+            sr.name.as_str(),
+            &sr.result_type,
+        ) {
+            // Not only the Host Details script produces host details. Therefore, check the port
+            ("general/Host_Details", _, ResultType::Log) => crate::models::ResultType::HostDetail,
+            (_, "HOST_START", ResultType::Log) => crate::models::ResultType::HostStart,
+            (_, "HOST_END", ResultType::Log) => crate::models::ResultType::HostEnd,
+            (_, "DEADHOST", ResultType::Log) => crate::models::ResultType::DeadHost,
+            (_, "Host Details", ResultType::Log) => crate::models::ResultType::HostDetail,
+            (_, _, ResultType::Log) => crate::models::ResultType::Log,
+            (_, _, ResultType::Alarm) => crate::models::ResultType::Alarm,
+            (_, _, ResultType::Error) => crate::models::ResultType::Error,
+            (_, _, ResultType::HostStart) => crate::models::ResultType::HostStart,
+            (_, _, ResultType::HostEnd) => crate::models::ResultType::HostEnd,
             // host details are sent via log messages
-            (_, ResultType::HostDetail) => unreachable!(),
+            (_, _, ResultType::HostDetail) => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
**What**:
Fix: Host details port for tls
Jira: SC-1294

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Not only the Host Details NASL script generates hosts details. Therefore, we check now for the port instead of the script name to generate the host detail result type
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
