### PR TITLE
Fix: scan id which is already in use

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -232,7 +232,7 @@ paths:
                   $ref: "#/components/examples/scan_id"
         "400":
           description: "Bad Request body"
-        "406":
+        "403":
           description: "ScanID already in use"
 
   /scans/preferences:

--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -232,6 +232,8 @@ paths:
                   $ref: "#/components/examples/scan_id"
         "400":
           description: "Bad Request body"
+        "406":
+          description: "ScanID already in use"
 
   /scans/preferences:
     get:

--- a/rust/src/openvasd/controller/entry.rs
+++ b/rust/src/openvasd/controller/entry.rs
@@ -408,10 +408,10 @@ where
                                 .into_iter()
                                 .any(|i| *i == id)
                             {
-                                tracing::debug!(%id, "Scan ID already exists");
-                                return Ok(ctx.response.not_accepted_with_reason(
-                                    &[id],
-                                    "Scan ID already exists".to_string(),
+                                tracing::debug!(%id, "Scan ID already in use");
+                                return Ok(ctx.response.forbidden_with_reason(
+                                    &id,
+                                    "Scan ID already in use".to_string(),
                                 ));
                             };
 

--- a/rust/src/openvasd/controller/entry.rs
+++ b/rust/src/openvasd/controller/entry.rs
@@ -400,6 +400,21 @@ where
                             } else {
                                 uuid::Uuid::new_v4().to_string()
                             };
+
+                            if ctx
+                                .scheduler
+                                .get_scan_ids()
+                                .await?
+                                .into_iter()
+                                .any(|i| *i == id)
+                            {
+                                tracing::debug!(%id, "Scan ID already exists");
+                                return Ok(ctx.response.not_accepted_with_reason(
+                                    &[id],
+                                    "Scan ID already exists".to_string(),
+                                ));
+                            };
+
                             let resp = ctx.response.created(&id);
                             scan.scan_id.clone_from(&id);
 

--- a/rust/src/openvasd/response.rs
+++ b/rust/src/openvasd/response.rs
@@ -368,4 +368,17 @@ impl Response {
         };
         self.create(hyper::StatusCode::NOT_ACCEPTABLE, &value)
     }
+
+    pub fn not_accepted_with_reason<T>(&self, got: &T, reason: String) -> Result
+    where
+        T: Serialize + std::fmt::Debug,
+    {
+        #[derive(Serialize, Debug)]
+        struct NotAcceptedWithReason<'a, T> {
+            got: &'a T,
+            reason: String,
+        }
+        let value = NotAcceptedWithReason { got, reason };
+        self.create(hyper::StatusCode::NOT_ACCEPTABLE, &value)
+    }
 }

--- a/rust/src/openvasd/response.rs
+++ b/rust/src/openvasd/response.rs
@@ -369,16 +369,16 @@ impl Response {
         self.create(hyper::StatusCode::NOT_ACCEPTABLE, &value)
     }
 
-    pub fn not_accepted_with_reason<T>(&self, got: &T, reason: String) -> Result
+    pub fn forbidden_with_reason<T>(&self, got: &T, reason: String) -> Result
     where
         T: Serialize + std::fmt::Debug,
     {
         #[derive(Serialize, Debug)]
-        struct NotAcceptedWithReason<'a, T> {
+        struct ForbiddenWithReason<'a, T> {
             got: &'a T,
             reason: String,
         }
-        let value = NotAcceptedWithReason { got, reason };
-        self.create(hyper::StatusCode::NOT_ACCEPTABLE, &value)
+        let value = ForbiddenWithReason { got, reason };
+        self.create(hyper::StatusCode::FORBIDDEN, &value)
     }
 }


### PR DESCRIPTION
**What**:
This is about given that you post a scan with fixed scan id which is already in use we should return not acceptable instead of creating double.

SC-1291

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Post a scan config with a fixed scanid many times
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
