### PR TITLE
Fix container-image-scanning issue with deleted Packages.db

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "libflate"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249fa21ba2b59e8cbd69e722f5b31e1b466db96c937ae3de23e8b99ead0d1383"
+checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
 dependencies = [
  "adler32",
  "core2",
@@ -4478,6 +4478,7 @@ dependencies = [
  "lazy-regex",
  "lazy_static",
  "libc",
+ "libflate",
  "libssh-rs",
  "md-5",
  "md2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -138,6 +138,8 @@ rustls-platform-verifier = "0.6.1"
 rustls-webpki = "0.103.4"
 tempfile = "3.23.0"
 snmp2 = { version = "0.4.8", features = ["full"] }
+tar = "0"
+libflate = "2.2.1"
 
 [workspace]
 members = ["crates/smoketest", "crates/nasl-function-proc-macro"]

--- a/rust/src/openvasd/container_image_scanner/image/extractor/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/extractor/mod.rs
@@ -10,8 +10,10 @@ pub mod filtered_image;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExtractorError {
-    #[error("io error")]
+    #[error("io error {0}")]
     Io(#[from] std::io::Error),
+    #[error("Wrong target path {0}: must be absolute path to existing directory.")]
+    WrongTargetDir(PathBuf),
 }
 
 pub struct Location(PathBuf);


### PR DESCRIPTION
In container image scanning, a specific image resulted in an empty detection. This was due to the fact that the
`/var/lib/rpm/Packages.db` file was deleted in the last layer. Since we currently scan only the last layer, we would find no packages, resulting in an error.

We also noted that the extraction mechanism in the docker-registry crate would result in `io::Error` during this operation, since it was trying to remove some files with `remove_dir_all`, resulting in `NotADirectory`.

To address both these issues at the same time, this commit moves the extraction logic out of docker-registry into the container-image-scanning code, so we can control it. Then, we skip the deletion mechanism (which is controlled via whiteout files), so that we see the `Packages.db` file even it should have been deleted.

This might be considered more of a bandaid than a true solution to the issue, since we need to address the question of whether to scan intermediate layer results for vulnerabilities as well.

Jira: SC-1499