### PR TITLE
Add: NASL Bultin Functions for Diffie-Hellman calculation

### DIFF
--- a/rust/src/nasl/builtin/cryptographic/README.md
+++ b/rust/src/nasl/builtin/cryptographic/README.md
@@ -89,14 +89,14 @@ let functions = nasl_builtin_utils::NaslfunctionRegisterBuilder::new()
 - rc4_encrypt
 - close_stream_cipher
 - get_smb2_signature
+- dh_compute_key
+- dh_generate_key
 
 ## Not yet implemented
 
 - bf_cbc_decrypt
 - bf_cbc_encrypt
 - des_ede_cbc_encrypt
-- dh_compute_key
-- dh_generate_key
 - dsa_do_sign
 - dsa_do_verify
 - get_signature

--- a/rust/src/nasl/builtin/cryptographic/dh.rs
+++ b/rust/src/nasl/builtin/cryptographic/dh.rs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use dsa::BigUint;
+
+use crate::nasl::{
+    prelude::*,
+    utils::function::{StringOrData, utils::get_named_arg},
+};
+
+/// Computes the Diffie-Hellman shared secret key from the shared
+/// parameters p and g, the server's public key dh_server_pub and the
+/// client's public and private keys pub_key an priv_key.  The return
+/// value is the shared secret key as an MPI (Multi Precision Integer).
+#[nasl_function(named(p, g, dh_server_pub, pub_key, priv_key))]
+fn dh_compute_key(
+    p: StringOrData,
+    #[allow(unused_variables)] g: StringOrData,
+    dh_server_pub: StringOrData,
+    #[allow(unused_variables)] pub_key: StringOrData,
+    priv_key: StringOrData,
+) -> Vec<u8> {
+    let p = BigUint::from_bytes_be(p.0.as_bytes());
+    let dh_server_pub = BigUint::from_bytes_be(dh_server_pub.0.as_bytes());
+    let priv_key = BigUint::from_bytes_be(priv_key.0.as_bytes());
+
+    dh_server_pub.modpow(&priv_key, &p).to_bytes_be().to_vec()
+}
+
+/// Generates a Diffie-Hellman public key from the shared parameters p
+/// and g and the private parameter priv. The return value is the public
+/// key as an MPI (Multi Precision Integer).
+#[nasl_function]
+fn dh_generate_key(reg: &Register) -> Result<Vec<u8>, FnError> {
+    // Get named arguments from Register, as `priv` is a reserved keyword in Rust
+    // Therefore we cannot use priv within the `nasl_function` macro
+    let (p, g, priv_key): (StringOrData, StringOrData, StringOrData) = (
+        get_named_arg(reg, "p")?,
+        get_named_arg(reg, "g")?,
+        get_named_arg(reg, "priv")?,
+    );
+    let p = BigUint::from_bytes_be(p.0.as_bytes());
+    let g = BigUint::from_bytes_be(g.0.as_bytes());
+    let priv_key = BigUint::from_bytes_be(priv_key.0.as_bytes());
+
+    Ok(g.modpow(&priv_key, &p).to_bytes_be().to_vec())
+}
+
+pub struct Dh;
+
+function_set! {
+    Dh,
+    (
+        dh_compute_key,
+        dh_generate_key,
+    )
+}

--- a/rust/src/nasl/builtin/cryptographic/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/mod.rs
@@ -17,6 +17,7 @@ mod aes_gcm;
 mod aes_gmac;
 mod bf_cbc;
 mod des;
+mod dh;
 mod hash;
 mod hmac;
 mod misc;
@@ -147,6 +148,7 @@ impl IntoFunctionSet for Cryptographic {
         set.add_set(smb::Smb);
         set.add_set(misc::Misc);
         set.add_set(ntlm::Ntlm);
+        set.add_set(dh::Dh);
         set
     }
 }

--- a/rust/src/nasl/builtin/cryptographic/tests/dh.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/dh.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use crate::nasl::{builtin::cryptographic::tests::helper::decode_hex, test_utils::TestBuilder};
+
+#[test]
+fn dh_compute_key() {
+    let mut t = TestBuilder::default();
+    t.run(r#"k1 = raw_string(0x03);"#);
+    t.run(r#"k2 = raw_string(0x03);"#);
+    t.run(r#"k3 = raw_string(0x07);"#);
+    t.run(r#"n = raw_string(0x00);"#);
+    t.ok(
+        r#"dh_compute_key(p: k3, g: n, dh_server_pub: k1, pub_key: n, priv_key: k2);"#,
+        decode_hex("06").unwrap(),
+    );
+}
+
+#[test]
+fn dh_generate_key() {
+    let mut t = TestBuilder::default();
+    t.run(r#"k1 = raw_string(0x03);"#);
+    t.run(r#"k2 = raw_string(0x03);"#);
+    t.run(r#"k3 = raw_string(0x07);"#);
+    t.ok(
+        r#"dh_generate_key(p: k3, g: k1, priv: k2);"#,
+        decode_hex("06").unwrap(),
+    );
+}

--- a/rust/src/nasl/builtin/cryptographic/tests/mod.rs
+++ b/rust/src/nasl/builtin/cryptographic/tests/mod.rs
@@ -9,6 +9,7 @@ mod aes_ctr;
 mod aes_gcm;
 mod bf_cbc;
 mod des;
+mod dh;
 mod hash;
 mod helper;
 mod hmac;


### PR DESCRIPTION
For some strange reasons both functions do exactly the same, but take different names for the arguments...

Here a Nasl file for testing, that the results are the same, as in `openvas-nasl`:
```c#
k1 = raw_string(0x03, 0x02, 0x01, 0x00);
k2 = raw_string(0x03, 0x04, 0x05, 0x06);
k3 = raw_string(0x07, 0x01);

n = raw_string(0x00);

display("k1: " + hexstr(k1));
display("k2: " + hexstr(k2));
display("k3: " + hexstr(k3));

res1 = dh_compute_key(p: k3, g: n, dh_server_pub: k1, pub_key: n, priv_key: k2);
res2 = dh_generate_key(p: k3, g: k1, priv: k2);

display("k1^k2 mod k3: " + hexstr(res1));
display("k1^k2 mod k3: " + hexstr(res2));
```


Jira: SC-1403
