### PR TITLE
Use std:.hint::black_box instead of criterion

### DIFF
--- a/rust/benches/infisto_comparison.rs
+++ b/rust/benches/infisto_comparison.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::Rng;
 use rand::distributions::Alphanumeric;
 use scannerlib::storage::infisto::{

--- a/rust/benches/interpreter.rs
+++ b/rust/benches/interpreter.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use futures::StreamExt;
 use scannerlib::nasl::utils::scan_ctx::Target;
 use scannerlib::nasl::{Code, NoOpLoader, nasl_std_functions};

--- a/rust/benches/nasl_syntax_parse.rs
+++ b/rust/benches/nasl_syntax_parse.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use scannerlib::nasl::Code;
 
 pub fn simple_parse_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
Will fix incoming deprecation warnings when `Cargo.lock` is updated