### PR TITLE
Use CARGO_MANIFEST_DIR to look up cargo root

### DIFF
--- a/rust/src/openvasd/storage/file.rs
+++ b/rust/src/openvasd/storage/file.rs
@@ -488,7 +488,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{env::current_dir, fs};
+    use std::fs;
 
     use models::{Phase, Scan, Status};
     use scannerlib::storage::infisto::{CachedIndexFileStorer, IndexedByteStorage};
@@ -502,15 +502,11 @@ pub(crate) mod tests {
     use super::*;
 
     pub async fn nasl_root() -> PathBuf {
-        let base = current_dir().unwrap_or_default();
-
-        let mut tbase = base.parent().unwrap().join("examples");
-        if fs::metadata(&tbase).is_err() {
-            tbase = base.join("examples");
-        }
-        let base_dir = tbase.join("feed");
-
-        base_dir.join("nasl")
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        PathBuf::from(manifest_dir)
+            .join("examples")
+            .join("feed")
+            .join("nasl")
     }
 
     pub async fn example_feeds() -> Vec<FeedHash> {


### PR DESCRIPTION
Simplify how the cargo root is determined in openvasd tests. This fixes a bug where having an "examples" directory in the top level folder of the repository (i.e. not in `rust/`) would make a number of tests fail, since they would try to use this directory. This happened because the logic was trying to make the tests work even if run within a subdirectory of the rust folder. Using `CARGO_MANIFEST_DIR` solves this problem since it will work robustly, even in a nested subdirectory.