### PR TITLE
Fix: drop sqlite inmemory DB

### DIFF
--- a/rust/src/container_image_scanner/config/mod.rs
+++ b/rust/src/container_image_scanner/config/mod.rs
@@ -159,7 +159,12 @@ impl SqliteConfiguration {
             .synchronous(SqliteSynchronous::Off)
             .create_if_missing(true);
         PoolOptions::<Sqlite>::new()
-            .min_connections(1) // otherwise it may drop in-memory db
+            // To prevent losing a in-memory DB we have to override max_lifetime and idle_timeout.
+            // It seems that min_connections is not reliable enough for now to ensure at least one
+            // connection being open.
+            .max_lifetime(None)
+            .idle_timeout(None)
+            // To prevent exhausting of the DB we limit the connections.
             .max_connections(self.max_connections)
             .connect_with(options)
             .await


### PR DESCRIPTION
Unfortunately it seems that min_connections is not sufficient to prevent dropping the inmemory sqlite DB reliably. Therefore we override the idle_timeout and max_lifetime.
