### PR TITLE
Fix: set the correct default value for plugins_timeout

### DIFF
--- a/rust/src/scanner/preferences/preference.rs
+++ b/rust/src/scanner/preferences/preference.rs
@@ -88,7 +88,7 @@ pub const PREFERENCES: [ScanPreferenceInformation; 23] = [
     ScanPreferenceInformation {
         id: "plugins_timeout",
         name: "Plugins Timeout",
-        default: PreferenceValue::Int(5),
+        default: PreferenceValue::Int(320),
         description: "This is the maximum lifetime, in seconds of a plugin. It may happen \
         that some plugins are slow because of the way they are written or \
         the way the remote server behaves. This option allows you to make \


### PR DESCRIPTION
The wrong default value caused some VTs to timeout after 5 seconds. This prevented some VTs from executing, with a longer runtime. E.g. the SSH authentication timeouted for some targets.