### PR TITLE
Initialise handle

### DIFF
--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -85,7 +85,7 @@ nasl_smb_connect (lex_ctxt *lexic)
   char *share = get_str_var_by_name (lexic, "share");
 
   tree_cell *retc;
-  SMB_HANDLE handle;
+  SMB_HANDLE handle = 0;
   int value;
 
   if ((host == NULL) || (username == NULL) || (password == NULL)


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Initialise handle in nasl_smb_connect.

Enable building latest release on el10.

**Why**:

<!-- Why are these changes necessary? -->

Without this gcc on el10 complains that "‘handle’ may be used uninitialized".

```
[ 79%] Linking C shared library libopenvas_nasl.so
cd /builds/irt-liuit/greenbone/openvas-scanner/rpmbuild/BUILD/openvas-scanner-23.21.0/redhat-linux-build/nasl && /usr/bin/cmake -E cmake_link_script CMakeFiles/openvas_nasl_shared.dir/link.txt --verbose=1
/usr/bin/gcc -fPIC -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v3 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1                                 -std=c11                                 -Wall                                 -Wextra                                 -Werror                                 -Wpedantic                                 -Wmissing-prototypes                                 -Wshadow                                 -Wsequence-point                                 -D_BSD_SOURCE                                 -D_ISOC11_SOURCE                                 -D_SVID_SOURCE                                 -D_DEFAULT_SOURCE -Wall -Wextra -fno-strict-aliasing -DNDEBUG -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector -Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes -shared -Wl,-soname,libopenvas_nasl.so.23 -o libopenvas_nasl.so.23.21.0 CMakeFiles/openvas_nasl_shared.dir/smb_interface_stub.c.o CMakeFiles/openvas_nasl_shared.dir/wmi_interface_stub.c.o CMakeFiles/openvas_nasl_shared.dir/arc4.c.o CMakeFiles/openvas_nasl_shared.dir/capture_packet.c.o CMakeFiles/openvas_nasl_shared.dir/charcnv.c.o CMakeFiles/openvas_nasl_shared.dir/exec.c.o CMakeFiles/openvas_nasl_shared.dir/genrand.c.o CMakeFiles/openvas_nasl_shared.dir/hmacmd5.c.o CMakeFiles/openvas_nasl_shared.dir/iconv.c.o CMakeFiles/openvas_nasl_shared.dir/lint.c.o CMakeFiles/openvas_nasl_shared.dir/md4.c.o CMakeFiles/openvas_nasl_shared.dir/md5.c.o CMakeFiles/openvas_nasl_shared.dir/nasl.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_builtin_find_service.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_builtin_openvas_tcp_scanner.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_builtin_synscan.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_cmd_exec.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_crypt_helper.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_crypto2.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_frame_forgery.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_snmp.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_ssh.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_cert.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_crypto.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_debug.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_func.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_grammar.tab.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_host.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_http.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_http2.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_init.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_lex_ctxt.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_misc_funcs.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_scanner_glue.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_packet_forgery.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_packet_forgery_v6.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_signature.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_smb.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_socket.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_text_utils.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_tree.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_var.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_wmi.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_isotime.c.o CMakeFiles/openvas_nasl_shared.dir/ntlmssp.c.o CMakeFiles/openvas_nasl_shared.dir/smb_crypt.c.o CMakeFiles/openvas_nasl_shared.dir/smb_crypt2.c.o CMakeFiles/openvas_nasl_shared.dir/smb_signing.c.o CMakeFiles/openvas_nasl_shared.dir/time.c.o CMakeFiles/openvas_nasl_shared.dir/nasl_krb5.c.o  -Wl,-rpath,/builds/irt-liuit/greenbone/openvas-scanner/rpmbuild/BUILD/openvas-scanner-23.21.0/redhat-linux-build/misc: ../misc/libopenvas_misc.so.23.21.0 -lcurl -lpcap -L/usr/lib64 -lglib-2.0 -L/usr/lib64 -ljson-glib-1.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -L/usr/lib64 -lgcrypt -lgpgme -lm -L/usr/lib64 -lgvm_base -L/usr/lib64 -lgvm_util -L/usr/lib64 -lgnutls -L/usr/lib64 -lssh -L/usr/lib64 -lksba -lgpg-error -L/usr/lib64 -lnetsnmp -lm -lssl -lssl -lssl -lssl -lcrypto -Wl,-z,relro -Wl,-z,now -ljson-glib-1.0 -lgio-2.0 -lgobject-2.0 -lgcrypt -lgpgme -lm -lgvm_base -lgvm_util -lgnutls -lssh -lksba -lgpg-error
/builds/irt-liuit/greenbone/openvas-scanner/rpmbuild/BUILD/openvas-scanner-23.21.0/nasl/nasl_smb.c: In function ‘nasl_smb_connect’:
/builds/irt-liuit/greenbone/openvas-scanner/rpmbuild/BUILD/openvas-scanner-23.21.0/nasl/nasl_smb.c:117:17: error: ‘handle’ may be used uninitialized [-Werror=maybe-uninitialized]
  117 |   retc->x.i_val = handle;
      |                 ^
/builds/irt-liuit/greenbone/openvas-scanner/rpmbuild/BUILD/openvas-scanner-23.21.0/nasl/nasl_smb.c:88:14: note: ‘handle’ declared here
   88 |   SMB_HANDLE handle;
      |              ^
lto1: all warnings being treated as errors
```

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

0 chosen as initial value as that is what is used as default value by all get_int_var_by_name calls that produced a value used as SMB_HANDLE in the same file.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
I would need a good deal of hints to add tests for this.
- [x] PR merge commit message adjusted
