### PR TITLE
Fix: GET scans/preferences.

### DIFF
--- a/rust/src/scanner/preferences/preference.rs
+++ b/rust/src/scanner/preferences/preference.rs
@@ -258,9 +258,7 @@ impl Default for ScanPrefValue {
 }
 
 #[derive(Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct FullScanPreferences {
-    scan_preferences: Vec<FullScanPreference>,
-}
+pub struct FullScanPreferences(Vec<FullScanPreference>);
 
 /// Configuration preference information for a scan. The type can be derived from the default value.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -309,23 +307,23 @@ impl FullScanPreferences {
         for pref in PREFERENCES.iter() {
             scan_preferences.push(FullScanPreference::from(pref));
         }
-        Self { scan_preferences }
+        Self(scan_preferences)
     }
 
     /// Override the default scanner preferences with the ones from the config file or command line.
     pub fn override_default_preferences(&mut self, preferences: HashMap<String, ScanPrefValue>) {
         for (pref_id, pref_val) in preferences.into_iter() {
-            if let Some(pref) = self.scan_preferences.iter_mut().find(|p| p.id == *pref_id) {
+            if let Some(pref) = self.0.iter_mut().find(|p| p.id == *pref_id) {
                 pref.default = pref_val.clone();
             }
         }
     }
 
     pub fn set_scan_with_preferences(&self, scan: &mut Scan) {
-        let mut config_prefs_copy = self.scan_preferences.clone();
+        let mut config_prefs_copy = self.0.clone();
         let scan_prefs = scan.scan_preferences.clone();
         let mut pref_index_to_remove = vec![];
-        for (i, cp) in self.scan_preferences.iter().enumerate() {
+        for (i, cp) in self.0.iter().enumerate() {
             for sp in scan_prefs.iter() {
                 if cp.id == sp.id {
                     pref_index_to_remove.push(i);


### PR DESCRIPTION
return the list without a object key

**What**:
Fix: GET scans/preferences. Return the list without a object key
SC-1362
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Differs from the API
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
