### PR TITLE
Revert "Add cancellation of running CI jobs on new commit"

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -3,10 +3,6 @@ name: Labeler
 on:
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,10 +8,6 @@ on:
   schedule:
     - cron: '30 5 * * 0' # 5:30h on Sundays
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -27,10 +27,6 @@ on:
     # rebuild image every sunday
     - cron: "0 0 * * 0"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 # Grants rights to push to the Github container registry.
 # The main workflow has to set the permissions.
 permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,10 +1,5 @@
 name: 'Dependency Review'
-
 on: [pull_request]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/helm-release-on-tag.yml
+++ b/.github/workflows/helm-release-on-tag.yml
@@ -4,10 +4,6 @@ on:
   push:
     tags: ["v*"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   release-helm-chart:
     name: Release helm chart

--- a/.github/workflows/push-helm-chart.yml
+++ b/.github/workflows/push-helm-chart.yml
@@ -12,6 +12,7 @@ on:
       token:
         required: true
 
+
 jobs:
   helm:
     runs-on: self-hosted-generic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 name: "release"
-
 on: 
   workflow_call:
     inputs:
@@ -32,6 +31,7 @@ on:
         required: true
       gpg_pass:
         required: true
+
 
 # This job first determines the target branch of the closed pull request. If the target branch is "main",
 # then the latest release tag is used. If no release tag exists, it is set to 0.1.0. If it is a release

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -1,14 +1,8 @@
 name: SBOM upload
-
 on:
   workflow_dispatch:
   push:
     branches: ["main"]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   SBOM-upload:
     runs-on: self-hosted-generic


### PR DESCRIPTION
Due to weird issues with our recent release, we suspect that `cancel-in-progress` in the CI might be responsible. This reverts the changes while we investigate further.