### PR TITLE
Add: NASL bultin function insert_hexzeros in rust

### DIFF
--- a/rust/src/nasl/builtin/cryptographic/README.md
+++ b/rust/src/nasl/builtin/cryptographic/README.md
@@ -73,6 +73,7 @@ let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
 - smb3kdf
 - smb_cmac_aes_signature
 - smb_gmac_aes_signature
+- insert_hexzeros
 
 ## Not yet implemented
 
@@ -90,8 +91,6 @@ let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
 - dsa_do_verify
 - get_signature
 - get_smb2_signature
-- index
-- insert_hexzeros
 - key_exchange
 - lm_owf_gen
 - nt_owf_gen

--- a/rust/src/nasl/builtin/cryptographic/misc.rs
+++ b/rust/src/nasl/builtin/cryptographic/misc.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use crate::nasl::prelude::*;
+
+#[nasl_function]
+fn insert_hexzeros(register: &Register) -> Result<Vec<u8>, FnError> {
+    // As in is a keyword in rust, we cannot use the nasl_function annotation for named arguments.
+    let data = register
+        .named("in")
+        .ok_or_else(|| ArgumentError::MissingNamed(vec!["in".into()]))?;
+    let data = match data {
+        ContextType::Value(NaslValue::Data(x)) => x,
+        ContextType::Value(NaslValue::String(x)) => x.as_bytes(),
+        _ => return Err(ArgumentError::WrongArgument("expected Data.".to_string()).into()),
+    };
+
+    let mut result = vec![];
+    for byte in data {
+        if *byte == 0 {
+            break;
+        }
+        result.push(*byte);
+        result.push(0);
+    }
+    Ok(result)
+}
+
+pub struct Misc;
+
+function_set! {
+    Misc,
+    (
+        (insert_hexzeros, "insert_hexzeros"),
+    )
+}

--- a/rust/src/nasl/builtin/cryptographic/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/mod.rs
@@ -19,6 +19,7 @@ pub mod bf_cbc;
 pub mod des;
 pub mod hash;
 pub mod hmac;
+pub mod misc;
 pub mod pem_to;
 pub mod rc4;
 pub mod rsa;
@@ -143,6 +144,7 @@ impl IntoFunctionSet for Cryptographic {
         set.add_set(bf_cbc::BfCbc);
         set.add_set(pem_to::PemTo);
         set.add_set(smb::Smb);
+        set.add_set(misc::Misc);
         set
     }
 }

--- a/rust/src/nasl/builtin/cryptographic/tests/misc.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/misc.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2024 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use super::helper::decode_hex;
+use crate::nasl::test_prelude::*;
+
+#[test]
+fn des_encrypt() {
+    let mut t = TestBuilder::default();
+    t.run(r#"data = hexstr_to_data("010101");"#);
+    t.ok(
+        r#"insert_hexzeros(in: data);"#,
+        decode_hex("010001000100").unwrap(),
+    );
+}

--- a/rust/src/nasl/builtin/cryptographic/tests/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/mod.rs
@@ -12,6 +12,7 @@ mod des;
 mod hash;
 mod helper;
 mod hmac;
+mod misc;
 mod pem_to;
 mod rc4;
 mod rsa;


### PR DESCRIPTION
Jira: SC-1348

To test this function, if it does the same as `openvas-nasl`, I used the following script:
```c#
data = raw_string(0x01, 0x01, 0x01, 0x00, 0x01);
result = insert_hexzeros(in: data);
display(hexstr(result));
```