### PR TITLE
Fix: Tests: always free suite

### DIFF
--- a/misc/ipc_openvas_tests.c
+++ b/misc/ipc_openvas_tests.c
@@ -150,6 +150,7 @@ Ensure (ipc_openvas, ipc_data_from_json_parse_many_objects)
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite;
 
   suite = create_test_suite ();
@@ -161,7 +162,11 @@ main (int argc, char **argv)
                          ipc_data_from_json_parse_many_objects);
 
   if (argc > 1)
-    return run_single_test (suite, argv[1], create_text_reporter ());
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
-  return run_test_suite (suite, create_text_reporter ());
+  destroy_test_suite (suite);
+
+  return ret;
 }

--- a/misc/pcap_tests.c
+++ b/misc/pcap_tests.c
@@ -299,13 +299,18 @@ openvas_routethrough ()
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite;
 
   suite = create_test_suite ();
   add_suite (suite, openvas_routethrough ());
 
   if (argc > 1)
-    return run_single_test (suite, argv[1], create_text_reporter ());
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
-  return run_test_suite (suite, create_text_reporter ());
+  destroy_test_suite (suite);
+
+  return ret;
 }

--- a/misc/table_driven_lsc_tests.c
+++ b/misc/table_driven_lsc_tests.c
@@ -92,6 +92,7 @@ Ensure (lsc, process_resp)
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite;
 
   suite = create_test_suite ();
@@ -99,7 +100,11 @@ main (int argc, char **argv)
   add_test_with_context (suite, lsc, process_resp);
   add_test_with_context (suite, lsc, make_pkg_in_json);
   if (argc > 1)
-    return run_single_test (suite, argv[1], create_text_reporter ());
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
-  return run_test_suite (suite, create_text_reporter ());
+  destroy_test_suite (suite);
+
+  return ret;
 }

--- a/src/attack_tests.c
+++ b/src/attack_tests.c
@@ -102,6 +102,7 @@ Ensure (attack, comm_send_status_sends_correct_text)
 int
 main (int argc, char **argv)
 {
+  int ret;
   TestSuite *suite;
 
   suite = create_test_suite ();
@@ -113,7 +114,11 @@ main (int argc, char **argv)
   add_test_with_context (suite, attack, comm_send_status_sends_correct_text);
 
   if (argc > 1)
-    return run_single_test (suite, argv[1], create_text_reporter ());
+    ret = run_single_test (suite, argv[1], create_text_reporter ());
+  else
+    ret = run_test_suite (suite, create_text_reporter ());
 
-  return run_test_suite (suite, create_text_reporter ());
+  destroy_test_suite (suite);
+
+  return ret;
 }


### PR DESCRIPTION
## What

Always free the suite in the tests.

## Why

Makes the output clearer when running tests with `-fsanitize=address`.

## References

Like https://github.com/greenbone/gvm-libs/pull/939.