### PR TITLE
Fix: on dead_host the scan keeps in running instead of failed

### DIFF
--- a/rust/src/container_image_scanner/scheduling/mod.rs
+++ b/rust/src/container_image_scanner/scheduling/mod.rs
@@ -182,7 +182,7 @@ where
             }
         }
         Self::scan_images::<T>(config, pool.clone(), products).await;
-        if let Err(error) = db::set_scans_to_finished(pool.clone()).await {
+        if let Err(error) = db::set_scans_to_finished(pool.as_ref()).await {
             tracing::warn!(%error, "Unable to set scans to finished");
         }
     }


### PR DESCRIPTION
On a failure when host_dead was set to >0:

```json
{
  "start_time": 1759158034,
  "end_time": ,
  "status": "running",
  "host_info": {
    "all": 3,
    "excluded": 0,
    "dead": 1,
    "alive": 2,
    "queued": 0,
    "finished": 3,
    "remaining_vts_per_host": {}
  }
}
```

The status of that scan was kept in running.

This is fixed by removing the `host_dead = 0` where clause on `set_scans_to_finished`.
