### PR TITLE
Fix: check the nasl file encoding before converting results to utf-8

### DIFF
--- a/.github/install-openvas-dependencies.sh
+++ b/.github/install-openvas-dependencies.sh
@@ -32,6 +32,7 @@ apt-get update && apt-get install --no-install-recommends --no-install-suggests 
     libcurl4 \
     libcurl4-gnutls-dev \
     libhiredis-dev \
+    libmagic-dev \
     && rm -rf /var/lib/apt/lists/*
 
 curl -L -o cgreen.tar.gz https://github.com/cgreen-devs/cgreen/archive/refs/tags/1.6.3.tar.gz -k

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,6 +28,7 @@ Prerequisites:
 * libcurl4-gnutls-dev
 * libbsd
 * krb5-multidev
+* libmagic-dev
 
 Prerequisites for building documentation:
 * Doxygen
@@ -57,7 +58,7 @@ Install prerequisites on Debian GNU/Linux 'Bullseye' 11:
     apt-get install gcc pkg-config libssh-gcrypt-dev libgnutls28-dev \
     libglib2.0-dev libjson-glib-dev libpcap-dev libgpgme-dev bison libksba-dev \
     libsnmp-dev libgcrypt20-dev redis-server libbsd-dev libcurl4-gnutls-dev \
-    krb5-multidev
+    krb5-multidev libmagic-dev
  
 
 

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -64,6 +64,15 @@ execute_process (COMMAND gpgme-config --cflags
   OUTPUT_VARIABLE GPGME_CFLAGS
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+message (STATUS "Looking for libmagic...")
+find_library (MAGIC magic)
+message (STATUS "Looking for libmagic... ${MAGIC} ${MAGIC_LDFLAFS} ${MAGIC_INCLUDE_DIRS}")
+if (MAGIC)
+    set (MAGIC_LDFLAGS "-L/usr/lib -lmagic")
+else (MAGIC)
+  message (SEND_ERROR "The magic library is required.")
+endif (MAGIC)
+
 set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 
@@ -95,7 +104,7 @@ set_target_properties (openvas_misc_shared PROPERTIES VERSION "${PROJECT_VERSION
 
 target_link_libraries (openvas_misc_shared LINK_PRIVATE
                        ${GNUTLS_LDFLAGS} ${UUID_LDFLAGS}
-                       ${GLIB_LDFLAGS} ${GLIB_JSON_LDFLAGS}
+                       ${GLIB_LDFLAGS} ${GLIB_JSON_LDFLAGS} ${MAGIC_LDFLAGS}
                        ${PCAP_LDFLAGS} ${LIBGVM_BOREAS_LDFLAGS} ${CURL_LDFLAGS} ${KRB5_LDFLAGS} ${KRB5_GSSAPI_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS})
 
@@ -138,7 +147,7 @@ enable_testing ()
 set (LINK_LIBS_FOR_TESTS cgreen
                        ${LIBGVM_BASE_LDFLAGS}
                        ${GLIB_LDFLAGS}
-                       ${PCAP_LDFLAGS}
+                       ${PCAP_LDFLAGS} ${MAGIC_LDFLAGS}
                        ${CURL_LDFLAGS} ${KRB5_LDFLAGS} ${KRB5_GSSAPI_LDFLAGS}
                        ${LINKER_HARDENING_FLAGS} ${CMAKE_THREAD_LIBS_INIT}
                        ${ALIVEDETECTION_TEST_LINKER_WRAP_OPTIONS})
@@ -179,6 +188,7 @@ target_include_directories (lsc-test PRIVATE ${CGREEN_INCLUDE_DIRS})
 target_link_libraries (lsc-test cgreen
                        ${LIBGVM_BASE_LDFLAGS}
                        ${LIBGVM_UTIL_LDFLAGS}
+                       ${MAGIC_LDFLAGS}
                        ${GLIB_LDFLAGS}
                        ${GLIB_JSON_LDFLAGS}
                        ${CURL_LDFLAGS} ${KRB5_LDFLAGS} ${KRB5_GSSAPI_LDFLAGS}


### PR DESCRIPTION
**What**:
check if the original nasl file is encoded in UTF-8 or not
SC-737
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
We convert everything to UTF-8 before sending the results to client.
To avoid double conversion, we check now that nasl files are in UTF-8 encoding.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
