### PR TITLE
Fix: Calculate MTU dinamically.

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -14,7 +14,7 @@ runs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
     - run: sudo apt update || true
       shell: bash
-    - run: sudo apt-get install -y libpcap-dev patchelf
+    - run: sudo apt-get install -y libpcap-dev libclang-dev patchelf
       shell: bash
     - run: rustup update stable && rustup default stable || rustup default stable
       shell: bash

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,6 +524,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2357,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mtu"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3124fb16267c5a77ce8cd015bcb5bb3f8aab28ec32d89d65f6a31c5c1306a0"
+dependencies = [
+ "bindgen",
+ "cfg_aliases",
+ "libc",
+ "static_assertions",
+ "windows 0.58.0",
+]
+
+[[package]]
 name = "nasl-c-lib"
 version = "0.1.0"
 dependencies = [
@@ -3668,6 +3687,7 @@ dependencies = [
  "md-5",
  "md2",
  "md4",
+ "mtu",
  "nasl-c-lib",
  "nasl-function-proc-macro",
  "num_cpus",
@@ -4125,6 +4145,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -96,6 +96,7 @@ openssl = { version = "0.10.72", features = ["vendored"] }
 blowfish = "0.9.1"
 rc4 = "0.1.0"
 dsa = "0.6.3"
+mtu = { version = "0.2.9", optional = true }
 
 [workspace]
 members = ["crates/smoketest", "crates/nasl-function-proc-macro"]
@@ -116,6 +117,7 @@ default = [
 ]
 
 nasl-builtin-raw-ip = [
+    "mtu",
     "pcap",
     "pnet_base",
     "pnet",

--- a/rust/src/nasl/builtin/network/mod.rs
+++ b/rust/src/nasl/builtin/network/mod.rs
@@ -4,6 +4,8 @@
 
 use std::{fmt::Display, net::IpAddr};
 
+#[cfg(feature = "nasl-builtin-raw-ip")]
+use crate::nasl::raw_ip_utils::raw_ip_utils;
 use crate::{nasl::prelude::*, storage::items::kb::KbKey};
 
 #[allow(clippy::module_inception)]
@@ -22,9 +24,16 @@ const MTU: usize = 512 - 60 - 8;
 const DEFAULT_PORT: u16 = 33435;
 
 // Get the max MTU possible for network communication
-// TODO: Calculate the MTU dynamically
+#[cfg(not(feature = "nasl-builtin-raw-ip"))]
 pub fn mtu(_: IpAddr) -> usize {
     MTU
+}
+#[cfg(feature = "nasl-builtin-raw-ip")]
+pub fn mtu(target_ip: IpAddr) -> usize {
+    match raw_ip_utils::get_mtu(target_ip) {
+        Ok(mtu) => mtu,
+        Err(_) => MTU,
+    }
 }
 
 pub enum OpenvasEncaps {

--- a/rust/src/nasl/builtin/raw_ip/mod.rs
+++ b/rust/src/nasl/builtin/raw_ip/mod.rs
@@ -26,6 +26,8 @@ pub enum RawIpError {
     FailedToGetLocalMacAddress,
     #[error("Failed to get device list.")]
     FailedToGetDeviceList,
+    #[error("Failed to get device MTU.")]
+    FailedToGetDeviceMTU,
     #[error("Invalid IP address.")]
     InvalidIpAddress,
     #[error("Failed to bind.")]

--- a/rust/src/nasl/builtin/raw_ip/raw_ip_utils.rs
+++ b/rust/src/nasl/builtin/raw_ip/raw_ip_utils.rs
@@ -71,6 +71,12 @@ pub fn get_interface_by_local_ip(local_address: IpAddr) -> Result<Device, FnErro
         .ok_or(RawIpError::InvalidIpAddress.into())
 }
 
+pub fn get_mtu(target_ip: IpAddr) -> Result<usize, RawIpError> {
+    let (_, mtu): (String, usize) =
+        mtu::interface_and_mtu(target_ip).map_err(|_| RawIpError::FailedToGetDeviceMTU)?;
+    Ok(mtu)
+}
+
 pub fn bind_local_socket(dst: &SocketAddr) -> Result<UdpSocket, RawIpError> {
     match dst {
         SocketAddr::V4(_) => UdpSocket::bind("0.0.0.0:0"),


### PR DESCRIPTION
**What**:
Fix: Calculate MTU dinamically.
SC-1324
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This functionality is under the feature `nasl-builtin-raw-ip` since it depends on libc. Currently, there is no rust native equivalent implementation of the C  struct
<!-- Why are these changes necessary? -->

**How**:
Compile with and without the feature `nasl-builtin-raw-ip` and run the following nasl script:
Compare the output running the same script with `openvas-nasl`
```
display(get_mtu());
```


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
