### PR TITLE
Move CI to github runner

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
         - uses: greenbone/actions/pr-conventional-commit-labeler@main
           with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [workflow_call]
 
 jobs:
   C:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     container:
       image: registry.community.greenbone.net/community/gvm-libs:stable
     steps:
@@ -17,7 +17,7 @@ jobs:
           cmake -Bbuild -DCMAKE_C_COMPILER=/usr/share/clang/scan-build-19/libexec/ccc-analyzer
           cmake --build build
   Rust:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -40,7 +40,7 @@ jobs:
   # this prevents us from having to pass down all labels, event_name, etc
   # to init.yml
   adapt_release:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     outputs:
       kind: ${{ steps.kind.outputs.kind}}
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - name: 'Dependency Review'
         uses: greenbone/actions/dependency-review@v3

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -10,7 +10,7 @@ jobs:
   # Tests that gvm-libs, openvas-smb and openvas dependencies work together and
   # that openvas is buildable and integrates openvas-smb when available
   distributed-monolith-railguard:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +23,7 @@ jobs:
       - run: docker run --rm test ldd /usr/local/sbin/openvas | grep libopenvas_wmiclient
       - run: docker rmi test || true
   build-rs:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/compile-x86_64
@@ -34,7 +34,7 @@ jobs:
           path: assets/*
           retention-days: 1
   build-image:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - run: |
@@ -123,7 +123,7 @@ jobs:
       #     path: /tmp/openvas.tar
       #     key: openvas-cache-${{ github.run_id }}
   tests:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     needs: [build-rs]
     services:
       redis:

--- a/.github/workflows/helm-release-on-tag.yml
+++ b/.github/workflows/helm-release-on-tag.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-helm-chart:
     name: Release helm chart
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/init.yaml
+++ b/.github/workflows/init.yaml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   init:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     outputs:
       is_latest_tag: ${{ steps.version.outputs.is_latest_tag }}
       is_version_tag: ${{ steps.version.outputs.is_version_tag }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,14 +4,14 @@ on: [workflow_call]
 
 jobs:
   C:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - name: Check out openvas-scanner
         uses: actions/checkout@v5
       - name: Formatting
         run: sh .github/check-c-formatting.sh ${{ github.base_ref }}
   Rust:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -22,7 +22,7 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo clippy --all-targets --features experimental -- -D warnings
   Rust-Typos:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -32,7 +32,7 @@ jobs:
       - run: cargo install typos-cli || true
       - run: typos
   Rust-Audit:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust
@@ -41,7 +41,7 @@ jobs:
       - run: cargo install cargo-audit || true
       - run: cargo audit
   License-Headers:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - name: Check out openvas-scanner
         uses: actions/checkout@v5

--- a/.github/workflows/push-container-oldstable.yml
+++ b/.github/workflows/push-container-oldstable.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   debian_oldstable:
     name: ghcr:debian:oldstable
-    runs-on: "self-hosted-generic"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/push-container-testing.yml
+++ b/.github/workflows/push-container-testing.yml
@@ -19,7 +19,7 @@ jobs:
   # TODO: do we need to push or is building enough?
   debian_testing:
     name: ghcr:debian:testing
-    runs-on: "self-hosted-generic"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/push-container.yml
+++ b/.github/workflows/push-container.yml
@@ -82,7 +82,7 @@ jobs:
   
   debian_stable:
     name: ghcr:debian:stable
-    runs-on: "self-hosted-generic"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/push-helm-chart.yml
+++ b/.github/workflows/push-helm-chart.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   helm:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: greenbone/actions/helm-build-push@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ on:
 jobs:
   release:
     name: release
-    runs-on: "self-hosted-generic"
+    runs-on: ubuntu-latest
     env:
       RELEASE_KIND: ${{inputs.release_kind}}
       RELEASE_REF: ${{inputs.release_ref}}

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
 jobs:
   SBOM-upload:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [workflow_call]
 
 jobs:
   C:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     container:
       image: registry.community.greenbone.net/community/gvm-libs:stable
     steps:
@@ -17,7 +17,7 @@ jobs:
           cmake -Bbuild -DCMAKE_BUILD_TYPE=Release
           CTEST_OUTPUT_ON_FAILURE=1 cmake --build build -- tests test
   Rust:
-    runs-on: self-hosted-generic
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: rust


### PR DESCRIPTION
Moves all checks that previously ran on `self-hosted-generic` to `ubuntu-latest`. For now, this leaves `self-hosted-arm64` as it is.