### PR TITLE
Fix bug with local function arguments.

### DIFF
--- a/rust/src/feed/update/mod.rs
+++ b/rust/src/feed/update/mod.rs
@@ -82,7 +82,7 @@ pub async fn feed_version(
 
     let feed_version = interpreter
         .register()
-        .nasl_value("PLUGIN_SET")
+        .global_nasl_value("PLUGIN_SET")
         .map(|x| x.to_string())
         .unwrap_or_else(|_| "0".to_owned());
     Ok(feed_version)

--- a/rust/src/nasl/builtin/cryptographic/misc.rs
+++ b/rust/src/nasl/builtin/cryptographic/misc.rs
@@ -11,7 +11,7 @@ use rand::{Rng, rng};
 fn insert_hexzeros(register: &Register) -> Result<Vec<u8>, FnError> {
     // As in is a keyword in rust, we cannot use the nasl_function annotation for named arguments.
     let data = register
-        .nasl_value("in")
+        .local_nasl_value("in")
         .map_err(|_| ArgumentError::MissingNamed(vec!["in".into()]))?;
     let data = match data {
         NaslValue::Data(x) => x,

--- a/rust/src/nasl/builtin/cryptographic/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/mod.rs
@@ -60,7 +60,7 @@ fn get_required_named_data<'a>(
     register: &'a Register,
     key: &'a str,
 ) -> Result<&'a [u8], ArgumentError> {
-    match register.nasl_value(key) {
+    match register.local_nasl_value(key) {
         Ok(NaslValue::Data(x)) => Ok(x.as_slice()),
         Ok(NaslValue::String(x)) => Ok(x.as_bytes()),
         Ok(x) => Err(ArgumentError::wrong_argument(
@@ -77,7 +77,7 @@ fn get_required_named_data<'a>(
 /// set to Some value. If it is false, no error will be returned but the Option can be either Some
 /// or None.
 fn get_optional_named_number(register: &Register, key: &str) -> Result<Option<i64>, ArgumentError> {
-    match register.nasl_value(key) {
+    match register.local_nasl_value(key) {
         Ok(NaslValue::Number(x)) => Ok(Some(*x)),
         Ok(x) => Err(ArgumentError::wrong_argument(
             key,

--- a/rust/src/nasl/builtin/cryptographic/pem_to.rs
+++ b/rust/src/nasl/builtin/cryptographic/pem_to.rs
@@ -12,7 +12,7 @@ use rsa::{RsaPrivateKey, pkcs8::DecodePrivateKey, traits::PrivateKeyParts};
 
 #[nasl_function(named(passphrase))]
 fn pem_to_rsa(register: &Register, passphrase: String) -> Result<NaslValue, FnError> {
-    let ori_pem = StringOrData::from_nasl_value(register.nasl_value("priv")?).map(|s| s.0)?;
+    let ori_pem = StringOrData::from_nasl_value(register.local_nasl_value("priv")?).map(|s| s.0)?;
     let decrypted_key = match RsaPrivateKey::from_pkcs8_encrypted_pem(&ori_pem, passphrase) {
         Ok(x) => x,
         Err(e) => return Err(ArgumentError::WrongArgument(format!("{e}")).into()),
@@ -23,7 +23,7 @@ fn pem_to_rsa(register: &Register, passphrase: String) -> Result<NaslValue, FnEr
 
 #[nasl_function(named(passphrase))]
 fn pem_to_dsa(register: &Register, passphrase: String) -> Result<NaslValue, FnError> {
-    let ori_pem = StringOrData::from_nasl_value(register.nasl_value("priv")?).map(|s| s.0)?;
+    let ori_pem = StringOrData::from_nasl_value(register.local_nasl_value("priv")?).map(|s| s.0)?;
     let decrypted_key = match SigningKey::from_pkcs8_encrypted_pem(&ori_pem, passphrase) {
         Ok(x) => x,
         Err(e) => return Err(ArgumentError::WrongArgument(format!("{e}")).into()),

--- a/rust/src/nasl/builtin/cryptographic/rc4.rs
+++ b/rust/src/nasl/builtin/cryptographic/rc4.rs
@@ -58,7 +58,7 @@ impl CipherHandlers {
     /// Closes a stream cipher.
     #[nasl_function]
     fn close_stream_cipher(&self, register: &Register) -> Result<NaslValue, FnError> {
-        let hd = match register.nasl_value("hd") {
+        let hd = match register.local_nasl_value("hd") {
             Ok(NaslValue::Number(x)) => *x as i32,
             _ => return Err(CryptographicError::Rc4("Handler ID not found".to_string()).into()),
         };
@@ -116,7 +116,7 @@ impl CipherHandlers {
             _ => return Err(CryptographicError::Rc4("Missing data argument".to_string()).into()),
         };
 
-        let hd = match register.nasl_value("hd") {
+        let hd = match register.local_nasl_value("hd") {
             Ok(NaslValue::Number(x)) => *x as i32,
             _ => 0,
         };

--- a/rust/src/nasl/builtin/description/mod.rs
+++ b/rust/src/nasl/builtin/description/mod.rs
@@ -72,13 +72,13 @@ macro_rules! make_storage_function {
             )?
             $(
             $(
-            let value = registrat.nasl_value(stringify!($value))?;
+            let value = registrat.global_nasl_value(stringify!($value))?;
             variables.push(value);
             )+
             )?
             $(
             $(
-            if let Ok(value) = registrat.nasl_value(stringify!($optional_value)) {
+            if let Ok(value) = registrat.global_nasl_value(stringify!($optional_value)) {
                variables.push(value);
             }
             )+

--- a/rust/src/nasl/builtin/http/mod.rs
+++ b/rust/src/nasl/builtin/http/mod.rs
@@ -243,7 +243,7 @@ impl NaslHttp2 {
         ctx: &ScanCtx<'_>,
         method: Method,
     ) -> Result<NaslValue, FnError> {
-        let handle_id = match register.nasl_value("handle") {
+        let handle_id = match register.local_nasl_value("handle") {
             Ok(NaslValue::Number(x)) => *x as i32,
             _ => return Err(ArgumentError::WrongArgument("Invalid handle ID".to_string()).into()),
         };
@@ -256,12 +256,12 @@ impl NaslHttp2 {
             .ok_or(HttpError::HandleIdNotFound(handle_id))?;
 
         let item: String = register
-            .nasl_value("item")
+            .local_nasl_value("item")
             .ok()
             .map(|x| x.to_string())
             .ok_or(FnError::missing_argument("item"))?;
 
-        let schema: String = match register.nasl_value("schema") {
+        let schema: String = match register.local_nasl_value("schema") {
             Ok(x) => {
                 if x.to_string() == *"http" || x.to_string() == *"https" {
                     x.to_string()
@@ -272,12 +272,12 @@ impl NaslHttp2 {
             _ => "https".to_string(),
         };
 
-        let data: String = match register.nasl_value("data") {
+        let data: String = match register.local_nasl_value("data") {
             Ok(x) => x.to_string(),
             _ => String::new(),
         };
 
-        let port = match register.nasl_value("port") {
+        let port = match register.local_nasl_value("port") {
             Ok(NaslValue::Number(x)) => *x as u16,
             _ => 0u16,
         };
@@ -393,7 +393,7 @@ impl NaslHttp2 {
     /// representing the http code response. Null on error.
     #[nasl_function]
     async fn get_response_code(&self, register: &Register) -> Result<NaslValue, FnError> {
-        let handle_id = match register.nasl_value("handle") {
+        let handle_id = match register.local_nasl_value("handle") {
             Ok(NaslValue::Number(x)) => *x as i32,
             _ => {
                 return Err(ArgumentError::WrongArgument(("Invalid handle ID").to_string()).into());
@@ -419,14 +419,14 @@ impl NaslHttp2 {
     /// On success the function returns an integer. 0 on success. Null on error.
     #[nasl_function]
     async fn set_custom_header(&self, register: &Register) -> Result<NaslValue, FnError> {
-        let header_item = match register.nasl_value("header_item") {
+        let header_item = match register.local_nasl_value("header_item") {
             Ok(NaslValue::String(x)) => x,
             _ => return Err(FnError::missing_argument("No command passed")),
         };
 
         let (key, val) = header_item.split_once(": ").expect("Missing header_item");
 
-        let handle_id = match register.nasl_value("handle") {
+        let handle_id = match register.local_nasl_value("handle") {
             Ok(NaslValue::Number(x)) => *x as i32,
             _ => {
                 return Err(ArgumentError::WrongArgument(("Invalid handle ID").to_string()).into());

--- a/rust/src/nasl/builtin/raw_ip/denial.rs
+++ b/rust/src/nasl/builtin/raw_ip/denial.rs
@@ -52,7 +52,7 @@ async fn end_denial(
 
     match script_ctx.denial_port {
         Some(port) => {
-            let vendor_version = match register.nasl_value("vendor_version")? {
+            let vendor_version = match register.local_nasl_value("vendor_version")? {
                 NaslValue::String(v) => v.clone(),
                 _ => "".to_string(),
             };

--- a/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
@@ -320,7 +320,7 @@ fn send_frame(
 /// - cap_timeout: time to wait for answer in seconds, 5 by default
 #[nasl_function]
 fn nasl_send_arp_request(register: &Register, context: &ScanCtx) -> Result<NaslValue, FnError> {
-    let timeout = match register.nasl_value("pcap_timeout") {
+    let timeout = match register.local_nasl_value("pcap_timeout") {
         Ok(NaslValue::Number(x)) => *x as i32 * 1000i32, // to milliseconds
         Ok(_) => {
             return Err(FnError::wrong_unnamed_argument(
@@ -404,14 +404,14 @@ fn nasl_get_local_mac_address_from_ip(register: &Register) -> Result<NaslValue, 
 /// - payload: is any data, which is then attached as payload to the frame.
 #[nasl_function]
 fn nasl_forge_frame(register: &Register) -> Result<NaslValue, FnError> {
-    let src_haddr = validate_mac_address(register.nasl_value("src_haddr").ok())?;
-    let dst_haddr = validate_mac_address(register.nasl_value("dst_haddr").ok())?;
-    let ether_proto = match register.nasl_value("ether_proto") {
+    let src_haddr = validate_mac_address(register.local_nasl_value("src_haddr").ok())?;
+    let dst_haddr = validate_mac_address(register.local_nasl_value("dst_haddr").ok())?;
+    let ether_proto = match register.local_nasl_value("ether_proto") {
         Ok(NaslValue::Number(x)) => *x as u16,
         _ => ETHERTYPE_IP,
     };
 
-    let payload: Vec<u8> = match register.nasl_value("payload") {
+    let payload: Vec<u8> = match register.local_nasl_value("payload") {
         Ok(NaslValue::String(x)) => x.clone().into_bytes(),
         Ok(NaslValue::Data(x)) => x.clone(),
         _ => vec![],
@@ -461,7 +461,7 @@ fn nasl_send_frame(
 /// This function is meant to be used for debugging.
 #[nasl_function]
 fn nasl_dump_frame(register: &Register) -> Result<NaslValue, FnError> {
-    let frame: Frame = match register.nasl_value("frame") {
+    let frame: Frame = match register.local_nasl_value("frame") {
         Ok(NaslValue::Data(x)) => (x as &[u8]).try_into()?,
         _ => return Err(FnError::wrong_unnamed_argument("Data", "Invalid data type")),
     };

--- a/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/packet_forgery.rs
@@ -1824,7 +1824,7 @@ fn forge_igmp_packet(
     let mut igmp_pkt = igmp::MutableIgmpPacket::new(&mut buf).unwrap();
 
     // use register since type is codeword
-    match register.nasl_value("type") {
+    match register.local_nasl_value("type") {
         Ok(NaslValue::Number(x)) => igmp_pkt.set_igmp_type(igmp::IgmpType::new(*x as u8)),
         _ => igmp_pkt.set_igmp_type(igmp::IgmpTypes::Default),
     };

--- a/rust/src/nasl/builtin/report_functions/mod.rs
+++ b/rust/src/nasl/builtin/report_functions/mod.rs
@@ -31,15 +31,18 @@ impl Reporting {
         register: &Register,
         context: &ScanCtx,
     ) -> Result<NaslValue, FnError> {
-        let data = register.nasl_value("data").ok().map(|x| x.to_string());
+        let data = register
+            .local_nasl_value("data")
+            .ok()
+            .map(|x| x.to_string());
         let port = register
-            .nasl_value("port")
+            .local_nasl_value("port")
             .ok()
             .map(|x| x.convert_to_number())
             .map(|x: i64| x as i16);
 
         let protocol = match register
-            .nasl_value("proto")
+            .local_nasl_value("proto")
             .ok()
             .map(|x| x.to_string())
             .as_ref()

--- a/rust/src/nasl/utils/function/utils.rs
+++ b/rust/src/nasl/utils/function/utils.rs
@@ -48,7 +48,7 @@ pub fn get_optional_named_arg<'a, T: FromNaslValue<'a>>(
     name: &'a str,
 ) -> Result<Option<T>, FnError> {
     register
-        .nasl_value(name)
+        .local_nasl_value(name)
         .ok()
         .map(|arg| <T as FromNaslValue>::from_nasl_value(arg))
         .transpose()
@@ -60,7 +60,7 @@ pub fn get_named_arg<'a, T: FromNaslValue<'a>>(
     register: &'a Register,
     name: &'a str,
 ) -> Result<T, FnError> {
-    <T as FromNaslValue>::from_nasl_value(register.nasl_value(name)?)
+    <T as FromNaslValue>::from_nasl_value(register.local_nasl_value(name)?)
 }
 
 /// A convenience function to obtain an argument


### PR DESCRIPTION
Previously, nasl_functions would look up the value of a function argument via `Register::nasl_value` which starts the lookup in the local scope, but goes all the way to the global scope. Omitting a named argument to a function could result in wrong values being taken out of the global context, i.e. in a set up like this:

```rust
fn foo(x: usize) -> x {
    x
}
```

```nasl
x = 3;
display(foo());
```

where the latter script would result in "3".