### PR TITLE
Remove the serde-support feature.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -108,12 +108,8 @@ once_cell = "1.20.1"
 insta = { version = "1.41.1", features = ["ron"] }
 
 [features]
-openvas_serde_support = []
-serde_support = []
 default = [
-    "openvas_serde_support",
     "enforce-no-trailing-arguments",
-    "serde_support",
 ]
 
 nasl-builtin-raw-ip = [

--- a/rust/crates/smoketest/Cargo.toml
+++ b/rust/crates/smoketest/Cargo.toml
@@ -16,8 +16,7 @@ serde_json = "1"
 scannerlib = { path = "../.." }
 
 [features]
-default = ["serde_support"]
-serde_support = ["serde"]
+default = []
 smoketest = []
 
 [dev-dependencies]

--- a/rust/src/models/advisories.rs
+++ b/rust/src/models/advisories.rs
@@ -4,30 +4,27 @@
 
 use std::collections::HashMap;
 
+use serde::Deserialize;
+
 /// Represents an advisory json file for notus product.
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ProductsAdvisories {
     /// Version of the advisory file
     pub version: String,
     /// SPDX license identifier
-    #[cfg_attr(feature = "serde_support", serde(rename = "spdx-license-identifier"))]
+    #[serde(rename = "spdx-license-identifier")]
     pub license_identifier: String,
     /// Copyright
     pub copyright: String,
     /// Vulnerability Family
     pub family: String,
     /// List of Advisories
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     pub advisories: Vec<Advisory>,
 }
 
 /// Represents an advisory json file for notus product.
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Advisory {
     /// The advisory's title.
     pub title: String,
@@ -42,20 +39,20 @@ pub struct Advisory {
     /// Advisory xref
     pub advisory_xref: String,
     /// Advisory contains a CVE that is listed in the catalog of Known Exploited CVEs from CISA
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     pub cisa_kev: bool,
     /// List of cves
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     pub cves: Vec<String>,
     /// Summary
     pub summary: String,
     /// Insight
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     pub insight: String,
     /// Affected
     pub affected: String,
     /// List of xrefs
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     pub xrefs: Vec<String>,
     /// Quality of detection
     pub qod_type: String,
@@ -64,11 +61,7 @@ pub struct Advisory {
 }
 
 /// A single vulnerability from an advisory file to be stored
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 pub struct Vulnerability {
     /// VT Parameters
     pub vt_params: Vec<String>,
@@ -107,27 +100,17 @@ pub struct Vulnerability {
 }
 
 /// Severity
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize, Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Severity {
     /// Origin of the severity
     pub origin: String,
     /// severity date
     pub date: u64,
     /// Cvss version v2
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cvss_v2: Option<String>,
     /// cvss vector v3
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cvss_v3: Option<String>,
 }
 

--- a/rust/src/models/credential.rs
+++ b/rust/src/models/credential.rs
@@ -3,17 +3,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 /// Represents a set of credentials to be used for scanning to access a host.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Credential {
     /// Service to use for accessing a host
     pub service: Service,
     /// Port used for getting access. If missing a standard port is used
     pub port: Option<u16>,
-    #[cfg_attr(feature = "serde_support", serde(flatten))]
+    #[serde(flatten)]
     /// Type of the credential to get access. Different services support different types.
     pub credential_type: CredentialType,
 }
@@ -46,38 +42,30 @@ impl Default for Credential {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PrivilegeInformation {
-    #[cfg_attr(feature = "serde_support", serde(rename = "privilege_username"))]
+    #[serde(rename = "privilege_username")]
     pub username: String,
-    #[cfg_attr(feature = "serde_support", serde(rename = "privilege_password"))]
+    #[serde(rename = "privilege_password")]
     pub password: String,
 }
 
 /// Enum of available services
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Service {
-    #[cfg_attr(feature = "serde_support", serde(rename = "ssh"))]
+    #[serde(rename = "ssh")]
     /// SSH, supports [UP](CredentialType::UP) and [USK](CredentialType::USK) as credential types
     SSH,
-    #[cfg_attr(feature = "serde_support", serde(rename = "smb"))]
+    #[serde(rename = "smb")]
     /// SMB, supports [UP](CredentialType::UP)
     SMB,
-    #[cfg_attr(feature = "serde_support", serde(rename = "esxi"))]
+    #[serde(rename = "esxi")]
     /// ESXi, supports [UP](CredentialType::UP)
     ESXi,
-    #[cfg_attr(feature = "serde_support", serde(rename = "snmp"))]
+    #[serde(rename = "snmp")]
     /// SNMP, supports [SNMP](CredentialType::SNMP)
     SNMP,
-    #[cfg_attr(feature = "serde_support", serde(rename = "krb5"))]
+    #[serde(rename = "krb5")]
     /// SNMP, supports [SNMP](CredentialType::SNMP)
     KRB5,
 }
@@ -109,14 +97,10 @@ impl TryFrom<&str> for Service {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// Enum representing the type of credentials.
 pub enum CredentialType {
-    #[cfg_attr(feature = "serde_support", serde(rename = "up"))]
+    #[serde(rename = "up")]
     /// User/password credentials.
     UP {
         /// The username for authentication.
@@ -124,35 +108,26 @@ pub enum CredentialType {
         /// The password for authentication.
         password: String,
         /// privilege credential only use for SSH service
-        #[cfg_attr(
-            feature = "serde_support",
-            serde(default, flatten, skip_serializing_if = "Option::is_none")
-        )]
+        #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
         privilege: Option<PrivilegeInformation>,
     },
-    #[cfg_attr(feature = "serde_support", serde(rename = "usk"))]
+    #[serde(rename = "usk")]
     /// User/ssh-key credentials.
     USK {
         /// The username for authentication.
         username: String,
         /// The password for authentication.
         // A key without passphrase can be expected
-        #[cfg_attr(
-            feature = "serde_support",
-            serde(default, skip_serializing_if = "Option::is_none")
-        )]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         password: Option<String>,
-        #[cfg_attr(feature = "serde_support", serde(rename = "private"))]
+        #[serde(rename = "private")]
         /// The private key for authentication.
         private_key: String,
         /// privilege credential only use for SSH service
-        #[cfg_attr(
-            feature = "serde_support",
-            serde(default, flatten, skip_serializing_if = "Option::is_none")
-        )]
+        #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
         privilege: Option<PrivilegeInformation>,
     },
-    #[cfg_attr(feature = "serde_support", serde(rename = "snmp"))]
+    #[serde(rename = "snmp")]
     /// SNMP credentials.
     SNMP {
         /// The SNMP username.

--- a/rust/src/models/host_info.rs
+++ b/rust/src/models/host_info.rs
@@ -33,11 +33,7 @@ impl HostInfoBuilder {
 }
 
 /// Information about hosts of a running scan
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HostInfo {
     all: u64,
     excluded: u64,
@@ -47,10 +43,7 @@ pub struct HostInfo {
     finished: u64,
     // Hosts that are currently being scanned. The second entry is the host
     // scan progress. Required for Openvas Scanner type
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     scanning: Option<HashMap<String, i32>>,
     // Hosts that are currently being scanned. The second entry is the number of
     // remaining VTs for this host.

--- a/rust/src/models/parameter.rs
+++ b/rust/src/models/parameter.rs
@@ -4,10 +4,8 @@
 
 use std::fmt::Display;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 /// Represents a parameter for a VTS configuration.
 pub struct Parameter {

--- a/rust/src/models/port.rs
+++ b/rust/src/models/port.rs
@@ -5,16 +5,9 @@ use core::iter::IntoIterator;
 use std::fmt::Display;
 
 /// Represents a port representation for scanning.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Port {
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Protocol for the given port range. If empty, prot range applies to UDP and TCP
     pub protocol: Option<Protocol>,
     /// Range for ports to scan.
@@ -22,11 +15,7 @@ pub struct Port {
 }
 
 /// Range for ports to scan.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PortRange {
     /// The required start port.
     ///
@@ -36,10 +25,7 @@ pub struct PortRange {
     ///
     /// It is an inclusive range.
     /// When the end port is not set, only the start port is used.
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub end: Option<usize>,
 }
 
@@ -71,12 +57,8 @@ impl Display for PortRange {
 }
 
 /// Enum representing the protocol used for scanning a port.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_support", serde(rename_all = "lowercase"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Protocol {
     UDP,
     TCP,

--- a/rust/src/models/product.rs
+++ b/rust/src/models/product.rs
@@ -2,40 +2,39 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+use serde::Deserialize;
+
 /// Represents an product json file for notus
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize))]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Product {
     /// Version of the file, some version might not be supported by notus
     pub version: String,
     /// Package type, important for parsing the corresponding package
     pub package_type: PackageType,
     /// List of vulnerability tests for product
-    #[cfg_attr(feature = "serde_support", serde(rename = "advisories"))]
+    #[serde(rename = "advisories")]
     pub vulnerability_tests: Vec<VulnerabilityTest>,
 }
 
 /// Enum of supported package types
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize))]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub enum PackageType {
-    #[cfg_attr(feature = "serde_support", serde(rename = "deb"))]
+    #[serde(rename = "deb")]
     DEB,
-    #[cfg_attr(feature = "serde_support", serde(rename = "ebuild"))]
+    #[serde(rename = "ebuild")]
     EBUILD,
-    #[cfg_attr(feature = "serde_support", serde(rename = "rpm"))]
+    #[serde(rename = "rpm")]
     RPM,
-    #[cfg_attr(feature = "serde_support", serde(rename = "slack"))]
+    #[serde(rename = "slack")]
     SLACK,
-    #[cfg_attr(feature = "serde_support", serde(rename = "msp"))]
+    #[serde(rename = "msp")]
     MSP,
-    #[cfg_attr(feature = "serde_support", serde(rename = "alpm"))]
+    #[serde(rename = "alpm")]
     ALPM,
 }
 
 /// Representing a single Vulnerability Test entry
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize))]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct VulnerabilityTest {
     /// OID to identify vulnerability
     pub oid: String,
@@ -44,8 +43,8 @@ pub struct VulnerabilityTest {
 }
 
 /// Version entry
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize), serde(untagged))]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
 pub enum FixedPackage {
     ByFullName {
         full_name: String,
@@ -63,32 +62,27 @@ pub enum FixedPackage {
 }
 
 /// A specifier can be one of: >, <, >=, <=, =
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Deserialize, serde::Serialize)
-)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub enum Specifier {
     /// >
-    #[cfg_attr(feature = "serde_support", serde(rename = ">"))]
+    #[serde(rename = ">")]
     GT,
     /// <
-    #[cfg_attr(feature = "serde_support", serde(rename = "<"))]
+    #[serde(rename = "<")]
     LT,
     /// >=
-    #[cfg_attr(feature = "serde_support", serde(rename = ">="))]
+    #[serde(rename = ">=")]
     GE,
     /// <=
-    #[cfg_attr(feature = "serde_support", serde(rename = "<="))]
+    #[serde(rename = "<=")]
     LE,
     /// =
-    #[cfg_attr(feature = "serde_support", serde(rename = "="))]
+    #[serde(rename = "=")]
     EQ,
 }
 
 /// Version range
