### PR TITLE
Add: NASL builtin prfs

### DIFF
--- a/doc/manual/nasl/built-in-functions/cryptographic/prf_sha256.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/prf_sha256.md
@@ -13,7 +13,9 @@
 
 prf_sha256 is pseudo random function based on [rfc-2246§5](https://www.rfc-editor.org/rfc/rfc2246.html). 
 
-It uses given seed and label as a basis for the pseudo random generator while the secret is the basis of the hash limited by the given outlen parameter. 
+It uses given seed and label as a basis for the pseudo random generator while the secret is the basis of the hash limited by the given outlen parameter.
+
+The outlen is the length of the returned value in bytes.
 
 
 ## RETURN VALUE

--- a/doc/manual/nasl/built-in-functions/cryptographic/prf_sha384.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/prf_sha384.md
@@ -15,6 +15,8 @@ prf_sha384 is pseudo random function based on [rfc-2246§5](https://www.rfc-edit
 
 It uses given seed and label as a basis for the pseudo random generator while the secret is the basis of the hash limited by the given outlen parameter. 
 
+The outlen is the length of the returned value in bytes.
+
 
 ## RETURN VALUE
 

--- a/doc/manual/nasl/built-in-functions/cryptographic/tls1_prf.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/tls1_prf.md
@@ -2,7 +2,9 @@
 
 ## NAME
 
-**tls1_prf** - takes four named arguments secret, seed, label, outlen
+DEPRECATED
+
+**tls1_prf** - takes four named arguments secret, seed, label, outlen. This function is deprecated and will not longer be supported!
 ## SYNOPSIS
 
 *str* **tls1_prf**(secret: str, seed: str, label: str, outlen: int);
@@ -15,6 +17,9 @@ tls1_prf is pseudo random function based on [rfc-4346§5](https://www.rfc-editor
 
 It uses given seed and label as a basis for the pseudo random generator while the secret is the basis of the hash limited by the given outlen parameter. 
 
+## DEPRECATED
+
+This function is deprecated and **[prf_sha256(3)](prf_sha256.md)** or **[prf_sha384(3)](prf_sha384.md)** should be used instead.
 
 ## RETURN VALUE
 

--- a/rust/doc/misc/builtin_coverage.nasl
+++ b/rust/doc/misc/builtin_coverage.nasl
@@ -67,7 +67,7 @@ check_category(cat: "cryptographic",
                                         "rsa_private_decrypt","rsa_public_decrypt",
                                         "rsa_public_encrypt","rsa_sign","SHA1","SHA256",
                                         "SHA512","smb3kdf","smb_cmac_aes_signature",
-                                        "smb_gmac_aes_signature","tls1_prf"));
+                                        "smb_gmac_aes_signature"));
 check_category(cat: "description-functions",
                function_list: make_list("script_add_preference","script_category",
                                         "script_copyright","script_cve_id","script_dependencies","script_exclude_keys",

--- a/rust/src/nasl/builtin/cryptographic/README.md
+++ b/rust/src/nasl/builtin/cryptographic/README.md
@@ -91,15 +91,14 @@ let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
 - get_smb2_signature
 - dh_compute_key
 - dh_generate_key
+- bf_cbc_decrypt
+- bf_cbc_encrypt
+- prf_sha256
+- prf_sha384
 - des_ede_cbc_encrypt
 
 ## Not yet implemented
 
-- bf_cbc_decrypt
-- bf_cbc_encrypt
 - dsa_do_sign
 - dsa_do_verify
 - get_signature
-- prf_sha256
-- prf_sha384
-- tls1_prf

--- a/rust/src/nasl/builtin/cryptographic/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/mod.rs
@@ -22,6 +22,7 @@ mod hmac;
 mod misc;
 mod ntlm;
 mod pem_to;
+mod prf;
 pub mod rc4;
 mod rsa;
 mod smb;
@@ -147,6 +148,7 @@ impl IntoFunctionSet for Cryptographic {
         set.add_set(misc::Misc);
         set.add_set(ntlm::Ntlm);
         set.add_set(dh::Dh);
+        set.add_set(prf::Prf);
         set
     }
 }

--- a/rust/src/nasl/builtin/cryptographic/prf.rs
+++ b/rust/src/nasl/builtin/cryptographic/prf.rs
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use aes::cipher::BlockSizeUser;
+use ccm::consts::U256;
+use digest::HashMarker;
+use digest::block_buffer::Eager;
+use digest::core_api::{BufferKindUser, CoreProxy, FixedOutputCore, UpdateCore};
+use digest::typenum::{IsLess, Le, NonZero};
+use sha2::{Sha256, Sha384};
+
+use crate::nasl::builtin::cryptographic::hmac::hmac;
+use crate::nasl::prelude::*;
+use crate::nasl::utils::function::StringOrData;
+
+fn prf<D>(
+    secret: StringOrData,
+    seed: StringOrData,
+    label: StringOrData,
+    outlen: usize,
+) -> Result<Vec<u8>, FnError>
+where
+    D: CoreProxy,
+    D::Core: HashMarker
+        + UpdateCore
+        + FixedOutputCore
+        + BufferKindUser<BufferKind = Eager>
+        + Default
+        + Clone,
+    <D::Core as BlockSizeUser>::BlockSize: IsLess<U256>,
+    Le<<D::Core as BlockSizeUser>::BlockSize, U256>: NonZero,
+{
+    let secret = secret.0.as_bytes();
+    let label_seed = label.0 + &seed.0;
+    let label_seed = label_seed.as_bytes();
+
+    let mut ai = hmac::<D>(secret, label_seed)?;
+
+    let mut result = vec![];
+    while result.len() < outlen {
+        let mut tmp = ai.clone();
+        tmp.extend_from_slice(label_seed);
+        let tmp2 = hmac::<D>(secret, &tmp)?;
+        result.extend_from_slice(&tmp2);
+        ai = hmac::<D>(secret, &ai)?;
+    }
+    result.truncate(outlen);
+    Ok(result)
+}
+
+#[nasl_function(named(secret, seed, label, outlen))]
+fn prf_sha256(
+    secret: StringOrData,
+    seed: StringOrData,
+    label: StringOrData,
+    outlen: usize,
+) -> Result<Vec<u8>, FnError> {
+    prf::<Sha256>(secret, seed, label, outlen)
+}
+
+#[nasl_function(named(secret, seed, label, outlen))]
+fn prf_sha384(
+    secret: StringOrData,
+    seed: StringOrData,
+    label: StringOrData,
+    outlen: usize,
+) -> Result<Vec<u8>, FnError> {
+    prf::<Sha384>(secret, seed, label, outlen)
+}
+
+pub struct Prf;
+
+function_set! {
+    Prf,
+    (
+        prf_sha256,
+        prf_sha384,
+    )
+}

--- a/rust/src/nasl/builtin/cryptographic/tests/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/mod.rs
@@ -15,6 +15,7 @@ mod hmac;
 mod misc;
 mod ntlm;
 mod pem_to;
+mod prf;
 mod rc4;
 mod rsa;
 mod smb;

--- a/rust/src/nasl/builtin/cryptographic/tests/prf.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/prf.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#[cfg(test)]
+mod tests {
+
+    use crate::nasl::builtin::cryptographic::tests::helper::decode_hex;
+    use crate::nasl::test_prelude::*;
+    use crate::nasl::test_utils::TestBuilder;
+
+    #[test]
+    fn prf_sha256() {
+        let mut t = TestBuilder::default();
+        t.run(r#"secret = "mysecret";"#);
+        t.run(r#"seed = "myseed";"#);
+        t.run(r#"label = "mylabel";"#);
+        t.run(r#"outlen = 33;"#);
+        t.ok(
+            r#"prf_sha256(secret:secret,seed:seed,label:label,outlen:outlen);"#,
+            NaslValue::Data(
+                decode_hex("16b8ad158f73cb9c96c7c83e81fe9f9dcb740fe35d27343e0f239a8146b93dad66")
+                    .unwrap(),
+            ),
+        );
+    }
+
+    #[test]
+    fn prf_sha384() {
+        let mut t = TestBuilder::default();
+        t.run(r#"secret = "mysecret";"#);
+        t.run(r#"seed = "myseed";"#);
+        t.run(r#"label = "mylabel";"#);
+        t.run(r#"outlen = 33;"#);
+        t.ok(
+            r#"prf_sha384(secret:secret,seed:seed,label:label,outlen:outlen);"#,
+            NaslValue::Data(
+                decode_hex("c54442096f12f7d75a71b9582f0c4cf61953663f616eb0006c7aa6e42aa8f9d5dd")
+                    .unwrap(),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
The following functions are contained in this commit:
- prf_sha256
- prf_sha384

There was originally an addition function `tls1_prf`, which is deprecated and should not be used. Prf is short for Pseudo Random Function

Used the following nasl script for testing:

```c#
secret = "mysecret";
seed = "myseed";
label = "mylabel";
outlen = 33;

result = prf_sha256(secret:secret,seed:seed,label:label,outlen:outlen);
display(hexstr(result));
```
For `prf_sha384` change the function in the script.

Jira: SC-1383 SC-1415 SC-1416