### PR TITLE
Fix: rs interpreter variable definition with first plusplus

### DIFF
--- a/rust/src/nasl/interpreter/tests/mod.rs
+++ b/rust/src/nasl/interpreter/tests/mod.rs
@@ -222,6 +222,7 @@ interpreter_test_ok!(
     NaslValue::Null,
 );
 
+interpreter_test_ok!(increment_assign, "j++; j;", NaslValue::Null, 1,);
 interpreter_test_err!(nonexistent_variable, "a += 12;");
 
 interpreter_test_err!(function_instead_of_variable, "function foo() { } a = foo;");

--- a/rust/src/nasl/interpreter/tests/mod.rs
+++ b/rust/src/nasl/interpreter/tests/mod.rs
@@ -223,7 +223,7 @@ interpreter_test_ok!(
 );
 
 interpreter_test_ok!(increment_assign, "j++; j;", NaslValue::Null, 1,);
-interpreter_test_err!(nonexistent_variable, "a += 12;");
+interpreter_test_ok!(nonexistent_variable, "a += 12;", 12);
 
 interpreter_test_err!(function_instead_of_variable, "function foo() { } a = foo;");
 interpreter_test_err!(variable_instead_of_function, "foo = 3; foo();");


### PR DESCRIPTION
**What**:
Fix: rs interpreter variable definition with first plusplus
SC-1391
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:


In C implementation is possible to define an int variable with the first ++ operator.
The followin nasl script
```
j++
display(j);
```
should show 
`1`

<!-- Why are these changes necessary? -->

**How**:
test the above nasl script with openvas-nasl and scannerctl. Compare the output.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
