### PR TITLE
C nasl kb usage

### DIFF
--- a/doc/man/openvas.8.in
+++ b/doc/man/openvas.8.in
@@ -169,6 +169,16 @@ Maximum load on the system. Once this load is reached, no further VTs are starte
 .IP min_free_mem
 Minimum available memory (in MB) which should be kept free on the system. Once this limit is reached, no further VTs are started until sufficient memory is available again.
 
+.IP max_mem_kb
+Maximum amount of memory (in MB) allowed to use for a single script.
+If this value is set, the amount of memory put into redis is tracked
+for every Script. If the amount of memory exceeds this limit, the
+script is not able to set more kb items. The tracked the value
+written into redis is only estimated, as it does not check, if a
+value was replaced or appended. The size of the key is also not
+tracked. If this value is not set or <= 0, the maximum amount is
+unlimited (Default).
+
 The other options in this file can usually be redefined by the client.
 
 .SH NETWORK USAGE

--- a/doc/manual/openvas/openvas.md
+++ b/doc/manual/openvas/openvas.md
@@ -294,6 +294,17 @@ min_free_mem
     system. Once this limit is reached, no further VTs are started until
     sufficient memory is available again.
 
+max_mem_kb
+
+:   Maximum amount of memory (in MB) allowed to use for a single script.
+    If this value is set, the amount of memory put into redis is tracked
+    for every Script. If the amount of memory exceeds this limit, the
+    script is not able to set more kb items. The tracked the value
+    written into redis is only estimated, as it does not check, if a
+    value was replaced or appended. The size of the key is also not
+    tracked. If this value is not set or <= 0, the maximum amount is
+    unlimited (Default).
+
 The other options in this file can usually be redefined by the client.
 
 ## NETWORK USAGE

--- a/misc/plugutils.h
+++ b/misc/plugutils.h
@@ -20,6 +20,9 @@
 #define ARG_INT 2
 
 void
+init_kb_usage (void);
+
+void
 scanner_add_port (struct script_infos *, int, char *);
 
 /*

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -820,7 +820,7 @@ replace_kb_item (lex_ctxt *lexic)
 }
 
 /**
- * @brief Set a volate kb item.
+ * @brief Set a volatile kb item.
  *
  * @param[in]  lexic  NASL lexer.
  * @param[in]  name Name of Item.

--- a/rust/src/openvasd/storage/redis.rs
+++ b/rust/src/openvasd/storage/redis.rs
@@ -89,7 +89,6 @@ impl<T> Storage<T> {
         if !fu.feed_is_outdated(current_feed).await.unwrap() {
             return Ok(());
         }
-        fu.perform_update().await?;
         tracing::debug!("finished nasl feed update");
         Ok(())
     }

--- a/rust/src/scanner/preferences/preference.rs
+++ b/rust/src/scanner/preferences/preference.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-pub const PREFERENCES: [ScanPreferenceInformation; 22] = [
+pub const PREFERENCES: [ScanPreferenceInformation; 23] = [
     ScanPreferenceInformation {
         id: "auto_enable_dependencies",
         name: "Automatic Enable Dependencies",
@@ -213,6 +213,19 @@ pub const PREFERENCES: [ScanPreferenceInformation; 22] = [
         default: PreferenceValue::Int(10),
         description: "Amount of fake results generated per each host in the target \
         list for a dry run scan.",
+    },
+    ScanPreferenceInformation {
+        id: "max_mem_kb",
+        name: "Maximum Script KB Memory",
+        default: PreferenceValue::Int(0),
+        description: "Maximum amount of memory (in MB) allowed to use for a single script. \
+        If this value is set, the amount of memory put into redis is tracked \
+        for every Script. If the amount of memory exceeds this limit, the \
+        script is not able to set more kb items. The tracked the value \
+        written into redis is only estimated, as it does not check, if a \
+        value was replaced or appended. The size of the key is also not \
+        tracked. If this value is not set or <= 0, the maximum amount is \
+        unlimited (Default).",
     },
 ];
 

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -343,6 +343,8 @@ pluginlaunch_init (const char *host)
 
   num_running_processes = 0;
   bzero (&(processes), sizeof (processes));
+
+  init_kb_usage ();
 }
 
 void


### PR DESCRIPTION
Currently it can happen, that script try to allocate huge amount of memory in the KB, which leads
to flooding the RAM and crashing redis and openvas. The introduced config `max_mem_kb` limits
the maximum KB traffic (in MB) to the specified value for a single script. Only written strings
are tracked and only an estimation, as we do not know, if an item is replaced or appended. Also
the key size is not counted as well. If the value is not set or <= 0, the maximum amount is
unlimited (Default).

Jira: SC-919
Issue: https://github.com/greenbone/openvas-scanner/issues/1488
osp-openvas: https://github.com/greenbone/ospd-openvas/pull/1039

To test this, I created a custom feed with two script, each setting KB items with a size of 1MB in a loop and see, if the log message is shown, that the maximum amount of KB traffic for the script is reached. At the same time look at the memory used by redis and see, that redis' memory consumption does not grow anymore.