### PR TITLE
Update nasl_http2.c to use long integer for certain Curl requests

### DIFF
--- a/RELICENSE/trondendrestol.md
+++ b/RELICENSE/trondendrestol.md
@@ -1,0 +1,80 @@
+Thank you for your interest in the project openvas-scanner managed by Greenbone.
+In order for you to make Contributions now or in the future to this
+project, You agree to license your Contributions under the MIT-0 license (see below).
+Please note that You remain the copyright owner, and anyone receives the right to
+use your Contribution in proprietary and open source software without any
+attribution.
+ 
+..................
+ 
+MIT No Attribution (MIT-0)
+ 
+Copyright 2025 Trond Endrestøl
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+.........................
+ 
+Please note that You remain the copyright owner, and anyone receives the
+right to use your Contribution in proprietary and open source software
+without attribution. However, we will include your name as a Contributor
+in our CREDITS list as long as your Contribution is used in the project
+openvas-scanner.
+ 
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is submitted by you
+to Greenbone for inclusion in the project openvas-scanner.
+ 
+Greenbone requires that each Contribution you submit now or in the
+future to comply with the following commitments documented in the
+Developer Certificate of Origin (DCO) [https://developercertificate.org/]:
+ 
+........
+ 
+Developer Certificate of Origin
+ 
+Version 1.1
+ 
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+ 
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+ 
+Developer's Certificate of Origin 1.1
+ 
+By making a contribution to this project, I certify that:
+ 
+(a) The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+ 
+(b) The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+ 
+(c) The contribution was provided directly to me by some other
+   person who certified (a), (b) or (c) and I have not modified
+   it.
+ 
+(d) I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.
+ 
+.....

--- a/nasl/nasl_http2.c
+++ b/nasl/nasl_http2.c
@@ -366,7 +366,7 @@ _http2_req (lex_ctxt *lexic, KEYWORD keyword)
       curl_easy_setopt (handle, CURLOPT_CUSTOMREQUEST, "DELETE");
       break;
     case HEAD:
-      curl_easy_setopt (handle, CURLOPT_NOBODY, 1);
+      curl_easy_setopt (handle, CURLOPT_NOBODY, 1L);
       break;
     case PUT:
       curl_easy_setopt (handle, CURLOPT_CUSTOMREQUEST, "PUT");
@@ -377,7 +377,7 @@ _http2_req (lex_ctxt *lexic, KEYWORD keyword)
         }
       break;
     case GET:
-      curl_easy_setopt (handle, CURLOPT_HTTPGET, 1);
+      curl_easy_setopt (handle, CURLOPT_HTTPGET, 1L);
       break;
     case POST:
       // Set body. POST is set automatically with this options


### PR DESCRIPTION
**What**:

When compiling `nasl_http2.c` as part of `security/openvas` on FreeBSD using the customary FreeBSD Ports Collection, these error messages appeared after Curl was updated to 8.16.0 in the Ports Collection:

```
/construction/xports/security/openvas/work/openvas-scanner-23.20.1/nasl/nasl_http2.c:380:7: error: call to '_curl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning] 380 | curl_easy_setopt (handle, CURLOPT_HTTPGET, 1); | ^
/usr/local/include/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt' 50 | _curl_easy_setopt_err_long();
| ^
/construction/xports/security/openvas/work/openvas-scanner-23.20.1/nasl/nasl_http2.c:369:7: error: call to '_curl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning] 369 | curl_easy_setopt (handle, CURLOPT_NOBODY, 1); | ^
/usr/local/include/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt' 50 | _curl_easy_setopt_err_long();
| ^
2 errors generated.
ninja: build stopped: subcommand failed.
===> Compilation failed unexpectedly.
```

Solved by simply adding an `L` suffix to the final parameter for these two cases.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Unable to compile the source file given the most recent version of Curl.

**How**:

Tested on FreeBSD/amd64 stable/14.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
