### PR TITLE
Fix: initialize type value in get_kb_item

### DIFF
--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -717,7 +717,7 @@ get_kb_item (lex_ctxt *lexic)
   char *kb_entry = get_str_var_by_num (lexic, 0);
   char *val;
   tree_cell *retc;
-  int type, single = get_int_var_by_num (lexic, 1, 0);
+  int type = -1, single = get_int_var_by_num (lexic, 1, 0);
   size_t len;
 
   if (kb_entry == NULL)


### PR DESCRIPTION
It may happen, that the value of type is randomly 1, if not initialized, which would force an integer type to the output of `get_kb_item`. This happens rarely, but as the function is called very often during a run and an integer is defined to has at least 16 bits, there is a chance of 1/65536 on each call that this happens. It might lead to different behavior in some rare cases.