-#[cfg_attr(feature = "serde_support", derive(serde::Deserialize))]
-#[derive(Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Range {
     pub start: String,
     pub end: String,

--- a/rust/src/models/result.rs
+++ b/rust/src/models/result.rs
@@ -9,68 +9,39 @@ use crate::models::Specifier;
 use super::port::Protocol;
 
 /// Scan result
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Result {
     /// Incremental ID of a result
     pub id: usize,
-    #[cfg_attr(feature = "serde_support", serde(rename = "type"))]
+    #[serde(rename = "type")]
     /// Type of the result
     pub r_type: ResultType,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// IP address
     pub ip_address: Option<String>,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// DNS
     pub hostname: Option<String>,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// ID of the VT, which generated the result
     pub oid: Option<String>,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// Port
     pub port: Option<i16>,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// Protocol the port corresponds to
     pub protocol: Option<Protocol>,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// Additional information
     pub message: Option<String>,
 
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(skip_serializing_if = "Option::is_none", default)
-    )]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     /// Details are only set on status and can be ignored
     pub detail: Option<Detail>,
 }
 
 /// Host Details information
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Detail {
     /// Descriptive name of a Host Detail
     pub name: String,
@@ -81,11 +52,7 @@ pub struct Detail {
 }
 
 /// Host details source information
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Source {
     #[serde(rename = "type")]
     /// type of the source
@@ -106,12 +73,8 @@ impl<T: Into<Result>> From<(usize, T)> for Result {
 }
 
 /// Enum of possible types of results
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_support", serde(rename_all = "snake_case"))]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ResultType {
     /// Vulnerability
     Alarm,
@@ -133,16 +96,15 @@ pub enum ResultType {
 /// Notus Results are a Map from OIDs to vulnerable Packages
 pub type NotusResults = HashMap<String, Vec<VulnerablePackage>>;
 
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize))]
-#[derive(Debug)]
+#[derive(serde::Serialize, Debug)]
 pub struct VulnerablePackage {
     pub name: String,
     pub installed_version: String,
     pub fixed_version: FixedVersion,
 }
 
