### PR TITLE
Fix: treat missing packages not as an error

### DIFF
--- a/rust/src/openvasd/container_image_scanner/image/packages/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/packages/mod.rs
@@ -65,7 +65,7 @@ macro_rules! generate_all_types {
                         }
                     )+
 
-                    tracing::warn!("No supported package manager found. OS might be unsupported.");
+                    tracing::debug!("No packages found, might be because the package DB got deleted or unsupported OS.");
                     vec![]
                 })
             }


### PR DESCRIPTION
In some cases the package db can be deleted in an image on purpose.

While this
indicates an incorrectly build operating system and we don't know if it contains vulnerabilities or not it may be better to accept false negatives to reduce confusion.
SC-1499
