### PR TITLE
Add cargo ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
       github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "rust"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo:
         patterns:
           - "*"


### PR DESCRIPTION
Since a few weeks dependabot officially supports cargo. To have a nice automatic view on dependency update, this PR adds the cargo ecosystem to the dependabot file.