### PR TITLE
Add: support for handling AppStream modules for RPM (notus)

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/product.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/product.rs
@@ -51,16 +51,28 @@ pub enum FixedPackage {
     ByFullName {
         full_name: String,
         specifier: Specifier,
+        module: Option<Module>,
     },
     /// Contains a version and a specifier
     ByNameAndFullVersion {
         name: String,
         full_version: String,
         specifier: Specifier,
+        module: Option<Module>,
     },
 
     /// Contains a version Range
-    ByRange { name: String, range: Range },
+    ByRange {
+        name: String,
+        range: Range,
+        module: Option<Module>,
+    },
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Module {
+    pub name: String,
+    pub stream: String,
 }
 
 /// A specifier can be one of: >, <, >=, <=, =

--- a/rust/src/notus/tests.rs
+++ b/rust/src/notus/tests.rs
@@ -97,6 +97,6 @@ fn test_err_product_parse_error() {
 
     let os = "debian_10_product_parse_err";
     assert!(
-        matches!(notus.scan(os, &packages).expect_err("Should fail"), Error::VulnerabilityTestParseError(p, FixedPackage::ByRange { name, range }) if p == os && name == "gitlab-ce" && range.start == "?" && range.end == "=" )
+        matches!(notus.scan(os, &packages).expect_err("Should fail"), Error::VulnerabilityTestParseError(p, FixedPackage::ByRange { name, range, module }) if p == os && name == "gitlab-ce" && range.start == "?" && range.end == "=" && module.is_none())
     );
 }

--- a/rust/src/notus/vts.rs
+++ b/rust/src/notus/vts.rs
@@ -132,9 +132,15 @@ where
             FixedPackage::ByFullName {
                 specifier,
                 full_name,
+                module,
             } => {
+                let mut full_name = full_name.clone();
+
+                if let Some(module) = module {
+                    full_name = format!("{}@{}:{}", full_name, module.name, module.stream);
+                }
                 // Parse package from full name
-                let package = P::from_full_name(full_name)?;
+                let package = P::from_full_name(&full_name)?;
                 // Create Vulnerability Test Entry
                 Some((
                     package.get_name(),
@@ -151,9 +157,14 @@ where
                 full_version,
                 specifier,
                 name,
+                module,
             } => {
+                let mut full_version = full_version.clone();
+                if let Some(module) = module {
+                    full_version = format!("{}@{}:{}", full_version, module.name, module.stream);
+                }
                 // Parse package from name and full version
-                let package = P::from_name_and_full_version(name, full_version)?;
+                let package = P::from_name_and_full_version(name, &full_version)?;
                 // Create Vulnerability Test Entry
                 Some((
                     package.get_name(),
@@ -166,10 +177,20 @@ where
                     },
                 ))
             }
-            FixedPackage::ByRange { range, name } => {
+            FixedPackage::ByRange {
+                range,
+                name,
+                module,
+            } => {
                 // Parse both packages from name and full version
-                let start = P::from_name_and_full_version(name, &range.start)?;
-                let end = P::from_name_and_full_version(name, &range.end)?;
+                let mut start = range.start.clone();
+                let mut end = range.end.clone();
+                if let Some(module) = module {
+                    start = format!("{}@{}:{}", start, module.name, module.stream);
+                    end = format!("{}@{}:{}", end, module.name, module.stream);
+                }
+                let start = P::from_name_and_full_version(name, &start)?;
+                let end = P::from_name_and_full_version(name, &end)?;
                 // Create Vulnerability Test Entry
                 Some((
                     start.get_name(),


### PR DESCRIPTION
This adds support for AppStream modules for RPM packages, so that packages from differen modules are not comparable. This missing lead to a lot of fals positives. A new format for the Products notus file is established, which now allows an Optional field for defining the AppStream module.

Jira: SC-1299

closes https://github.com/greenbone/openvas-scanner/pull/1914