-#[cfg_attr(feature = "serde_support", derive(serde::Serialize), serde(untagged))]
-#[derive(Debug)]
+#[derive(serde::Serialize, Debug)]
+#[serde(untagged)]
 pub enum FixedVersion {
     Single {
         version: String,

--- a/rust/src/models/scan.rs
+++ b/rust/src/models/scan.rs
@@ -9,22 +9,14 @@ use super::{target::Target, vt::VT};
 pub type ScanID = String;
 
 /// Struct for creating and getting a scan
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(deny_unknown_fields)
-)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Scan {
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// Unique ID of a scan
     pub scan_id: ScanID,
     /// Information about the target to scan
     pub target: Target,
-    #[cfg_attr(
-        feature = "serde_support",
-        serde(default, alias = "scanner_preferences")
-    )]
+    #[serde(default, alias = "scanner_preferences")]
     /// Configuration options for a scan
     pub scan_preferences: ScanPrefs,
     /// List of VTs to execute for the target

--- a/rust/src/models/scan_action.rs
+++ b/rust/src/models/scan_action.rs
@@ -4,22 +4,14 @@
 use std::fmt::{Display, Formatter};
 
 /// Action to perform on a scan
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ScanAction {
     pub action: Action,
 }
 
 /// Enum representing possible actions
