### PR TITLE
Fix: reported error Wstringop

### DIFF
--- a/misc/pcap.c
+++ b/misc/pcap.c
@@ -628,7 +628,7 @@ getipv4routes (struct myroute *myroutes, int *numroutes)
                          " /proc/net/route line");
               continue;
             }
-          strncpy (iface, p, sizeof (iface));
+          strncpy (iface, p, sizeof (iface) - 1);
           iface[MAX_IFACE_NAME_LEN - 1] = '\0';
           if ((p = strchr (iface, ':')))
             {
@@ -1121,7 +1121,7 @@ routethrough (struct in_addr *dest, struct in_addr *source)
                              " /proc/net/route line");
                   continue;
                 }
-              strncpy (iface, p, sizeof (iface));
+              strncpy (iface, p, sizeof (iface) - 1);
               iface[MAX_IFACE_NAME_LEN - 1] = '\0';
               if ((p = strchr (iface, ':')))
                 {


### PR DESCRIPTION
**What**:
Fix Wstringop error reported by gcc after adding the `-fsanitize=address` compiler flag (related to PR #2028)
Jira: SC-1404
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
