### PR TITLE
Fix: exhaust on too many http connections

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/lib.rs
+++ b/rust/crates/greenbone-scanner-framework/src/lib.rs
@@ -1,4 +1,13 @@
-use std::{marker::PhantomData, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc, sync::RwLock};
+use std::{
+    marker::PhantomData,
+    net::SocketAddr,
+    path::PathBuf,
+    pin::Pin,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use delete_scans_id::{DeleteScansId, DeleteScansIdHandler};
 use entry::Prefixed;
@@ -118,6 +127,7 @@ pub struct RuntimeBuilder<T> {
     tls: Option<TLSConfig>,
     api_keys: Option<Vec<String>>,
     handlers: RequestHandlers,
+    max_concurrent_connections: usize,
     _phantom: PhantomData<T>,
 }
 
@@ -152,6 +162,7 @@ impl<T> RuntimeBuilder<T> {
             api_keys: None,
             handlers,
             listener_address,
+            max_concurrent_connections: 10,
             _phantom: PhantomData,
         }
     }
@@ -193,6 +204,14 @@ impl<T> RuntimeBuilder<T> {
                 path_client_certs: Some(path_client_certs),
             },
         });
+        self
+    }
+
+    pub fn max_concurrent_connections(
+        mut self,
+        max_concurrent_connections: usize,
+    ) -> RuntimeBuilder<T> {
+        self.max_concurrent_connections = max_concurrent_connections;
         self
     }
 
@@ -258,6 +277,7 @@ impl<T> RuntimeBuilder<T> {
             api_keys: ior.api_keys,
             handlers: ior.handlers,
             _phantom: PhantomData,
+            max_concurrent_connections: ior.max_concurrent_connections,
         }
     }
 
@@ -329,6 +349,7 @@ impl RuntimeBuilder<runtime_builder_states::Start> {
             api_keys: ior.api_keys,
             handlers: ior.handlers,
             _phantom: PhantomData,
+            max_concurrent_connections: ior.max_concurrent_connections,
         }
     }
 }
@@ -346,6 +367,7 @@ impl RuntimeBuilder<runtime_builder_states::DeleteScanIDSet> {
             tls: ior.tls,
             api_keys: ior.api_keys,
             handlers: ior.handlers,
+            max_concurrent_connections: ior.max_concurrent_connections,
             _phantom: PhantomData,
         }
     }
@@ -361,6 +383,8 @@ impl RuntimeBuilder<runtime_builder_states::End> {
 
         let incoming = TcpListener::bind(&self.listener_address).await?;
         let handlers = Arc::new(self.handlers);
+        let connection_counter = Arc::new(AtomicUsize::new(0));
+        let max_connections = self.max_concurrent_connections;
 
         if let Some(tls_config) = tls_config {
             use hyper::server::conn::http2::Builder;
@@ -375,6 +399,7 @@ impl RuntimeBuilder<runtime_builder_states::End> {
                 let identifier = tls_config.client_identifier.clone();
                 let ctx = scanner.clone();
                 let handlers = handlers.clone();
+                let connection_counter = connection_counter.clone();
                 tokio::spawn(async move {
                     let tls_stream = match tls_acceptor.accept(tcp_stream).await {
                         Ok(tls_stream) => tls_stream,
@@ -384,13 +409,23 @@ impl RuntimeBuilder<runtime_builder_states::End> {
                         }
                     };
                     let cci = retrieve_and_reset_client_identifier(identifier);
-                    let service = entry::EntryPoint::new(ctx, Arc::new(cci), handlers);
+                    // count amount of requests
+                    let service = entry::EntryPoint::new(
+                        ctx,
+                        Arc::new(cci),
+                        handlers,
+                        max_connections,
+                        connection_counter.fetch_add(1, Ordering::SeqCst),
+                    );
                     if let Err(err) = Builder::new(TokioExecutor::new())
+                        .max_concurrent_streams(20)
                         .serve_connection(TokioIo::new(tls_stream), service)
                         .await
                     {
                         tracing::debug!("failed to serve connection: {err:#}");
                     }
+                    let released = connection_counter.fetch_sub(1, Ordering::SeqCst);
+                    tracing::debug!(released, "released");
                 });
             }
         } else {
@@ -400,15 +435,25 @@ impl RuntimeBuilder<runtime_builder_states::End> {
                 let (tcp_stream, _remote_addr) = incoming.accept().await?;
                 let ctx = scanner.clone();
                 let handlers = handlers.clone();
+                let connection_counter = connection_counter.clone();
                 tokio::spawn(async move {
                     let cci = ClientIdentifier::Unknown;
-                    let service = entry::EntryPoint::new(ctx, Arc::new(cci), handlers);
+                    let service = entry::EntryPoint::new(
+                        ctx,
+                        Arc::new(cci),
+                        handlers,
+                        max_connections,
+                        connection_counter.fetch_add(1, Ordering::SeqCst),
+                    );
                     if let Err(err) = Builder::new()
                         .serve_connection(TokioIo::new(tcp_stream), service)
                         .await
                     {
                         tracing::debug!("failed to serve connection: {err:#}");
                     }
+
+                    let connection = connection_counter.fetch_sub(1, Ordering::SeqCst);
+                    tracing::debug!(connection, "released");
                 });
             }
         }

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -288,6 +288,14 @@ impl StorageTypes {
             }
         }
     }
+
+    pub fn max_connections(&self) -> usize {
+        let result = match self {
+            StorageTypes::V1(_) => SqliteConfiguration::default().max_connections,
+            StorageTypes::V2(sqlite_configuration) => sqlite_configuration.max_connections,
+        };
+        if result > 0 { result as usize } else { 1 }
+    }
 }
 impl Default for StorageTypes {
     fn default() -> Self {

--- a/rust/src/openvasd/main.rs
+++ b/rust/src/openvasd/main.rs
@@ -103,6 +103,7 @@ async fn main() -> Result<()> {
 
     rb.insert_scans(Arc::new(scan))
         .insert_get_vts(vts.clone())
+        .max_concurrent_connections(config.storage.max_connections() * 10)
         .add_request_handler(get_notus)
         .add_request_handler(post_notus)
         .insert_additional_scan_endpoints(Arc::new(cis_scans), Arc::new(cis_vts))


### PR DESCRIPTION
Mitigates DB exhaust issues by adding the possibility to configure a max_concurrent_connection value within the Entrypoint of greenbone-scanner-framework.

OpenVASD checks how many DB connections are allowed and multiplies that with 10.

If a request is declined the greenbone-scanner-framework returns 503 with a hint that the client should retry that operation in 10 seconds.

Usually that is enough time for the DB to finish its operations.

SC-1250
