### PR TITLE
Begin implementation of `find_service` builtin

### DIFF
--- a/rust/data/service_definitions.json
+++ b/rust/data/service_definitions.json
@@ -1,0 +1,200 @@
+{
+  "version": "1.0",
+  "description": "Service detection definitions for find_service builtin",
+  "services": [
+    {
+      "name": "http",
+      "service_key": "www",
+      "description": "HTTP Web Server",
+      "detections": [
+        {
+          "type": "http"
+        }
+      ],
+      "ports": [80, 8080, 8000, 3000, 8081],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "A web server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "https",
+      "service_key": "www",
+      "description": "HTTPS Web Server (SSL)",
+      "detections": [
+        {
+          "type": "https"
+        }
+      ],
+      "ports": [443, 8443, 9443],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "A SSL/TLS web server is running on this port"
+      },
+      "kb_entries": {
+        "Transport/SSL": "{port}"
+      }
+    },
+    {
+      "name": "smtp",
+      "description": "SMTP Mail Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_starts_with",
+          "value": "220",
+          "case_sensitive": false
+        },
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_contains",
+          "value": "SMTP",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [25, 587, 465],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "An SMTP server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "ssh",
+      "description": "SSH Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_starts_with",
+          "value": "SSH-",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [22, 2222],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "An SSH server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "ftp",
+      "description": "FTP Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_starts_with",
+          "value": "220",
+          "case_sensitive": false
+        },
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_contains",
+          "value": "FTP",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [21, 2121],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "An FTP server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "telnet",
+      "description": "Telnet Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_contains_hex",
+          "value": "fffd"
+        },
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_contains_hex",
+          "value": "fffb"
+        }
+      ],
+      "ports": [23, 2323],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "A telnet server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "pop3",
+      "description": "POP3 Mail Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_starts_with",
+          "value": "+OK",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [110, 995],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "A POP3 server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "imap",
+      "description": "IMAP Mail Server",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_starts_with",
+          "value": "* OK",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [143, 993],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": false,
+        "message": "An IMAP server is running on this port"
+      },
+      "kb_entries": {}
+    },
+    {
+      "name": "netbus",
+      "description": "NetBus Trojan (Security Alert)",
+      "detections": [
+        {
+          "type": "banner",
+          "banner_detection_type": "banner_equals",
+          "value": "NetBus",
+          "case_sensitive": false
+        }
+      ],
+      "ports": [12345, 12346],
+      "save_banner": true,
+      "generate_result": {
+        "enabled": true,
+        "is_vulnerability": true,
+        "message": "NetBus backdoor is running on this port"
+      },
+      "kb_entries": {}
+    }
+  ]
+}

--- a/rust/data/service_definitions.json
+++ b/rust/data/service_definitions.json
@@ -46,13 +46,13 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_starts_with",
+          "banner_detection_type": "starts_with",
           "value": "220",
           "case_sensitive": false
         },
         {
           "type": "banner",
-          "banner_detection_type": "banner_contains",
+          "banner_detection_type": "contains",
           "value": "SMTP",
           "case_sensitive": false
         }
@@ -72,7 +72,7 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_starts_with",
+          "banner_detection_type": "starts_with",
           "value": "SSH-",
           "case_sensitive": false
         }
@@ -92,13 +92,13 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_starts_with",
+          "banner_detection_type": "starts_with",
           "value": "220",
           "case_sensitive": false
         },
         {
           "type": "banner",
-          "banner_detection_type": "banner_contains",
+          "banner_detection_type": "contains",
           "value": "FTP",
           "case_sensitive": false
         }
@@ -118,12 +118,12 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_contains_hex",
+          "banner_detection_type": "contains_hex",
           "value": "fffd"
         },
         {
           "type": "banner",
-          "banner_detection_type": "banner_contains_hex",
+          "banner_detection_type": "contains_hex",
           "value": "fffb"
         }
       ],
@@ -142,7 +142,7 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_starts_with",
+          "banner_detection_type": "starts_with",
           "value": "+OK",
           "case_sensitive": false
         }
@@ -162,7 +162,7 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_starts_with",
+          "banner_detection_type": "starts_with",
           "value": "* OK",
           "case_sensitive": false
         }
