### PR TITLE
Fix clippy lints for new version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4371,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,7 +69,7 @@ socket2 = "0.5.8"
 sysinfo = "0.30.5"
 thiserror = "1.0.62"
 time = { version = "0", features = ["parsing"] }
-tokio = { version = "1.39.3", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 tokio-rustls = "0.26.0"
 toml = "0.8.4"
 tracing = "0.1.37"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+// We allow this fow now, since it would require lots of changes
+// but should eventually solve this.
+#![allow(clippy::result_large_err)]
+#![allow(clippy::large_enum_variant)]
+
 #[cfg(feature = "nasl-builtin-raw-ip")]
 pub mod alive_test;
 pub mod feed;

--- a/rust/src/models/advisories.rs
+++ b/rust/src/models/advisories.rs
@@ -28,7 +28,6 @@ pub struct ProductsAdvisories {
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
 )]
-
 pub struct Advisory {
     /// The advisory's title.
     pub title: String,

--- a/rust/src/models/result.rs
+++ b/rust/src/models/result.rs
@@ -71,7 +71,6 @@ pub struct Result {
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
 )]
-
 pub struct Detail {
     /// Descriptive name of a Host Detail
     pub name: String,

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -634,7 +634,7 @@ pub fn check_ftp_response(
 
     line = String::from(line.trim());
 
-    if expected_codes.iter().any(|ec| code == *ec) {
+    if expected_codes.contains(&code) {
         Ok(code)
     } else {
         Err(SocketError::ResponseCodeMismatch(

--- a/rust/src/nasl/builtin/network/udp.rs
+++ b/rust/src/nasl/builtin/network/udp.rs
@@ -43,14 +43,11 @@ impl Write for UdpConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mtu = mtu(self.socket.peer_addr()?.ip());
         if buf.len() > mtu {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "UDP data of size {} exceeds the maximum length of {}",
-                    buf.len(),
-                    mtu
-                ),
-            ));
+            return Err(io::Error::other(format!(
+                "UDP data of size {} exceeds the maximum length of {}",
+                buf.len(),
+                mtu
+            )));
         }
         let result = unsafe {
             libc::send(

--- a/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
@@ -588,7 +588,7 @@ mod tests {
     #[test]
     fn get_local_mac() {
         if cfg!(target_os = "macos") {
-            assert!(matches!(get_local_mac_address("lo"), Err(_)));
+            assert!(get_local_mac_address("lo").is_err());
         } else {
             assert_eq!(get_local_mac_address("lo").unwrap(), MacAddr::zero());
         }

--- a/rust/src/nasl/builtin/ssh/mod.rs
+++ b/rust/src/nasl/builtin/ssh/mod.rs
@@ -419,11 +419,10 @@ impl Ssh {
         let channel = session.get_channel().await?;
         channel.ensure_open()?;
 
-        let result = match channel.stdin().write_all(cmd.0.as_bytes()) {
+        match channel.stdin().write_all(cmd.0.as_bytes()) {
             Ok(_) => Ok(0),
             Err(_) => Ok(-1),
-        };
-        result
+        }
     }
 
     /// Close an ssh shell.

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -340,7 +340,7 @@ where
 
     fn context(&self) -> Context {
         let target = Target::do_not_resolve_hostname(&self.target);
-        let context = ContextBuilder {
+        ContextBuilder {
             storage: &self.storage,
             loader: &self.loader,
             executor: &self.executor,
@@ -353,8 +353,7 @@ where
             filename: self.filename.clone(),
             scan_preferences: Vec::default(),
         }
-        .build();
-        context
+        .build()
     }
 
     /// Check that no errors were returned by any

--- a/rust/src/openvasd/main.rs
+++ b/rust/src/openvasd/main.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 #![doc = include_str!("README.md")]
+// We allow this fow now, since it would require lots of changes
+// but should eventually solve this.
+#![allow(clippy::result_large_err)]
 
 use std::marker::{Send, Sync};
 

--- a/rust/src/openvasd/tls.rs
+++ b/rust/src/openvasd/tls.rs
@@ -240,7 +240,7 @@ pub fn tls_config(config: &crate::config::Config) -> Result<Option<TlsConfig>, E
 }
 
 fn error(err: String) -> io::Error {
-    io::Error::new(io::ErrorKind::Other, err)
+    io::Error::other(err)
 }
 
 // Load public certificate from file.

--- a/rust/src/scannerctl/main.rs
+++ b/rust/src/scannerctl/main.rs
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 #![doc = include_str!("README.md")]
+// We allow this fow now, since it would require lots of changes
+// but should eventually solve this.
+#![allow(clippy::result_large_err)]
+
 #[cfg(feature = "nasl-builtin-raw-ip")]
 mod alivetest;
 mod error;


### PR DESCRIPTION
Fixes the lints in the new clippy version.

Note: this sets `#![allow(clippy::result_large_err)]` for scannerlib/openvasd/scannerctl. This should be removed eventually and the lint taken care of, but the needed changes are quite large.

See: SC-1315