### PR TITLE
Satisfy clippy and Bump Dependency versions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -152,28 +152,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
- "term 0.7.0",
-]
-
-[[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
-dependencies = [
- "term 1.0.1",
+ "term",
 ]
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -181,19 +184,19 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "time",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -205,7 +208,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -216,7 +219,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -339,7 +342,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.100",
+ "syn",
  "which",
 ]
 
@@ -349,16 +352,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
 
 [[package]]
@@ -366,12 +360,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -386,6 +374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -445,15 +442,18 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "capnp"
-version = "0.14.11"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
+checksum = "4e985a566bdaae9a428a957d12b10c318d41b2afddb54cfbb764878059df636e"
+dependencies = [
+ "embedded-io",
+]
 
 [[package]]
 name = "capnp-futures"
-version = "0.14.3"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d7115c9c31cc85c6d21aea9417059f9d6ee87762a36693a2afcfb8ba23009b"
+checksum = "f8f3ee810b3890498e51028448ac732cdd5009223897124dd2fac6b085b5d867"
 dependencies = [
  "capnp",
  "futures",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "capnp-rpc"
-version = "0.14.1"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4f17f96f68f2c1168ed7105d9e5cb4a095a5bef3578aee0f9c0644b85ca95e"
+checksum = "fe57ab22a5e121e6fddaf36e837514aab9ae888bcff2baa6fda5630820dfc501"
 dependencies = [
  "capnp",
  "capnp-futures",
@@ -599,7 +599,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.6",
+ "libloading",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -664,10 +664,11 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
  "unicode-width",
 ]
@@ -868,12 +869,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -909,7 +910,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -935,7 +936,7 @@ checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -951,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -995,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
@@ -1014,13 +1015,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1042,7 +1044,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1152,6 +1154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "ena"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,12 +1247,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1370,7 +1372,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -1730,7 +1732,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.25",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1896,7 +1898,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2049,52 +2051,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
-dependencies = [
- "cpufeatures",
-]
-
-[[package]]
 name = "lalrpop"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
- "ascii-canvas 3.0.0",
- "bit-set 0.5.3",
+ "ascii-canvas",
+ "bit-set",
  "ena",
  "itertools 0.11.0",
- "lalrpop-util 0.20.2",
- "petgraph 0.6.5",
+ "lalrpop-util",
+ "petgraph",
  "regex",
  "regex-syntax 0.8.5",
  "string_cache",
- "term 0.7.0",
+ "term",
  "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
-dependencies = [
- "ascii-canvas 4.0.0",
- "bit-set 0.8.0",
- "ena",
- "itertools 0.14.0",
- "lalrpop-util 0.22.1",
- "petgraph 0.7.1",
- "regex",
- "regex-syntax 0.8.5",
- "sha3",
- "string_cache",
- "term 1.0.1",
  "unicode-xid",
  "walkdir",
 ]
@@ -2106,16 +2078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
  "regex-automata 0.4.9",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
-dependencies = [
- "regex-automata 0.4.9",
- "rustversion",
 ]
 
 [[package]]
@@ -2138,7 +2100,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2158,23 +2120,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libgcrypt-sys"
 version = "0.1.0"
-
-[[package]]
-name = "libloading"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libloading"
@@ -2393,7 +2345,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2512,6 +2464,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]
@@ -2570,7 +2541,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2600,6 +2571,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "overload"
@@ -2707,15 +2684,15 @@ dependencies = [
 
 [[package]]
 name = "pcap"
-version = "1.3.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e935fc73d54a89fff576526c2ccd42bbf8247aae05b358693475b14fd4ff79"
+checksum = "83cdabc34a80d9ec3563694cc31423fba6bb9bab4f31a9a5d5b85f29bd6d660a"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
  "futures",
  "libc",
- "libloading 0.6.7",
+ "libloading",
  "pkg-config",
  "regex",
  "tokio",
@@ -2753,17 +2730,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset 0.4.2",
- "indexmap",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2793,7 +2760,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -2882,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "pnet"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd959a8268165518e2bf5546ba84c7b3222744435616381df3c456fe8d983576"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
 dependencies = [
  "ipnetwork",
  "pnet_base",
@@ -2896,18 +2863,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_base"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872e46346144ebf35219ccaa64b1dffacd9c6f188cd7d012bd6977a2a838f42e"
+checksum = "ffc190d4067df16af3aba49b3b74c469e611cad6314676eaf1157f31aa0fb2f7"
 dependencies = [
  "no-std-net",
 ]
 
 [[package]]
 name = "pnet_datalink"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c302da22118d2793c312a35fb3da6846cb0fab6c3ad53fd67e37809b06cdafce"
+checksum = "e79e70ec0be163102a332e1d2d5586d362ad76b01cec86f830241f2b6452a7b7"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -2918,30 +2885,30 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d932134f32efd7834eb8b16d42418dac87086347d1bc7d142370ef078582bc"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bde678bbd85cb1c2d99dc9fc596e57f03aa725f84f3168b0eaf33eeccb41706"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
 dependencies = [
  "glob",
  "pnet_base",
@@ -2951,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf7a58b2803d818a374be9278a1fe8f88fce14b936afbe225000cfcd9c73f16"
+checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi",
@@ -2961,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "813d1c0e4defbe7ee22f6fe1755f122b77bfb5abe77145b1b5baaf463cab9249"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
 dependencies = [
  "libc",
  "pnet_base",
@@ -3022,7 +2989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -3045,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
 dependencies = [
  "memchr",
  "serde",
@@ -3081,13 +3048,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3463,7 +3429,7 @@ dependencies = [
  "flurry",
  "log",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-util",
 ]
@@ -3550,15 +3516,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.0",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -3595,9 +3561,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3611,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3690,7 +3659,7 @@ dependencies = [
  "hyper-rustls 0.27.5",
  "hyper-util",
  "insta",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "lazy-regex",
  "lazy_static",
  "libc",
@@ -3720,7 +3689,7 @@ dependencies = [
  "rsa",
  "russh",
  "russh-keys",
- "rustls 0.23.25",
+ "rustls 0.23.31",
  "rustls-pemfile 1.0.4",
  "rustls-pemfile 2.2.0",
  "sequoia-ipc",
@@ -3729,9 +3698,9 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "socket2 0.5.8",
+ "socket2 0.6.0",
  "sysinfo",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "time",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -3833,28 +3802,24 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "sequoia-ipc"
-version = "0.30.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fca3c6c11aa62b9fe55a94682007e6fe18d127644928627e7e7c41597f8b9"
+checksum = "c92579bbd37f62bbcc41e4dce7771fea395037bebaf9b8e10c20b765be8280ab"
 dependencies = [
  "anyhow",
- "buffered-reader",
  "capnp-rpc",
- "crossbeam-utils",
  "ctor",
  "dirs",
  "fs2",
- "futures",
- "lalrpop 0.22.1",
- "lalrpop-util 0.22.1",
- "lazy_static",
+ "lalrpop",
+ "lalrpop-util",
  "libc",
  "memsec",
  "rand 0.8.5",
  "sequoia-openpgp",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "tokio",
  "tokio-util",
  "winapi",
@@ -3862,29 +3827,28 @@ dependencies = [
 
 [[package]]
 name = "sequoia-openpgp"
-version = "1.22.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e858e4e9e48ff079cede92e1b45c942a5466ce9a4e3cc0c2a7e66586a718ef59"
+checksum = "015e5fc3d023418b9db98ca9a7f3e90b305872eeafe5ca45c5c32b5eb335c1e8"
 dependencies = [
  "anyhow",
+ "argon2",
  "base64 0.22.1",
  "buffered-reader",
  "chrono",
  "dyn-clone",
  "getrandom 0.2.15",
  "idna",
- "lalrpop 0.20.2",
- "lalrpop-util 0.20.2",
- "lazy_static",
+ "lalrpop",
+ "lalrpop-util",
  "libc",
  "memsec",
- "once_cell",
  "openssl",
  "openssl-sys",
  "regex",
  "regex-syntax 0.8.5",
  "sha1collisiondetection",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "xxhash-rust",
 ]
 
@@ -3905,7 +3869,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -3922,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -3977,16 +3941,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
-dependencies = [
- "digest",
- "keccak",
 ]
 
 [[package]]
@@ -4066,22 +4020,22 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4189,17 +4143,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -4223,22 +4166,21 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "07cec4dc2d2e357ca1e610cfb07de2fa7a10fc3e9fe89f72545f3d244ea87753"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4287,16 +4229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bb6001afcea98122260987f8b7b5da969ecad46dbf0b5453702f776b491a41"
-dependencies = [
- "home",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4316,11 +4248,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -4331,18 +4263,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -4441,7 +4373,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -4460,7 +4392,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.25",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -4492,37 +4424,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower-service"
@@ -4549,7 +4486,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -4609,7 +4546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -4700,7 +4637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.2",
  "serde",
 ]
 
@@ -4778,7 +4715,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4813,7 +4750,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4888,22 +4825,34 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4921,11 +4870,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4936,7 +4909,18 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4947,14 +4931,35 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4966,13 +4971,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5044,6 +5067,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5168,12 +5200,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
-dependencies = [
- "memchr",
-]
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "winreg"
@@ -5208,9 +5237,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "x509-certificate"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+checksum = "e57b9f8bcae7c1f36479821ae826d75050c60ce55146fd86d3553ed2573e2762"
 dependencies = [
  "bcder",
  "bytes",
@@ -5227,9 +5256,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -5238,7 +5267,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.14",
  "time",
 ]
 
@@ -5268,7 +5297,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -5298,7 +5327,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -5309,7 +5338,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -5329,7 +5358,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
  "synstructure",
 ]
 
@@ -5350,7 +5379,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]
 
 [[package]]
@@ -5372,5 +5401,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,7 @@ http-body-util = "0.1.0"
 hyper = { version = "1", features = ["full"] }
 hyper-rustls = "0"
 hyper-util = { version = "0", features = ["tokio"] }
-itertools = "0.12.0"
+itertools = "0.14.0"
 lazy-regex = "3.3.0"
 lazy_static = "1.4.0"
 libc = "0.2"
@@ -45,45 +45,49 @@ md4 = "0.10.2"
 num_cpus = "1.16.0"
 pbkdf2 = { version = "0.12.2", features = ["password-hash"] }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem", "std"] }
-quick-xml = { version = "0.37.1", features = ["serde", "serde-types", "serialize"] }
+quick-xml = { version = "0.38.1", features = [
+    "serde",
+    "serde-types",
+    "serialize",
+] }
 
 rand = "0.8.5"
 redis = "0.22.3"
 regex = "1.10.6"
 ripemd = "0.1.3"
-rsa = { version = "0.9.6", features = ["hazmat"] }
+rsa = { version = "0.9.8", features = ["hazmat"] }
 russh = "0.46.0"
 russh-keys = "0.46.0"
-rustls = "0.23.5"
-rustls-pemfile = "2.1.2"
+rustls = "0.23.31"
+rustls-pemfile = "2.2.0"
 rustls-pemfile-old = { version = "1.0.2", package = "rustls-pemfile" }
-sequoia-ipc = "0.30.1"
-sequoia-openpgp = { version = "1.16.1", default-features = false, features = [
+sequoia-ipc = "0.36.0"
+sequoia-openpgp = { version = "2.0.0", default-features = false, features = [
     "crypto-openssl",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.96"
 sha1 = "0.10.5"
 sha2 = "0.10.7"
-socket2 = "0.5.8"
-sysinfo = "0.30.5"
-thiserror = "1.0.62"
+socket2 = { version = "0.6.0", features = ["all"] }
+sysinfo = "0.37.0"
+thiserror = "2.0.14"
 time = { version = "0", features = ["parsing"] }
 tokio = { version = "1.45.0", features = ["full"] }
 tokio-rustls = "0.26.0"
-toml = "0.8.4"
+toml = "0.9.5"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 urlencoding = "2.1.2"
 uuid = { version = "1", features = ["v4", "fast-rng", "serde"] }
 walkdir = "2"
-x509-certificate = "0.23.1"
-x509-parser = "0.16.0"
-pcap = { version = "1.0.0", optional = true, features = ["all-features", "capture-stream"] }
-pnet_base = { version = "0.33.0", optional = true }
-pnet = { version = "0.33.0", optional = true }
-pnet_macros = { version = "0.33.0", optional = true }
-pnet_macros_support = { version = "0.33.0", optional = true }
+x509-certificate = "0.24.0"
+x509-parser = "0.17.0"
+pcap = { version = "2.3.0", optional = true, features = ["capture-stream"] }
+pnet_base = { version = "0.35.0", optional = true }
+pnet = { version = "0.35.0", optional = true }
+pnet_macros = { version = "0.35.0", optional = true }
+pnet_macros_support = { version = "0.35.0", optional = true }
 
 libssh-rs = { version = "0.3.5", features = [
     "vendored-openssl",
@@ -95,7 +99,7 @@ nasl-c-lib = { path = "crates/nasl-c-lib", optional = true }
 openssl = { version = "0.10.72", features = ["vendored"] }
 blowfish = "0.9.1"
 rc4 = "0.1.0"
-codespan-reporting = "0.11.1"
+codespan-reporting = "0.12.0"
 dsa = "0.6.3"
 mtu = { version = "0.2.9", optional = true }
 
@@ -109,9 +113,7 @@ once_cell = "1.20.1"
 insta = { version = "1.41.1", features = ["ron"] }
 
 [features]
-default = [
-    "enforce-no-trailing-arguments",
-]
+default = ["enforce-no-trailing-arguments"]
 
 nasl-builtin-raw-ip = [
     "mtu",

--- a/rust/crates/nasl-function-proc-macro/src/parse.rs
+++ b/rust/crates/nasl-function-proc-macro/src/parse.rs
@@ -230,10 +230,10 @@ fn parse_function_args<'a>(
 fn first_unsorted_index(iter: impl Iterator<Item = usize>) -> Option<usize> {
     let mut prev = None;
     for (index, next) in iter.enumerate() {
-        if let Some(prev) = prev {
-            if next < prev {
-                return Some(index);
-            }
+        if let Some(prev) = prev
+            && next < prev
+        {
+            return Some(index);
         }
         prev = Some(next);
     }

--- a/rust/src/alive_test/alive_test.rs
+++ b/rust/src/alive_test/alive_test.rs
@@ -216,10 +216,8 @@ async fn capture_task(
     loop {
         tokio::select! {
             packet = stream.next() => { // packet is Option<Result<Box>>
-                if let Some(Ok(data)) = packet {
-                    if let Ok(Some(alive_host)) = process_packet(&data) {
+                if let Some(Ok(data)) = packet && let Ok(Some(alive_host)) = process_packet(&data) {
                         tx_msg.send(alive_host).await.unwrap()
-                    }
                 }
             },
             ctl = rx_ctl.recv() => {

--- a/rust/src/alive_test/tcp_ping.rs
+++ b/rust/src/alive_test/tcp_ping.rs
@@ -22,24 +22,7 @@ use crate::nasl::raw_ip_utils::raw_ip_utils::{
 pub const FILTER_PORT: u16 = 9910;
 pub const TCP_LENGTH: usize = 20;
 
-#[derive(PartialEq, Eq)]
-pub enum TcpFlags {
-    Empty = 0x00,
-    ThSyn = 0x02,
-    ThAck = 0x10,
-}
-
-impl From<u16> for TcpFlags {
-    fn from(value: u16) -> Self {
-        match value {
-            0x02 => Self::ThSyn,
-            0x10 => Self::ThAck,
-            _ => Self::Empty,
-        }
-    }
-}
-
-pub fn tcp_ping(dport: u16, tcp_flag: u16) -> Vec<u8> {
+pub fn tcp_ping(dport: u16, tcp_flag: u8) -> Vec<u8> {
     let mut tcp_buf = vec![0u8; TCP_LENGTH];
     // known buffer size.
     let mut tcp = MutableTcpPacket::new(&mut tcp_buf).unwrap();
@@ -90,7 +73,7 @@ fn forge_ipv4_packet_for_tcp(
 pub fn forge_tcp_ping_ipv4(
     dst: Ipv4Addr,
     dport: &u16,
-    tcp_flag: u16,
+    tcp_flag: u8,
 ) -> Result<Ipv4Packet<'static>, AliveTestError> {
     let mut tcp_buf = tcp_ping(*dport, tcp_flag);
     forge_ipv4_packet_for_tcp(&mut tcp_buf, dst)
@@ -127,7 +110,7 @@ fn forge_ipv6_packet_for_tcp(
 pub fn forge_tcp_ping_ipv6(
     dst: Ipv6Addr,
     dport: &u16,
-    tcp_flag: u16,
+    tcp_flag: u8,
 ) -> Result<Ipv6Packet<'static>, AliveTestError> {
     let mut tcp_buf = tcp_ping(*dport, tcp_flag);
     forge_ipv6_packet_for_tcp(&mut tcp_buf, dst)

--- a/rust/src/feed/oid/mod.rs
+++ b/rust/src/feed/oid/mod.rs
@@ -41,10 +41,10 @@ where
     }
 
     fn script_oid(stmt: &Statement) -> Option<String> {
-        if let Statement::ExprStmt(Expr::Atom(Atom::FnCall(call))) = stmt {
-            if call.fn_name.to_str() == "script_oid" {
-                return call.args.items.first().map(|x| x.to_string());
-            }
+        if let Statement::ExprStmt(Expr::Atom(Atom::FnCall(call))) = stmt
+            && call.fn_name.to_str() == "script_oid"
+        {
+            return call.args.items.first().map(|x| x.to_string());
         }
         None
     }

--- a/rust/src/models/advisories.rs
+++ b/rust/src/models/advisories.rs
@@ -134,7 +134,7 @@ impl<'a> Iterator for ProductsAdvisoriesIterator<'a> {
 }
 
 impl ProductsAdvisories {
-    pub fn iter(&self) -> ProductsAdvisoriesIterator {
+    pub fn iter(&self) -> ProductsAdvisoriesIterator<'_> {
         ProductsAdvisoriesIterator {
             products_advisories: self,
             index: 0,

--- a/rust/src/models/resources/check.rs
+++ b/rust/src/models/resources/check.rs
@@ -37,15 +37,15 @@ impl Checker {
     pub fn breakaways(&self) -> Vec<ObservableResources> {
         let mut results = Vec::with_capacity(2);
         let available = super::available();
-        if let Some(free) = self.memory {
-            if available.memory < free {
-                results.push(ObservableResources::Memory);
-            }
+        if let Some(free) = self.memory
+            && available.memory < free
+        {
+            results.push(ObservableResources::Memory);
         }
-        if let Some(workload) = self.cpu {
-            if available.cpu > workload {
-                results.push(ObservableResources::CPU);
-            }
+        if let Some(workload) = self.cpu
+            && available.cpu > workload
+        {
+            results.push(ObservableResources::CPU);
         }
 
         results

--- a/rust/src/models/resources/mod.rs
+++ b/rust/src/models/resources/mod.rs
@@ -15,7 +15,7 @@ pub struct AvailableResources {
 /// Returns available resources
 pub fn available() -> AvailableResources {
     let system = sysinfo::System::new_all();
-    let cpu = system.global_cpu_info().cpu_usage();
+    let cpu = system.global_cpu_usage();
     let memory = system.available_memory();
     AvailableResources { memory, cpu }
 }

--- a/rust/src/nasl/builtin/cryptographic/rc4.rs
+++ b/rust/src/nasl/builtin/cryptographic/rc4.rs
@@ -20,7 +20,7 @@ pub struct CipherHandler {
 
 fn lock_handlers(
     handlers: &Arc<Mutex<Vec<CipherHandler>>>,
-) -> Result<MutexGuard<Vec<CipherHandler>>, FnError> {
+) -> Result<MutexGuard<'_, Vec<CipherHandler>>, FnError> {
     // we actually need to panic as a lock error is fatal
     // alternatively we need to add a poison error on FnError
     Ok(Arc::as_ref(handlers).lock().unwrap())
@@ -123,12 +123,12 @@ impl CipherHandlers {
 
         let mut handlers = lock_handlers(&self.cipher_handlers)?;
 
-        if hd > 0 {
-            if let Some((_i, h)) = handlers.iter_mut().enumerate().find(|(_i, h)| h.id == hd) {
-                let d = h.handler.encode(data);
-                return Ok(NaslValue::Data(d));
-            };
-        };
+        if hd > 0
+            && let Some((_i, h)) = handlers.iter_mut().enumerate().find(|(_i, h)| h.id == hd)
+        {
+            let d = h.handler.encode(data);
+            return Ok(NaslValue::Data(d));
+        }
 
         let key = match get_key(register) {
             Ok(k) if !k.is_empty() => k.to_vec(),

--- a/rust/src/nasl/builtin/host/mod.rs
+++ b/rust/src/nasl/builtin/host/mod.rs
@@ -102,10 +102,10 @@ pub fn get_host_name(_register: &Register, context: &ScanCtx) -> Result<NaslValu
 #[nasl_function(named(hostname))]
 pub fn get_host_name_source(context: &ScanCtx, hostname: Hostname) -> String {
     let vh = context.target().vhosts();
-    if !vh.is_empty() {
-        if let Some(vhost) = vh.iter().find(|vhost| vhost.hostname() == hostname.0) {
-            return vhost.source().to_string();
-        };
+    if !vh.is_empty()
+        && let Some(vhost) = vh.iter().find(|vhost| vhost.hostname() == hostname.0)
+    {
+        return vhost.source().to_string();
     }
     context.target().original_target_str().to_string()
 }

--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -73,7 +73,7 @@ pub struct NaslHttp2 {
 
 async fn lock_handles(
     handles: &Arc<Mutex<Vec<Handle>>>,
-) -> Result<MutexGuard<Vec<Handle>>, FnError> {
+) -> Result<MutexGuard<'_, Vec<Handle>>, FnError> {
     // we actually need to panic as a lock error is fatal
     // alternatively we need to add a poison error on FnError
     Ok(Arc::as_ref(handles).lock().await)

--- a/rust/src/nasl/builtin/isotime/mod.rs
+++ b/rust/src/nasl/builtin/isotime/mod.rs
@@ -29,14 +29,12 @@ fn parse_readable_time(time: &str) -> Option<NaiveDateTime> {
     if let Ok(time) = NaiveDateTime::parse_from_str(time, "%Y-%m-%d %H:%M") {
         return Some(time);
     }
-    if let Some((date, hours)) = time.split_once(" ") {
-        if let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") {
-            if let Ok(hours) = hours.parse::<u32>() {
-                if let Some(time) = date.and_hms_opt(hours, 0, 0) {
-                    return Some(time);
-                }
-            }
-        }
+    if let Some((date, hours)) = time.split_once(" ")
+        && let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        && let Ok(hours) = hours.parse::<u32>()
+        && let Some(time) = date.and_hms_opt(hours, 0, 0)
+    {
+        return Some(time);
     }
     if let Ok(date) = NaiveDate::parse_from_str(time, "%Y-%m-%d") {
         // Cannot fail, since we add no time to the date

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -87,10 +87,10 @@ impl Interval {
     /// Check the time since the last tick and wait if necessary.
     pub fn tick(&self) {
         let mut last_tick = self.last_tick.lock().unwrap();
-        if let Ok(since) = SystemTime::now().duration_since(*last_tick) {
-            if since < self.interval {
-                sleep(self.interval - since);
-            }
+        if let Ok(since) = SystemTime::now().duration_since(*last_tick)
+            && since < self.interval
+        {
+            sleep(self.interval - since);
         }
         *last_tick = SystemTime::now();
     }

--- a/rust/src/nasl/builtin/preferences/mod.rs
+++ b/rust/src/nasl/builtin/preferences/mod.rs
@@ -29,16 +29,15 @@ fn script_get_preference(
 
     // A parameter name is given. Search for the param in NVT metadata to get the ID.
     // Then, search with the ID in the scan config, otherwise return the default value from the NVT metadata.
-    if let Some(pref_name) = name {
-        if let Some(pref) = config
+    if let Some(pref_name) = name
+        && let Some(pref) = config
             .nvt()
             .clone()
             .and_then(|nvt| nvt.preferences.into_iter().find(|p| p.name == pref_name))
-        {
-            return register
-                .script_param(pref.id().unwrap() as usize)
-                .or_else(|| Some(NaslValue::String(pref.default().to_string())));
-        }
+    {
+        return register
+            .script_param(pref.id().unwrap() as usize)
+            .or_else(|| Some(NaslValue::String(pref.default().to_string())));
     }
     None
 }

--- a/rust/src/nasl/builtin/raw_ip/denial.rs
+++ b/rust/src/nasl/builtin/raw_ip/denial.rs
@@ -29,13 +29,13 @@ fn start_denial(context: &ScanCtx, script_ctx: &mut ScriptCtx) -> Result<NaslVal
     let retry = get_timeout(context);
 
     let port = context.get_random_open_tcp_port().unwrap_or_default();
-    if port > 0 {
-        if let Ok(_soc) = make_tcp_socket(context.target().ip_addr(), port, retry) {
-            script_ctx.denial_port = Some(port);
+    if port > 0
+        && let Ok(_soc) = make_tcp_socket(context.target().ip_addr(), port, retry)
+    {
+        script_ctx.denial_port = Some(port);
 
-            return Ok(NaslValue::Null);
-        }
-    };
+        return Ok(NaslValue::Null);
+    }
 
     script_ctx.alive = nasl_tcp_ping_shared(context, None)? > NaslValue::Number(0);
 
@@ -85,10 +85,9 @@ async fn end_denial(
     )
     .run_alive_test()
     .await
+        && !alive_test_result.is_empty()
     {
-        if !alive_test_result.is_empty() {
-            return Ok(NaslValue::Number(1));
-        }
+        return Ok(NaslValue::Number(1));
     }
 
     Ok(NaslValue::Null)

--- a/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
@@ -39,7 +39,6 @@ use pnet::packet::{
     udp::{MutableUdpPacket, UdpPacket},
 };
 
-use pnet_macros_support::types::u9be;
 use socket2::{Domain, Protocol, Socket};
 use tracing::debug;
 
@@ -88,7 +87,7 @@ const DEFAULT_IPV4_HEADER_LENGTH_32BIT_INCREMENTS: u8 = 5;
 const DEFAULT_TCP_DATA_OFFSET_32BIT_INCREMENTS: u8 = 5;
 /// Default ttl value is inherit from NASL C
 const DEFAULT_TTL: u8 = 0x40;
-const TH_SYN: u16 = 0x02;
+const TH_SYN: u8 = 0x02;
 
 #[derive(Default)]
 struct PacketPayload {
@@ -616,7 +615,7 @@ fn forge_tcp(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_offset: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_win: Option<u16>,
     th_urp: Option<u16>,
 ) -> Vec<u8> {
@@ -635,7 +634,7 @@ fn forge_tcp(
     tcp_seg.set_acknowledgement(th_ack.unwrap_or(0_u32));
     tcp_seg.set_reserved(th_x2.unwrap_or(0_u8));
     tcp_seg.set_data_offset(th_offset.unwrap_or(5_u8));
-    tcp_seg.set_flags(th_flags.unwrap_or(0_u16));
+    tcp_seg.set_flags(th_flags.unwrap_or(0_u8));
     tcp_seg.set_window(th_win.unwrap_or(0_u16));
     tcp_seg.set_urgent_ptr(th_urp.unwrap_or(0_u16));
 
@@ -684,7 +683,7 @@ fn forge_tcp_packet(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_off: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_win: Option<u16>,
     th_urp: Option<u16>,
     th_sum: Option<u16>,
@@ -904,7 +903,7 @@ fn set_elements_tcp<'a>(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_off: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_urp: Option<u16>,
     th_win: Option<u16>,
     new_buf: &'a mut Vec<u8>,
@@ -1013,7 +1012,7 @@ fn set_tcp_elements(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_off: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_urp: Option<u16>,
     th_sum: Option<u16>,
     th_win: Option<u16>,
@@ -1246,7 +1245,7 @@ fn display_opts(pkt: &TcpPacket) {
 fn format_flags(pkt: &TcpPacket) -> String {
     let flags = pkt.get_flags();
     let mut flag_strs = vec![];
-    let mut check_flag = |flag: u9be, name: &str| {
+    let mut check_flag = |flag: u8, name: &str| {
         if flags & flag == flag {
             flag_strs.push(name.to_owned());
         }
@@ -2467,7 +2466,7 @@ fn forge_tcp_v6_packet(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_off: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_win: Option<u16>,
     th_urp: Option<u16>,
     th_sum: Option<u16>,
@@ -2534,7 +2533,7 @@ fn set_tcp_v6_elements(
     th_ack: Option<u32>,
     th_x2: Option<u8>,
     th_off: Option<u8>,
-    th_flags: Option<u16>,
+    th_flags: Option<u8>,
     th_urp: Option<u16>,
     th_sum: Option<u16>,
     th_win: Option<u16>,

--- a/rust/src/nasl/builtin/ssh/libssh/session.rs
+++ b/rust/src/nasl/builtin/ssh/libssh/session.rs
@@ -105,10 +105,10 @@ impl SshSession {
     }
 
     pub async fn close(&mut self) {
-        if let Some(channel) = &mut self.channel().await {
-            if let Err(e) = channel.close() {
-                debug!("Encountered error while closing channel: {}", e);
-            }
+        if let Some(channel) = &mut self.channel().await
+            && let Err(e) = channel.close()
+        {
+            debug!("Encountered error while closing channel: {}", e);
         }
         self.channel = None;
     }

--- a/rust/src/nasl/builtin/ssh/sessions.rs
+++ b/rust/src/nasl/builtin/ssh/sessions.rs
@@ -23,7 +23,7 @@ pub struct SshSessions {
 }
 
 impl SshSessions {
-    pub async fn get_by_id(&self, id: SessionId) -> Result<BorrowedSession> {
+    pub async fn get_by_id(&self, id: SessionId) -> Result<BorrowedSession<'_>> {
         Ok(self
             .sessions
             .get(&id)

--- a/rust/src/nasl/interpreter/tests/description.rs
+++ b/rust/src/nasl/interpreter/tests/description.rs
@@ -2,26 +2,11 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use crate::nasl::syntax::{LoadError, Loader};
 use crate::storage::Retriever;
 use crate::storage::inmemory::InMemoryStorage;
 use crate::storage::items::nvt::{
     ACT::Denial, FileName, Nvt, NvtPreference, NvtRef, PreferenceType::Password, TagKey,
 };
-
-#[derive(Default)]
-pub struct NoOpLoader {}
-
-/// Is a no operation loader for test purposes.
-impl Loader for NoOpLoader {
-    fn load(&self, _: &str) -> Result<String, LoadError> {
-        Ok(String::default())
-    }
-
-    fn root_path(&self) -> Result<std::string::String, crate::nasl::syntax::LoadError> {
-        Ok(String::default())
-    }
-}
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/rust/src/nasl/syntax/metadata.rs
+++ b/rust/src/nasl/syntax/metadata.rs
@@ -34,10 +34,10 @@ impl Parse for DescriptionBlock {
 }
 
 fn check_condition(condition: &Expr) -> bool {
-    if let Expr::Atom(Atom::Ident(ident)) = condition {
-        if ident.to_string() == "description" {
-            return true;
-        }
+    if let Expr::Atom(Atom::Ident(ident)) = condition
+        && ident.to_string() == "description"
+    {
+        return true;
     }
     false
 }

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -281,7 +281,7 @@ where
 
     /// Runs the given lines of code and returns the list of results
     /// along with the `ScanCtx` used for evaluating them.
-    pub fn results_and_context(&self) -> (Vec<NaslResult>, ScanCtx) {
+    pub fn results_and_context(&self) -> (Vec<NaslResult>, ScanCtx<'_>) {
         futures::executor::block_on(async {
             let context = self.context();
             (
@@ -338,7 +338,7 @@ where
         })
     }
 
-    fn context(&self) -> ScanCtx {
+    fn context(&self) -> ScanCtx<'_> {
         let target = Target::do_not_resolve_hostname(&self.target);
         ScanCtxBuilder {
             storage: &self.storage,

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -333,10 +333,11 @@ impl<'a> ScanCtx<'a> {
         loop {
             i += 1;
             let result = self.executor.exec(name, self, register, script_ctx).await;
-            if let Some(Err(ref e)) = result {
-                if e.retryable() && i < NUM_RETRIES_ON_RETRYABLE_ERROR {
-                    continue;
-                }
+            if let Some(Err(ref e)) = result
+                && e.retryable()
+                && i < NUM_RETRIES_ON_RETRYABLE_ERROR
+            {
+                continue;
             }
             return result;
         }

--- a/rust/src/notus/loader/fs.rs
+++ b/rust/src/notus/loader/fs.rs
@@ -97,14 +97,12 @@ where
         let mut available_os = vec![];
         for dir_entry in paths.flatten() {
             let file = dir_entry.path();
-            if file.is_file() {
-                if let Some(p) = file.file_name() {
-                    if p.to_string_lossy().ends_with(".notus") {
-                        if let Some(stem) = file.file_stem() {
-                            available_os.push(stem.to_string_lossy().to_string());
-                        }
-                    }
-                }
+            if file.is_file()
+                && let Some(p) = file.file_name()
+                && p.to_string_lossy().ends_with(".notus")
+                && let Some(stem) = file.file_stem()
+            {
+                available_os.push(stem.to_string_lossy().to_string());
             }
         }
         Ok(available_os)

--- a/rust/src/notus/loader/hashsum.rs
+++ b/rust/src/notus/loader/hashsum.rs
@@ -66,15 +66,15 @@ impl ProductLoader for HashsumProductLoader {
     }
 
     fn has_changed(&self, os: &str, stamp: &FeedStamp) -> bool {
-        if let Ok(mut loader) = HashSumNameLoader::sha256(&self.loader) {
-            if let Some(Ok(file_item)) = loader.find(|entry| {
+        if let Ok(mut loader) = HashSumNameLoader::sha256(&self.loader)
+            && let Some(Ok(file_item)) = loader.find(|entry| {
                 if let Ok(item) = entry {
                     return item.get_filename() == format!("{os}.notus");
                 }
                 false
-            }) {
-                return *stamp != FeedStamp::Hashsum(file_item.get_hashsum());
-            }
+            })
+        {
+            return *stamp != FeedStamp::Hashsum(file_item.get_hashsum());
         }
         false
     }

--- a/rust/src/openvas/openvas.rs
+++ b/rust/src/openvas/openvas.rs
@@ -397,12 +397,12 @@ impl ScanResultFetcher for Scanner {
 
                     // Read openvas scanner exit code and if failed, reset the status to Failed.
                     let exit_status = scan.wait().map_err(OpenvasError::CmdError)?;
-                    if let Some(code) = exit_status.code() {
-                        if code != 0 {
-                            scan_res.status.status = Phase::Failed;
-                            scan_res.status.start_time = scan_res.status.end_time;
-                            scan_res.status.host_info = None;
-                        }
+                    if let Some(code) = exit_status.code()
+                        && code != 0
+                    {
+                        scan_res.status.status = Phase::Failed;
+                        scan_res.status.start_time = scan_res.status.end_time;
+                        scan_res.status.host_info = None;
                     }
 
                     redis_help

--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -256,12 +256,11 @@ where
     async fn prepare_boreas_alive_test(&mut self) -> RedisStorageResult<()> {
         // Check "test_alive_hosts_only" configuration from openvas.conf
         // If set no, boreas is disabled and alive_host.nasl is used instead.
-        if let Ok(config) = cmd::read_openvas_config() {
-            if let Some(setting) = config.get("default", "test_alive_hosts_only") {
-                if setting == "no" {
-                    return Ok(());
-                }
-            }
+        if let Ok(config) = cmd::read_openvas_config()
+            && let Some(setting) = config.get("default", "test_alive_hosts_only")
+            && setting == "no"
+        {
+            return Ok(());
         }
 
         let methods = self.scan_config.target.alive_test_methods.clone();
@@ -566,11 +565,12 @@ mod tests {
         models::{
             AliveTestMethods, Credential, CredentialType, Port, PortRange, Protocol, Scan, Service,
         },
+        openvas::openvas_redis::test::FakeRedis,
         scanner::preferences::preference::ScanPrefs,
     };
 
     use super::PreferenceHandler;
-    use crate::openvas::openvas_redis::{FakeRedis, KbAccess};
+    use crate::openvas::openvas_redis::KbAccess;
 
     #[tokio::test]
     async fn test_prefs() {

--- a/rust/src/openvas/result_collector.rs
+++ b/rust/src/openvas/result_collector.rs
@@ -211,10 +211,10 @@ where
     }
 
     pub async fn collect_scan_status(&mut self, scan_id: String) -> RedisStorageResult<()> {
-        if let Ok(scan_status) = self.redis_connector.scan_status(scan_id) {
-            if let Ok(mut results) = Arc::as_ref(&self.results).lock() {
-                results.scan_status = scan_status.to_string();
-            }
+        if let Ok(scan_status) = self.redis_connector.scan_status(scan_id)
+            && let Ok(mut results) = Arc::as_ref(&self.results).lock()
+        {
+            results.scan_status = scan_status.to_string();
         }
         Ok(())
     }
@@ -223,8 +223,10 @@ where
 #[cfg(test)]
 mod tests {
 
-    use crate::models::{self, Protocol, Result, ResultType};
-    use crate::openvas::openvas_redis::FakeRedis;
+    use crate::{
+        models::{self, Protocol, Result, ResultType},
+        openvas::openvas_redis::test::FakeRedis,
+    };
     use std::collections::HashMap;
 
     use super::ResultHelper;

--- a/rust/src/openvasd/config.rs
+++ b/rust/src/openvasd/config.rs
@@ -680,10 +680,10 @@ impl Config {
         if let Some(mode) = cmds.get_one::<Mode>("mode") {
             config.mode = mode.clone();
         }
-        if let Some(key) = cmds.get_one::<String>("storage_key") {
-            if !key.is_empty() {
-                config.storage.fs.key = Some(key.clone());
-            }
+        if let Some(key) = cmds.get_one::<String>("storage_key")
+            && !key.is_empty()
+        {
+            config.storage.fs.key = Some(key.clone());
         }
 
         let scan_prefs: HashMap<String, ScanPrefValue> = PREFERENCES

--- a/rust/src/openvasd/response.rs
+++ b/rust/src/openvasd/response.rs
@@ -215,10 +215,10 @@ impl Response {
             if send(SendState::Start) {
                 return;
             }
-            if let Some(v) = value.next() {
-                if send(SendState::Bytes(true, v)) {
-                    return;
-                };
+            if let Some(v) = value.next()
+                && send(SendState::Bytes(true, v))
+            {
+                return;
             }
             if value.any(|v| send(SendState::Bytes(false, v))) {
                 return;

--- a/rust/src/openvasd/scheduling.rs
+++ b/rust/src/openvasd/scheduling.rs
@@ -157,10 +157,10 @@ where
         }
 
         let mut queued = self.queued.write().await;
-        if let Some(max_queuing) = self.config().max_queued_scans {
-            if queued.len() == max_queuing {
-                return Err(Error::QueueFull);
-            }
+        if let Some(max_queuing) = self.config().max_queued_scans
+            && queued.len() == max_queuing
+        {
+            return Err(Error::QueueFull);
         }
         if queued.iter().any(|x| x == id) {
             return Err(Error::ScanAlreadyQueued);

--- a/rust/src/osp/connection.rs
+++ b/rust/src/osp/connection.rs
@@ -26,10 +26,10 @@ pub fn send_command<T: AsRef<Path>>(
 ) -> Result<Response, Error> {
     let mut socket = UnixStream::connect(address)?;
     let cmd = cmd.try_to_xml()?;
-    if let Some(rtimeout) = r_timeout {
-        if !rtimeout.is_zero() {
-            socket.set_read_timeout(Some(rtimeout))?;
-        }
+    if let Some(rtimeout) = r_timeout
+        && !rtimeout.is_zero()
+    {
+        socket.set_read_timeout(Some(rtimeout))?;
     }
     socket.write_all(&cmd)?;
     let reader: BufReader<_> = BufReader::new(socket);

--- a/rust/src/osp/response.rs
+++ b/rust/src/osp/response.rs
@@ -789,9 +789,7 @@ mod tests {
                    port="443/tcp"
                    test_id=""
                    name="Path disclosure vulnerability"
-                   type="Log Message">
-             bla
-           </result>
+                   type="Log Message">bla</result>
          </results>
          <progress>
             <host name="127.0.0.1">45</host>

--- a/rust/src/scannerctl/osp/start_scan.rs
+++ b/rust/src/scannerctl/osp/start_scan.rs
@@ -297,11 +297,11 @@ impl<'de> Deserialize<'de> for Target {
                         }
                         "alive_test" => {
                             if let Ok(at) = map.next_value::<String>() {
-                                if let Ok(at) = at.parse::<u8>() {
-                                    if let Ok(at) = models::AliveTestMethods::try_from(at) {
-                                        result.alive_test_methods = Some(vec![at]);
-                                        continue;
-                                    }
+                                if let Ok(at) = at.parse::<u8>()
+                                    && let Ok(at) = models::AliveTestMethods::try_from(at)
+                                {
+                                    result.alive_test_methods = Some(vec![at]);
+                                    continue;
                                 }
                                 return Err(de::Error::custom(format!(
                                     "{at} is not a valid number. It must be a number of 1, 2, 4, 8 or 16."

--- a/rust/src/scannerctl/syntax/check.rs
+++ b/rust/src/scannerctl/syntax/check.rs
@@ -33,11 +33,11 @@ fn print_results(path: &Path, verbose: bool) -> Result<usize, CliError> {
 
     let results = Code::load(&NonUtf8Loader, path)?.parse();
     num_errors += results.num_errors();
-    if let Ok(stmts) = results.emit_errors() {
-        if verbose {
-            for stmt in stmts.stmts().iter() {
-                print_stmt(stmt);
-            }
+    if let Ok(stmts) = results.emit_errors()
+        && verbose
+    {
+        for stmt in stmts.stmts().iter() {
+            print_stmt(stmt);
         }
     }
     Ok(num_errors)

--- a/rust/src/storage/infisto/base.rs
+++ b/rust/src/storage/infisto/base.rs
@@ -92,7 +92,7 @@ pub trait IndexedByteStorage {
         T: TryFrom<Vec<u8>>,
         <T as TryFrom<Vec<u8>>>::Error: std::fmt::Debug,
     {
-        let data = self.by_indices(key, &[index.clone()])?;
+        let data = self.by_indices(key, std::slice::from_ref(index))?;
         Ok(data.into_iter().next())
     }
 
@@ -370,10 +370,10 @@ impl CachedIndexFileStorer {
     }
     fn find_index(&self, key: &str) -> Option<(usize, &Vec<Index>)> {
         for i in 0..self.cache.len() {
-            if let Some((k, v)) = &self.cache[i] {
-                if k == key {
-                    return Some((i, v));
-                }
+            if let Some((k, v)) = &self.cache[i]
+                && k == key
+            {
+                return Some((i, v));
             }
         }
         None
@@ -450,10 +450,10 @@ impl IndexedByteStorage for CachedIndexFileStorer {
     fn remove(&mut self, key: &str) -> Result<(), Error> {
         self.base.clean(key)?;
         for i in 0..self.cache.len() {
-            if let Some((k, _)) = &self.cache[i] {
-                if k == key {
-                    self.cache[i] = None;
-                }
+            if let Some((k, _)) = &self.cache[i]
+                && k == key
+            {
+                self.cache[i] = None;
             }
         }
         Ok(())

--- a/rust/src/storage/time.rs
+++ b/rust/src/storage/time.rs
@@ -13,7 +13,7 @@ pub trait AsUnixTimeStamp {
 use time::{OffsetDateTime, format_description};
 
 // the function panics because the support formats are hardcoded and therefore the user cannot change anything
-fn parse_or_panic(input: &str) -> Vec<time::format_description::FormatItem> {
+fn parse_or_panic(input: &str) -> Vec<time::format_description::FormatItem<'_>> {
     match format_description::parse(input) {
         Ok(x) => x,
         Err(e) => panic!("expected {input} to be parsable: {e:?}"),


### PR DESCRIPTION
This PR satisfies the new cargo clippy version and updates the dependencies to match their newest versions
SC-1354

The following dependencies are still not up to date:
|package|current|latest|
|-|-|-|
|[generic-array](https://deps.rs/crate/generic-array/0.14.7)|^0.14|1.2.0|
|[rand](https://deps.rs/crate/rand/0.8.5)|^0.8.5|0.9.2|
|[redis](https://deps.rs/crate/redis/0.22.3)|^0.22.3|0.32.5|
|[russh](https://deps.rs/crate/russh/0.46.0)|^0.46.0|0.54.1|
|[russh-keys](https://deps.rs/crate/russh-keys/0.46.0)|^0.46.0|0.49.2|

These contain breaking changes with more than minimal changes and will be handled in different PRs