### PR TITLE
Fix: get_port_transport

### DIFF
--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -151,7 +151,7 @@ fn get_host_open_port(context: &Context) -> i64 {
 
 #[nasl_function(named(asstring))]
 fn get_port_transport(context: &Context, port: u16, asstring: bool) -> Result<NaslValue, FnError> {
-    let transport = context.get_port_transport(port)?.unwrap_or(1);
+    let transport = context.get_port_transport(port).unwrap_or(1);
     let ret = if asstring {
         let transport_str = match transport {
             0 => "auto".to_string(),

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -437,7 +437,7 @@ fn open_sock_tcp_vhost(
     transport: i64,
 ) -> Result<Option<NaslSocket>, FnError> {
     let mut transport = if transport.is_negative() {
-        context.get_port_transport(port)?.unwrap_or(1)
+        context.get_port_transport(port).unwrap_or(1)
     } else {
         transport
     };

--- a/rust/src/nasl/utils/context.rs
+++ b/rust/src/nasl/utils/context.rs
@@ -858,9 +858,10 @@ impl<'a> Context<'a> {
         )
     }
 
-    pub fn get_port_transport(&self, port: u16) -> Result<Option<i64>, FnError> {
+    pub fn get_port_transport(&self, port: u16) -> Option<i64> {
         self.get_single_kb_item_inner(&KbKey::Transport(kb::Transport::Tcp(port.to_string())))
-            .map(|x| match x {
+            .ok()
+            .and_then(|item| match item {
                 KbItem::Number(n) => Some(n),
                 _ => None,
             })


### PR DESCRIPTION
**What**:
Fix: get_port_transport
 SC-1318
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently, if the transport is not set for the port in the Kb, it returns an error. Now, it returns None, and and open_sock_tcp() will be able to open a socket with IP encapsulation (no tls).

<!-- Why are these changes necessary? -->

**How**:

run scannerctl execute script test_open_socket.nasl -t localhost

test_open_socket.nasl:
```
open_sock_tcp(23);
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