-#[derive(Debug, Copy, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_support", serde(rename_all = "snake_case"))]
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Action {
     /// Start a scan
     Start,

--- a/rust/src/models/scanner.rs
+++ b/rust/src/models/scanner.rs
@@ -11,11 +11,7 @@ use super::{Scan, Status};
 ///
 /// It is usually returned on fetch_results which gets all results of all running scans for further
 /// processing.
-#[derive(Debug, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ScanResults {
     pub id: String,
     pub status: Status,

--- a/rust/src/models/scanner_preference.rs
+++ b/rust/src/models/scanner_preference.rs
@@ -3,11 +3,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 /// Configuration preference for the scanner
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ScanPreference {
     /// The ID of a scan preference.
     pub id: String,
@@ -16,12 +12,8 @@ pub struct ScanPreference {
 }
 
 /// Preference value
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(untagged)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
 pub enum PreferenceValue {
     Bool(bool),
     Int(i64),
@@ -35,11 +27,7 @@ impl Default for PreferenceValue {
 }
 
 /// Configuration preference information for a scan. The type can be derived from the default value.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ScanPreferenceInformation {
     /// The ID of the scan preference
     pub id: &'static str,

--- a/rust/src/models/status.rs
+++ b/rust/src/models/status.rs
@@ -7,11 +7,7 @@ use std::{fmt::Display, str::FromStr};
 use super::host_info::HostInfo;
 
 /// Status information about a scan
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Status {
     /// Timestamp for the start of a scan
     pub start_time: Option<u64>,
@@ -54,12 +50,8 @@ impl Status {
 }
 
 /// Enum of the possible phases of a scan
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_support", serde(rename_all = "snake_case"))]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Phase {
     /// A scan has been stored but not started yet
     #[default]

--- a/rust/src/models/target.rs
+++ b/rust/src/models/target.rs
@@ -9,44 +9,36 @@ use super::{credential::Credential, port::Port};
 pub type Host = String;
 
 /// Information about a target of a scan
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Target {
     /// List of hosts to scan
     pub hosts: Vec<Host>,
     /// List of ports used for scanning
     pub ports: Vec<Port>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// List of excluded hosts to scan
     pub excluded_hosts: Vec<Host>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// List of credentials used to get access to a system
     pub credentials: Vec<Credential>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// List of ports used for alive testing
     pub alive_test_ports: Vec<Port>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// Methods used for alive testing
     pub alive_test_methods: Vec<AliveTestMethods>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// If multiple IP addresses resolve to the same DNS name the DNS name will only get scanned
     /// once.
     pub reverse_lookup_unify: Option<bool>,
-    #[cfg_attr(feature = "serde_support", serde(default))]
+    #[serde(default)]
     /// Only scan IP addresses that can be resolved into a DNS name.
     pub reverse_lookup_only: Option<bool>,
 }
 
 /// Enum of possible alive test methods
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_support", serde(rename_all = "snake_case"))]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum AliveTestMethods {
     TcpAck = 0x01,
     Icmp = 0x02,

--- a/rust/src/models/vt.rs
+++ b/rust/src/models/vt.rs
@@ -5,15 +5,22 @@
 use super::parameter::Parameter;
 
 /// A VT to execute during a scan, including its parameters
-#[derive(Debug, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    PartialOrd,
+    Ord,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 pub struct VT {
     /// The ID of the VT to execute
     pub oid: String,
-    #[cfg_attr(feature = "serde_support", serde(default,))]
+    #[serde(default)]
     /// The list of parameters for the VT
     pub parameters: Vec<Parameter>,
 }

--- a/rust/src/openvas/config.rs
+++ b/rust/src/openvas/config.rs
@@ -4,12 +4,8 @@
 
 use std::time::Duration;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "openvas_serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(deny_unknown_fields)
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub max_queued_scans: Option<usize>,
     pub max_running_scans: Option<usize>,

--- a/rust/src/scanner/preferences/preference.rs
+++ b/rust/src/scanner/preferences/preference.rs
@@ -257,21 +257,13 @@ impl Default for ScanPrefValue {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FullScanPreferences {
     pub scan_preferences: Vec<FullScanPreference>,
 }
 
 /// Configuration preference information for a scan. The type can be derived from the default value.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FullScanPreference {
     /// The ID of the scan preference
     pub id: String,
@@ -350,11 +342,7 @@ impl FullScanPreferences {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize)
-)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ScanPrefs(pub Vec<ScanPreference>);
 
 impl ScanPrefs {

--- a/rust/src/storage/items/kb.rs
+++ b/rust/src/storage/items/kb.rs
@@ -8,12 +8,8 @@ use std::{collections::HashMap, fmt::Display, hash::Hash, net::IpAddr};
 
 use crate::storage::{ScanID, Target};
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 /// List defined KbKeys. For all kb keys that are not defined by
 /// a NASL user should use a variant from the enum, that is not
 /// custom.
@@ -56,12 +52,8 @@ pub enum KbKey {
     Custom(String),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Ssl {
     Cert,
     Key,
@@ -69,57 +61,37 @@ pub enum Ssl {
     Ca,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Port {
     Tcp(String),
     Udp(String),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Transport {
     Tcp(String),
     Ssl,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Internals {
     Results,
     ScanId,
     Vhosts,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Host {
     Tcp,
     Udp,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Service {
     Wrapped,
     Unknown,
@@ -127,12 +99,8 @@ pub enum Service {
     Custom(String),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FindService {
     CnxTime1000(String),
     CnxTime(String),
@@ -142,12 +110,8 @@ pub enum FindService {
     TcpSpontaneous(String),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Kdc {
     Hostname,
     Port,
@@ -259,12 +223,8 @@ impl From<String> for KbKey {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Default, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(untagged)
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
 /// Allowed type definitions
 pub enum KbItem {
     /// String value

--- a/rust/src/storage/items/nvt.rs
+++ b/rust/src/storage/items/nvt.rs
@@ -41,12 +41,20 @@ use super::kb::KbItem;
 /// - End
 ///
 /// It is defined as a numeric value instead of string representations due to downwards compatible reasons.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Default, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Default,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
 )]
+#[serde(rename_all = "snake_case")]
 pub enum ACT {
     /// Defines a initializer
     Init,
@@ -99,11 +107,7 @@ impl FromStr for ACT {
 macro_rules! make_str_lookup_enum {
     ($enum_name:ident: $doc:expr => { $($matcher:ident => $key:ident),+ }) => {
         #[doc = $doc]
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord,PartialOrd, Hash)]
-        #[cfg_attr(feature = "serde_support",
-                   derive(serde::Serialize, serde::Deserialize),
-                   serde(rename_all = "snake_case")
-        )]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Ord,PartialOrd, Hash, serde::Serialize, serde::Deserialize)]
         pub enum $enum_name {
             $(
              #[doc = concat!(stringify!($matcher))]
@@ -199,12 +203,10 @@ make_str_lookup_enum! {
 }
 
 /// Allowed types for preferences
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "lowercase")
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, serde::Serialize, serde::Deserialize,
 )]
+#[serde(rename_all = "lowercase")]
 pub enum PreferenceType {
     #[doc = "checkbox"]
     CheckBox,
@@ -347,12 +349,8 @@ pub struct Feed;
 pub type FeedFilter = Vec<NvtField>;
 
 /// Preferences that can be set by a user when running a script.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct NvtPreference {
     /// Preference ID
     pub id: Option<i32>,
@@ -365,12 +363,8 @@ pub struct NvtPreference {
 }
 
 /// References defines where the information for that vulnerability attack is from.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub struct NvtRef {
     /// Reference type ("cve", "bid", ...)
     pub class: String,
@@ -518,12 +512,8 @@ impl TagValue {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde_support",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "snake_case")
-)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 /// Structure to hold a NVT
 pub struct Nvt {
     /// The ID of the nvt.


### PR DESCRIPTION
This is motivated by the fact that our codebase currently does not compile without the feature and we also don't have a real plan how to not use serde.
