### PR TITLE
Add: kb scannerctl command line option.

### DIFF
--- a/rust/src/openvasd/scheduling.rs
+++ b/rust/src/openvasd/scheduling.rs
@@ -189,7 +189,7 @@ where
         Ok(())
     }
 
-    /// Coordinates scan starts, if a feed syncrhonization is taking place it will do nothing.
+    /// Coordinates scan starts, if a feed synchronization is taking place it will do nothing.
     /// Otherwise it start scans within the capacity block from queued list.
     async fn coordinate_scans(&self) -> Result<(), Error> {
         if *self.is_synchronizing_feed.read().await {

--- a/rust/src/scannerctl/error.rs
+++ b/rust/src/scannerctl/error.rs
@@ -37,6 +37,8 @@ pub enum CliErrorKind {
     Corrupt(String),
     #[error("Invalid XML: {0}")]
     InvalidXML(#[from] DeError),
+    #[error("{0}")]
+    InvalidCmdOpt(String),
 }
 
 pub struct Filename<T>(pub T);

--- a/rust/src/scannerctl/execute/mod.rs
+++ b/rust/src/scannerctl/execute/mod.rs
@@ -41,6 +41,9 @@ struct ScriptArgs {
     /// Target to scan.
     #[clap(short, long)]
     target: Option<String>,
+    /// KB key value.
+    #[clap(short, long = "kb")]
+    kb: Vec<String>,
     /// TCP Ports to scan.
     #[clap(short, long = "port")]
     ports: Vec<u16>,
@@ -137,6 +140,7 @@ async fn script(args: ScriptArgs) -> Result<(), CliError> {
         args.feed_path,
         &args.script,
         args.target.clone(),
+        args.kb.clone(),
         args.ports.clone(),
         args.udp_ports.clone(),
     )

--- a/rust/src/scannerctl/main.rs
+++ b/rust/src/scannerctl/main.rs
@@ -108,6 +108,10 @@ async fn main() {
                 tracing::warn!("script error, {e}");
                 std::process::exit(1);
             }
+            CliErrorKind::InvalidCmdOpt(_) => {
+                tracing::warn!("Command line option error, {e}");
+                std::process::exit(1);
+            }
             _ => panic!("{e}"),
         },
     }


### PR DESCRIPTION
**What**:
Add: kb scannerctl command line option.
 Allow to set KbItem key value to scannerctl execute script command line

SC-1331
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
run the following nasl script:
```
display(get_kb_item("TCP/PORTS"));
```
with:
`scannerctl execute script --kb="TCP/PORTS=443" examples/get_kb_item.nasl `
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