@@ -182,7 +182,7 @@
       "detections": [
         {
           "type": "banner",
-          "banner_detection_type": "banner_equals",
+          "banner_detection_type": "equals",
           "value": "NetBus",
           "case_sensitive": false
         }

--- a/rust/src/nasl/builtin/error.rs
+++ b/rust/src/nasl/builtin/error.rs
@@ -10,6 +10,7 @@ use crate::nasl::utils::error::FnErrorKind;
 use super::KBError;
 use super::cert::CertError;
 use super::cryptographic::CryptographicError;
+use super::find_service::FindServiceError;
 use super::host::HostError;
 use super::http::HttpError;
 use super::isotime::IsotimeError;
@@ -45,6 +46,8 @@ pub enum BuiltinError {
     Cert(CertError),
     #[error("{0}")]
     Sys(SysError),
+    #[error("{0}")]
+    FindService(FindServiceError),
     #[cfg(feature = "nasl-builtin-raw-ip")]
     #[error("{0}")]
     RawIp(RawIpError),
@@ -91,6 +94,7 @@ builtin_error_variant!(KBError, KB);
 builtin_error_variant!(HostError, Host);
 builtin_error_variant!(CertError, Cert);
 builtin_error_variant!(SysError, Sys);
+builtin_error_variant!(FindServiceError, FindService);
 
 #[cfg(feature = "nasl-builtin-raw-ip")]
 builtin_error_variant!(RawIpError, RawIp);

--- a/rust/src/nasl/builtin/find_service/mod.rs
+++ b/rust/src/nasl/builtin/find_service/mod.rs
@@ -309,6 +309,8 @@ fn read_from_tcp_at_port(target: IpAddr, port: u16) -> Result<ReadResult, FindSe
 }
 
 fn try_http_request(target: IpAddr, port: u16) -> Result<Vec<u8>, FindServiceError> {
+    // TODO: Use a more robust approach that also takes HTTP2 into
+    // account (such as using h2)
     let mut socket = make_tcp_socket(target, port, 0)?;
     let http_request = b"GET / HTTP/1.0\r\n\r\n";
     match socket {

--- a/rust/src/nasl/builtin/find_service/mod.rs
+++ b/rust/src/nasl/builtin/find_service/mod.rs
@@ -229,8 +229,11 @@ impl ServiceDetector {
         port: u16,
     ) -> Result<(), FnError> {
         let banner = service.banner;
-        // This is O(n^2), but simpler than using a HashMap and performance
-        // should really not matter here.
+        // The following lookup is in O(n^2). However, since the
+        // number of services is likely to be small, this is very
+        // unlikely to become a performance problem, so that I prefer
+        // the simplicity of this approach (as opposed to using a
+        // HashMap).
         let service = self
             .services
             .services

--- a/rust/src/nasl/builtin/find_service/mod.rs
+++ b/rust/src/nasl/builtin/find_service/mod.rs
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: 2023 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use std::{
+    collections::HashMap,
+    io::{self, Write},
+    net::IpAddr,
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::nasl::prelude::*;
+use crate::storage::items::kb::{self, KbItem, KbKey};
+
+use super::network::socket::{NaslSocket, SocketError, make_tcp_socket};
+
+const TIMEOUT_MILLIS: u64 = 5000;
+
+#[derive(Debug, Error)]
+pub enum FindServiceError {
+    #[error("{0}")]
+    SocketError(#[from] SocketError),
+    #[error("JSON parsing error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("Regex error: {0}")]
+    RegexError(#[from] regex::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceDefinitions {
+    pub version: String,
+    pub description: String,
+    pub services: Vec<Service>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Service {
+    pub name: String,
+    pub service_key: Option<String>,
+    pub description: String,
+    pub detections: Vec<Detection>,
+    pub ports: Vec<u16>,
+    pub save_banner: bool,
+    pub generate_result: GenerateResult,
+    pub kb_entries: HashMap<String, String>,
+}
+
+impl Service {
+    fn key(&self) -> String {
+        self.service_key.as_ref().unwrap_or(&self.name).clone()
+    }
+}
+
+pub type ServiceId = String;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Detection {
+    Banner(BannerDetection),
+    Https,
+    Http,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "banner_detection_type", rename_all = "snake_case")]
+pub enum BannerDetection {
+    BannerContains {
+        value: String,
+        #[serde(default)]
+        case_sensitive: bool,
+    },
+    BannerStartsWith {
+        value: String,
+        #[serde(default)]
+        case_sensitive: bool,
+    },
+    BannerEquals {
+        value: String,
+        #[serde(default)]
+        case_sensitive: bool,
+    },
+    BannerContainsHex {
+        value: String,
+        position: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateResult {
+    pub enabled: bool,
+    pub is_vulnerability: bool,
+    pub message: String,
+}
+
+enum ReadResult {
+    Data(Vec<u8>),
+    Timeout,
+}
+
+struct DetectedService {
+    id: ServiceId,
+    banner: Vec<u8>,
+}
+
+enum ScanPortResult {
+    Service(DetectedService),
+    Timeout,
+    NoMatch,
+}
+
+impl BannerDetection {
+    fn matches(&self, banner: &[u8]) -> bool {
+        let banner_str = String::from_utf8_lossy(banner);
+        match self {
+            BannerDetection::BannerContains {
+                value,
+                case_sensitive,
+            } => {
+                if *case_sensitive {
+                    banner_str.contains(value)
+                } else {
+                    banner_str.to_lowercase().contains(&value.to_lowercase())
+                }
+            }
+            BannerDetection::BannerStartsWith {
+                value,
+                case_sensitive,
+            } => {
+                if *case_sensitive {
+                    banner_str.starts_with(value)
+                } else {
+                    banner_str.to_lowercase().starts_with(&value.to_lowercase())
+                }
+            }
+            BannerDetection::BannerEquals {
+                value,
+                case_sensitive,
+            } => {
+                if *case_sensitive {
+                    banner_str.trim() == *value
+                } else {
+                    banner_str.trim().to_lowercase() == value.to_lowercase()
+                }
+            }
+            BannerDetection::BannerContainsHex { value, position } => match hex::decode(value) {
+                Ok(hex_bytes) => {
+                    if let Some(pos) = position {
+                        banner.len() > pos + hex_bytes.len()
+                            && banner[*pos..*pos + hex_bytes.len()] == hex_bytes
+                    } else {
+                        banner
+                            .windows(hex_bytes.len())
+                            .any(|window| window == hex_bytes)
+                    }
+                }
+                Err(_) => false,
+            },
+        }
+    }
+}
+
+impl Detection {
+    fn matches(&self, banner_or_http_response: &[u8]) -> Result<bool, FindServiceError> {
+        match self {
+            Detection::Banner(banner_pattern) => {
+                Ok(banner_pattern.matches(banner_or_http_response))
+            }
+            Detection::Https => Ok(Self::detect_https(banner_or_http_response)),
+            Detection::Http => Ok(Self::detect_http_response(banner_or_http_response)),
+        }
+    }
+
+    fn detect_https(_: &[u8]) -> bool {
+        todo!()
+    }
+
+    fn detect_http_response(banner: &[u8]) -> bool {
+        let response = String::from_utf8_lossy(banner);
+        response.contains("HTTP/1.0")
+            || response.contains("HTTP/1.1")
+            || response.contains("HTTP/2")
+    }
+}
+
+struct ServiceDetector {
+    services: ServiceDefinitions,
+}
+
+impl ServiceDetector {
+    fn new() -> Result<Self, FindServiceError> {
+        let json_content = include_str!("../../../../data/service_definitions.json");
+        let definitions: ServiceDefinitions = serde_json::from_str(&json_content)?;
+        Ok(ServiceDetector {
+            services: definitions,
+        })
+    }
+
+    fn detect_service(
+        &self,
+        banner: &[u8],
+        port: u16,
+    ) -> Result<Option<DetectedService>, FindServiceError> {
+        for service in &self.services.services {
+            if !service.ports.is_empty() && !service.ports.contains(&port) {
+                continue;
+            }
+
+            for pattern in &service.detections {
+                if pattern.matches(banner)? {
+                    return Ok(Some(DetectedService {
+                        id: service.name.clone(),
+                        banner: banner.to_vec(),
+                    }));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn handle_detected_service(
+        &self,
+        context: &ScanCtx<'_>,
+        service: DetectedService,
+        port: u16,
+    ) -> Result<(), FnError> {
+        let banner = service.banner;
+        // This is O(n^2), but simpler than using a HashMap and performance
+        // should really not matter here.
+        let service = self
+            .services
+            .services
+            .iter()
+            .find(|s| s.name == service.id)
+            .unwrap();
+
+        add_kb_entries(context, service, port, banner)?;
+
+        if service.generate_result.enabled {
+            if service.generate_result.is_vulnerability {
+                tracing::warn!(
+                    "Security alert on port {}: {}",
+                    port,
+                    service.generate_result.message
+                );
+            } else {
+                tracing::info!(
+                    "Service detected on port {}: {}",
+                    port,
+                    service.generate_result.message
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn add_kb_entries(
+    context: &ScanCtx<'_>,
+    service: &Service,
+    port: u16,
+    banner: Vec<u8>,
+) -> Result<(), FnError> {
+    for (key_template, value_template) in &service.kb_entries {
+        let key = key_template.replace("{port}", &port.to_string());
+        let value = value_template.replace("{port}", &port.to_string());
+
+        context.set_kb_item(KbKey::Custom(key), KbItem::String(value))?;
+    }
+
+    context.set_kb_item(
+        KbKey::Service(kb::Service::Custom(service.key())),
+        KbItem::String(format!("{}/tcp", port)),
+    )?;
+
+    context.set_kb_item(KbKey::KnownTcp(port), KbItem::String(service.key()))?;
+
+    if service.save_banner {
+        let banner_key = format!("Banner/{}", port);
+        context.set_kb_item(KbKey::Custom(banner_key), KbItem::Data(banner))?;
+    }
+
+    Ok(())
+}
+
+fn read_from_tcp_at_port(target: IpAddr, port: u16) -> Result<ReadResult, FindServiceError> {
+    let mut socket = make_tcp_socket(target, port, 0)?;
+    let mut buf = vec![0; 1024];
+    let result = socket.read_with_timeout(&mut buf, Duration::from_millis(TIMEOUT_MILLIS));
+    match result {
+        Ok(pos) => {
+            buf.truncate(pos);
+            Ok(ReadResult::Data(buf))
+        }
+        Err(e) if e.kind() == io::ErrorKind::TimedOut => Ok(ReadResult::Timeout),
+        Err(e) => Err(SocketError::IO(e).into()),
+    }
+}
+
+fn try_http_request(target: IpAddr, port: u16) -> Result<Vec<u8>, FindServiceError> {
+    let mut socket = make_tcp_socket(target, port, 0)?;
+    let http_request = b"GET / HTTP/1.0\r\n\r\n";
+    match socket {
+        NaslSocket::Tcp(ref mut tcp_conn) => {
+            tcp_conn
+                .write_all(http_request)
+                .map_err(|e| SocketError::IO(e))?;
+
+            // Read response
+            let mut buf = vec![0; 1024];
+            let result =
+                tcp_conn.read_with_timeout(&mut buf, Duration::from_millis(TIMEOUT_MILLIS));
+            match result {
+                Ok(pos) => {
+                    buf.truncate(pos);
+                    Ok(buf)
+                }
+                Err(e) => Err(SocketError::IO(e).into()),
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn scan_port(
+    detector: &ServiceDetector,
+    target: IpAddr,
+    port: u16,
+) -> Result<ScanPortResult, FindServiceError> {
+    // Check if any service on this port needs HTTP request detection
+    let needs_http_request = detector.services.services.iter().any(|service| {
+        (service.ports.is_empty() || service.ports.contains(&port))
+            && service
+                .detections
+                .iter()
+                .any(|d| matches!(d, Detection::Http))
+    });
+
+    let banner = if needs_http_request {
+        // For services that need HTTP request, try HTTP first, then fallback to banner
+        match try_http_request(target, port) {
+            Ok(http_response) => http_response,
+            Err(_) => {
+                // Fallback to regular banner reading
+                match read_from_tcp_at_port(target, port)? {
+                    ReadResult::Data(data) => data,
+                    ReadResult::Timeout => return Ok(ScanPortResult::Timeout),
+                }
+            }
+        }
+    } else {
+        // Regular banner reading for non-HTTP services
+        match read_from_tcp_at_port(target, port)? {
+            ReadResult::Data(data) => data,
+            ReadResult::Timeout => return Ok(ScanPortResult::Timeout),
+        }
+    };
+
+    match detector.detect_service(&banner, port)? {
+        Some(service) => Ok(ScanPortResult::Service(service)),
+        None => Ok(ScanPortResult::NoMatch),
+    }
+}
+
+#[nasl_function]
+fn plugin_run_find_service(context: &ScanCtx<'_>) -> NaslResult {
+    let detector = ServiceDetector::new()?;
+    let open_ports = context.get_open_tcp_ports()?;
+    for port in open_ports {
+        match scan_port(&detector, context.target().ip_addr(), port) {
+            Ok(ScanPortResult::Service(service)) => {
+                detector.handle_detected_service(context, service, port)?;
+            }
+            Ok(ScanPortResult::Timeout) => {
+                tracing::debug!("Timeout reading from port {}", port);
+            }
+            Ok(ScanPortResult::NoMatch) => {
+                tracing::debug!("No service match found for port {}", port);
+            }
+            Err(e) => {
+                tracing::warn!("Error scanning port {}: {}", port, e);
+            }
+        }
+    }
+
+    Ok(NaslValue::Null)
+}
+
+#[derive(Default)]
+pub struct FindService;
+
+function_set! {
+    FindService,
+    (
+        plugin_run_find_service
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_file_valid() {
+        // Implicitly check if the JSON is valid by
+        // creating the ServiceDetector
+        let detector = ServiceDetector::new();
+        detector.unwrap();
+    }
+}

--- a/rust/src/nasl/builtin/find_service/mod.rs
+++ b/rust/src/nasl/builtin/find_service/mod.rs
@@ -193,7 +193,10 @@ struct ServiceDetector {
 
 impl ServiceDetector {
     fn new() -> Result<Self, FindServiceError> {
-        let json_content = include_str!("../../../../data/service_definitions.json");
+        let json_content = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/data/service_definitions.json"
+        ));
         let definitions: ServiceDefinitions = serde_json::from_str(&json_content)?;
         Ok(ServiceDetector {
             services: definitions,

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -64,7 +64,7 @@ pub fn nasl_std_functions() -> Executor {
         .add_set(cryptographic::rc4::CipherHandlers::default())
         .add_set(sys::Sys)
         .add_set(ssh::Ssh::default())
-        .add_set(find_service::FindService::default())
+        .add_set(find_service::FindService)
         .add_set(cert::NaslCerts::default());
 
     #[cfg(feature = "nasl-builtin-raw-ip")]

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -9,6 +9,7 @@ mod cert;
 mod cryptographic;
 mod description;
 mod error;
+mod find_service;
 mod host;
 mod http;
 mod isotime;
@@ -63,6 +64,7 @@ pub fn nasl_std_functions() -> Executor {
         .add_set(cryptographic::rc4::CipherHandlers::default())
         .add_set(sys::Sys)
         .add_set(ssh::Ssh::default())
+        .add_set(find_service::FindService::default())
         .add_set(cert::NaslCerts::default());
 
     #[cfg(feature = "nasl-builtin-raw-ip")]

--- a/rust/src/nasl/builtin/network/network.rs
+++ b/rust/src/nasl/builtin/network/network.rs
@@ -156,7 +156,7 @@ fn scanner_get_port(context: &ScanCtx, idx: u16) -> Result<NaslValue, FnError> {
 
 #[nasl_function]
 fn get_host_open_port(context: &ScanCtx) -> i64 {
-    context.get_host_open_port().unwrap_or_default() as i64
+    context.get_random_open_tcp_port().unwrap_or_default() as i64
 }
 
 #[nasl_function(named(asstring))]

--- a/rust/src/nasl/builtin/network/tcp.rs
+++ b/rust/src/nasl/builtin/network/tcp.rs
@@ -98,6 +98,7 @@ impl TcpConnection {
         bufsz: Option<usize>,
         retry: u8,
     ) -> io::Result<Self> {
+        let retry = if retry == 0 { 1 } else { retry };
         let mut i = 0;
         let sock = match addr {
             IpAddr::V4(_) => Socket::new(

--- a/rust/src/nasl/builtin/raw_ip/denial.rs
+++ b/rust/src/nasl/builtin/raw_ip/denial.rs
@@ -26,7 +26,7 @@ fn get_timeout(context: &ScanCtx) -> u8 {
 fn start_denial(context: &ScanCtx, script_ctx: &mut ScriptCtx) -> Result<NaslValue, FnError> {
     let retry = get_timeout(context);
 
-    let port = context.get_host_open_port().unwrap_or_default();
+    let port = context.get_random_open_tcp_port().unwrap_or_default();
     if port > 0 {
         if let Ok(_soc) = make_tcp_socket(context.target().ip_addr(), port, retry) {
             script_ctx.denial_port = Some(port);

--- a/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
@@ -1978,7 +1978,7 @@ pub fn nasl_tcp_ping_shared(configs: &ScanCtx, port: Option<u16>) -> Result<Nasl
     let target_ip = configs.target().ip_addr();
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
-    let port = port.unwrap_or(configs.get_host_open_port().unwrap_or_default());
+    let port = port.unwrap_or(configs.get_random_open_tcp_port().unwrap_or_default());
 
     if islocalhost(target_ip) {
         return Ok(NaslValue::Number(1));
@@ -3179,7 +3179,7 @@ pub fn nasl_tcp_v6_ping_shared(configs: &ScanCtx, port: Option<u16>) -> Result<N
     let local_ip = get_source_ip(target_ip)?;
     let iface = get_interface_by_local_ip(local_ip)?;
 
-    let port = port.unwrap_or(configs.get_host_open_port().unwrap_or_default());
+    let port = port.unwrap_or(configs.get_random_open_tcp_port().unwrap_or_default());
 
     if islocalhost(target_ip) {
         return Ok(NaslValue::Number(1));

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -884,7 +884,7 @@ impl<'a> ScanCtx<'a> {
             .filter_map(|(key, _values)| {
                 // Key format is "Ports/tcp/{port}"
                 key.split('/')
-                    .last()
+                    .next_back()
                     .and_then(|port_str| port_str.parse().ok())
             })
             .collect();

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -874,28 +874,49 @@ impl<'a> ScanCtx<'a> {
             })
     }
 
+    /// Looks up open TCP ports from the knowledge base
+    pub fn get_open_tcp_ports(&self) -> Result<Vec<u16>, FnError> {
+        let open_ports =
+            self.get_kb_items_with_keys(&KbKey::Port(kb::Port::Tcp("*".to_string())))?;
+
+        let port_numbers: Vec<u16> = open_ports
+            .iter()
+            .filter_map(|(key, _values)| {
+                // Key format is "Ports/tcp/{port}"
+                key.split('/')
+                    .last()
+                    .and_then(|port_str| port_str.parse().ok())
+            })
+            .collect();
+
+        // If no ports found in KB, fall back to context port range
+        if port_numbers.is_empty() {
+            Ok(self.port_range().into_iter().collect())
+        } else {
+            Ok(port_numbers)
+        }
+    }
+
     /// Don't always return the first open port, otherwise
     /// we might get bitten by OSes doing active SYN flood
     /// countermeasures. Also, avoid returning 80 and 21 as
     /// open ports, as many transparent proxies are acting for these...
-    pub fn get_host_open_port(&self) -> Result<u16, FnError> {
+    pub fn get_random_open_tcp_port(&self) -> Result<u16, FnError> {
         let mut open21 = false;
         let mut open80 = false;
-        let ports: Vec<u16> = self
-            .get_kb_items_with_keys(&KbKey::Port(kb::Port::Tcp("*".to_string())))?
+        let all_ports = self.get_open_tcp_ports()?;
+        let ports: Vec<u16> = all_ports
             .iter()
-            .filter_map(|x| {
-                x.0.split('/').next_back().and_then(|x| {
-                    if x == "21" {
-                        open21 = true;
-                        None
-                    } else if x == "80" {
-                        open80 = true;
-                        None
-                    } else {
-                        x.parse::<u16>().ok()
-                    }
-                })
+            .filter_map(|&port| {
+                if port == 21 {
+                    open21 = true;
+                    None
+                } else if port == 80 {
+                    open80 = true;
+                    None
+                } else {
+                    Some(port)
+                }
             })
             .collect();
 

--- a/rust/src/storage/items/kb.rs
+++ b/rust/src/storage/items/kb.rs
@@ -36,7 +36,7 @@ pub enum KbKey {
     FindService(FindService),
 
     /// Known TCP ports
-    KnownTcp(String),
+    KnownTcp(u16),
 
     /// Number of timeouts for a given IP address and port. After a failed attempt
     /// this number is increased by 1 and logged.

--- a/rust/tests/find_service/Dockerfile
+++ b/rust/tests/find_service/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:22.04
+
+# Configure postfix non-interactively
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
+RUN echo "postfix postfix/mailname string localhost" | debconf-set-selections
+
+# Install all dependencies: services, Rust build tools, and OpenVAS dependencies
+RUN apt-get update && apt-get install -y \
+    apache2 \
+    openssh-server \
+    vsftpd \
+    dovecot-pop3d \
+    dovecot-imapd \
+    postfix \
+    mysql-server \
+    telnetd \
+    xinetd \
+    netcat-openbsd \
+    curl \
+    build-essential \
+    pkg-config \
+    zlib1g-dev \
+    libssl-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure SSH
+RUN mkdir /var/run/sshd
+RUN echo 'root:testpassword' | chpasswd
+RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
+
+# Configure Apache
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+RUN echo '<html><body><h1>Test HTTP Server</h1></body></html>' > /var/www/html/index.html
+
+# Configure FTP
+RUN echo "anonymous_enable=YES" >> /etc/vsftpd.conf
+RUN echo "local_enable=YES" >> /etc/vsftpd.conf
+RUN echo "write_enable=YES" >> /etc/vsftpd.conf
+RUN echo "listen=YES" >> /etc/vsftpd.conf
+RUN echo "listen_ipv6=NO" >> /etc/vsftpd.conf
+
+# Configure Dovecot for POP3/IMAP
+RUN sed -i 's/#listen = \*, ::/listen = */' /etc/dovecot/dovecot.conf
+RUN sed -i 's/#disable_plaintext_auth = yes/disable_plaintext_auth = no/' /etc/dovecot/conf.d/10-auth.conf
+
+# Configure MySQL
+RUN service mysql start && \
+    mysql -e "CREATE USER 'testuser'@'%' IDENTIFIED BY 'testpass';" && \
+    mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'testuser'@'%';" && \
+    mysql -e "FLUSH PRIVILEGES;"
+RUN sed -i 's/bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/' /etc/mysql/mysql.conf.d/mysqld.cnf
+
+# Configure Postfix/SMTP
+RUN sed -i 's/inet_interfaces = loopback-only/inet_interfaces = all/' /etc/postfix/main.cf
+
+# Configure Telnet
+RUN echo "service telnet\n{\n    socket_type     = stream\n    protocol        = tcp\n    wait            = no\n    user            = root\n    server          = /usr/sbin/in.telnetd\n    disable         = no\n    port            = 23\n}" > /etc/xinetd.d/telnet
+
+# Create a simple NetBus-like service on port 12345 for security testing
+RUN echo '#!/bin/bash\nwhile true; do echo "NetBus" | nc -l -p 12345; done' > /usr/local/bin/netbus-sim.sh
+RUN chmod +x /usr/local/bin/netbus-sim.sh
+
+# Create startup script starts services and provides a shell
+RUN echo '#!/bin/bash\n\
+echo "Starting services..."\n\
+service mysql start\n\
+service apache2 start\n\
+service ssh start\n\
+service vsftpd start\n\
+service dovecot start\n\
+service postfix start\n\
+service xinetd start\n\
+/usr/local/bin/netbus-sim.sh &\n\
+\n\
+exec /bin/bash' > /usr/local/bin/start-services.sh
+
+RUN chmod +x /usr/local/bin/start-services.sh
+
+# Set working directory for user files
+WORKDIR /workspace
+
+CMD ["/usr/local/bin/start-services.sh"]

--- a/rust/tests/find_service/run.sh
+++ b/rust/tests/find_service/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Get the rust directory (two levels up from the script)
+RUST_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Test directory is where this script is located
+TEST_DIR="$SCRIPT_DIR"
+
+echo "Script directory: $SCRIPT_DIR"
+echo "Rust directory: $RUST_DIR"
+
+# Change to rust directory for cargo commands
+cd "$RUST_DIR"
+
+echo "Building Docker container..."
+docker build -t openvas-find-service-test "$TEST_DIR/"
+
+echo "Starting Docker container..."
+CONTAINER_ID=$(docker run -d --rm -v "$TEST_DIR:/workspace" openvas-find-service-test /bin/bash -c "
+service mysql start
+service apache2 start  
+service ssh start
+service vsftpd start
+service dovecot start
+service postfix start
+service xinetd start
+/usr/local/bin/netbus-sim.sh &
+sleep infinity
+")
+
+echo "Waiting for services to start..."
+sleep 10
+
+CONTAINER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$CONTAINER_ID")
+echo "Container IP: $CONTAINER_IP"
+
+echo "Running scannerctl with test script..."
+cargo run --bin scannerctl execute script "$TEST_DIR/test_find_service.nasl" --target "$CONTAINER_IP"
+
+# echo "Cleaning up..."
+# docker stop "$CONTAINER_ID"

--- a/rust/tests/find_service/test_find_service.nasl
+++ b/rust/tests/find_service/test_find_service.nasl
@@ -1,0 +1,49 @@
+# Function to test specific service detection
+function test_service_detection(port, expected_service) {
+    service_key = "Services/" + expected_service;
+    known_key = "Known/tcp/" + port;
+    
+    service_value = get_kb_item(service_key);
+    known_value = get_kb_item(known_key);
+    
+    if (service_value) {
+        display("Service detection successful for port " + port + ": " + expected_service);
+        display("    Services/" + expected_service + " = " + service_value);
+    } else {
+        display("Service detection failed for port " + port + ": expected " + expected_service);
+    }
+    
+    if (known_value) {
+        display("    Known/tcp/" + port + " = " + known_value);
+    }
+    
+    return service_value != NULL;
+}
+
+function setup_test_ports() {
+    # Set up some common ports that should be detected by find_service
+    set_kb_item(name:"Ports/tcp/21", value:1);     # FTP
+    set_kb_item(name:"Ports/tcp/22", value:1);     # SSH
+    set_kb_item(name:"Ports/tcp/23", value:1);     # Telnet
+    set_kb_item(name:"Ports/tcp/25", value:1);     # SMTP
+    set_kb_item(name:"Ports/tcp/80", value:1);     # HTTP
+    set_kb_item(name:"Ports/tcp/110", value:1);    # POP3
+    set_kb_item(name:"Ports/tcp/143", value:1);    # IMAP
+    set_kb_item(name:"Ports/tcp/12345", value:1);  # NetBus (security test)
+    
+    display("Set up test ports in KB");
+}
+
+display("Target: " + get_host_ip());
+setup_test_ports();
+display("Running find_service...");
+plugin_run_find_service();
+
+test_service_detection(port: 21, expected_service: "ftp");
+test_service_detection(port: 22, expected_service: "ssh");
+test_service_detection(port: 23, expected_service: "telnet");
+test_service_detection(port: 25, expected_service: "smtp");
+test_service_detection(port: 80, expected_service: "www");
+test_service_detection(port: 110, expected_service: "pop3");
+test_service_detection(port: 143, expected_service: "imap");
+test_service_detection(port: 12345, expected_service: "netbus");


### PR DESCRIPTION
Add `run_find_service` implementation.

This is a very rudimentary implementation of the `find_service` builtin. It only includes a limited number of services but hopefully lays the foundation of something ... great.

In this implementation, service detection is not hardcoded, but determined by a list of services in a JSON file. In this JSON, the services are defined as metadata (such as name and description), possible ports, along with some detection methods as well as custom KB entries to add when the service is detected.

For now, only a smaller number of services are detected:
FTP, telnet, SSH, web/http, SMTP, POP3, IMAP and NetBus.

For testing, a dockerfile along with a NASL script and a bash script to
start the dockerfile and run the NASL script against the container is
provided.}

jira: SC-1209