### PR TITLE
Clean up usage of the loader trait.

### DIFF
--- a/rust/benches/interpreter.rs
+++ b/rust/benches/interpreter.rs
@@ -2,8 +2,9 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use futures::StreamExt;
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::nasl::utils::scan_ctx::Target;
-use scannerlib::nasl::{Code, NoOpLoader, nasl_std_functions};
+use scannerlib::nasl::{Code, nasl_std_functions};
 use scannerlib::nasl::{Register, ScanCtxBuilder, interpreter::ForkingInterpreter};
 use scannerlib::scanner::preferences::preference::ScanPrefs;
 use scannerlib::storage::ScanID;
@@ -23,7 +24,7 @@ pub fn run_interpreter_in_description_mode(c: &mut Criterion) {
                     ports: Default::default(),
                     storage: &InMemoryStorage::default(),
                     executor: &nasl_std_functions(),
-                    loader: &NoOpLoader::default(),
+                    loader: &Loader::test_empty(),
                     scan_preferences: ScanPrefs::new(),
                     alive_test_methods: Vec::new(),
                 };

--- a/rust/src/feed/README.md
+++ b/rust/src/feed/README.md
@@ -22,11 +22,11 @@ Also, implements a `signature verifier` for checking the signature of the sha256
 ### Example
 
 ```rust,no_run
-use scannerlib::nasl::FSPluginLoader;
+use scannerlib::nasl::Loader;
 // needs to be path that contains a sha256sums file otherwise
 // it will throw an exception.
 let path = "/var/lib/openvas/plugins/";
-let loader = FSPluginLoader::new(path);
+let loader = Loader::from_feed_path(path);
 let verifier = scannerlib::feed::HashSumNameLoader::sha256(&loader).expect("sha256sums");
 ```
 

--- a/rust/src/feed/update_tests.rs
+++ b/rust/src/feed/update_tests.rs
@@ -2,20 +2,17 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::{env, path::PathBuf};
+use std::{env, path::Path};
 
 use crate::{
     feed::{HashSumNameLoader, Update},
-    nasl::syntax::FSPluginLoader,
+    nasl::syntax::Loader,
     storage::inmemory::InMemoryStorage,
 };
 use futures::StreamExt;
 
-fn loader() -> FSPluginLoader {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("data/feed/")
-        .to_owned();
-    FSPluginLoader::new(root)
+fn loader() -> Loader {
+    Loader::from_feed_path(Path::new(env!("CARGO_MANIFEST_DIR")).join("data/feed/"))
 }
 
 #[test]
@@ -41,7 +38,7 @@ async fn verify_feed() {
     let loader = loader();
     let storage: InMemoryStorage = InMemoryStorage::new();
     let mut verifier = HashSumNameLoader::sha256(&loader).expect("sha256sums should be available");
-    let updater = Update::init("1", 1, &loader, &storage, &mut verifier);
+    let updater = Update::init("1", 1, loader.clone(), &storage, &mut verifier);
     let files = updater
         .stream()
         .filter_map(|x| async { x.ok() })

--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -12,12 +12,11 @@
 
 use std::{
     fs::File,
-    io::{self, BufRead, BufReader, Read},
+    io::{self, BufRead, Read},
     path::{Path, PathBuf},
 };
 
-use crate::nasl::syntax::{AsBufReader, LoadError};
-use crate::nasl::syntax::{FSPluginLoader, Loader};
+use crate::nasl::syntax::{LoadError, Loader};
 use hex::encode;
 use sha2::{Digest, Sha256};
 
@@ -215,14 +214,13 @@ pub enum Hasher {
 }
 
 /// Computes hash of a given reader
-fn compute_hash_with<R, H>(
-    reader: &mut BufReader<R>,
+fn compute_hash_with<H>(
+    reader: &mut dyn BufRead,
     hasher: &dyn Fn() -> H,
     key: &str,
 ) -> Result<String, Error>
 where
     H: Digest,
-    R: Read,
 {
     let mut buffer = [0; 1024];
     let mut hasher = hasher();
@@ -239,6 +237,7 @@ where
     let result = encode(&result[..]);
     Ok(result)
 }
+
 impl Hasher {
     /// Returns the name of the used sums file
     pub fn sum_file(&self) -> &str {
@@ -248,10 +247,7 @@ impl Hasher {
     }
 
     /// Returns the hash of a given reader and key
-    fn hash<R>(&self, reader: &mut BufReader<R>, key: &str) -> Result<String, Error>
-    where
-        R: Read,
-    {
+    fn hash(&self, reader: &mut dyn BufRead, key: &str) -> Result<String, Error> {
         let hasher = match self {
             Hasher::Sha256 => &Sha256::new,
         };
@@ -262,14 +258,14 @@ impl Hasher {
 /// Loads a given hashsums file and lazily verifies the loaded filename key of the sums file and verifies
 /// the hash within the sums file with an calculated hash of the found content.
 pub struct HashSumNameLoader<'a> {
-    reader: &'a FSPluginLoader,
+    reader: &'a Loader,
     hasher: Hasher,
-    buf: io::Lines<BufReader<File>>,
+    buf: io::Lines<Box<dyn BufRead>>,
 }
 
 /// Loads hashsum verified names of the feed based on a sum file.
 impl<'a> HashSumNameLoader<'a> {
-    fn new(buf: io::Lines<BufReader<File>>, reader: &'a FSPluginLoader, hasher: Hasher) -> Self {
+    fn new(buf: io::Lines<Box<dyn BufRead>>, reader: &'a Loader, hasher: Hasher) -> Self {
         Self {
             reader,
             hasher,
@@ -278,7 +274,7 @@ impl<'a> HashSumNameLoader<'a> {
     }
 
     /// Returns a sha256 implementation of HashSumNameLoader
-    pub fn sha256(reader: &'a FSPluginLoader) -> Result<HashSumNameLoader<'a>, Error> {
+    pub fn sha256(reader: &'a Loader) -> Result<HashSumNameLoader<'a>, Error> {
         let buf = reader
             .as_bufreader(Hasher::Sha256.sum_file())
             .map(|x| x.lines())
@@ -319,12 +315,11 @@ impl<'a> Iterator for HashSumNameLoader<'a> {
 }
 
 /// Contains all information  necessary to do a hash sum check
-#[derive(Debug)]
 pub struct HashSumFileItem<'a> {
     pub file_name: String,
     pub hashsum: String,
     pub hasher: Option<Hasher>,
-    pub reader: &'a FSPluginLoader,
+    pub reader: &'a Loader,
 }
 
 impl HashSumFileItem<'_> {
@@ -357,32 +352,25 @@ impl HashSumFileItem<'_> {
     }
 }
 
-fn get_all_plugins(loader: &FSPluginLoader) -> Vec<PathBuf> {
+fn get_all_plugins(loader: &Loader) -> Vec<PathBuf> {
     let mut files = Vec::new();
-    if let Ok(rp) = loader.root_path() {
-        for e in walkdir::WalkDir::new(&rp)
-            .into_iter()
-            .filter_map(|e| e.ok())
-        {
-            if e.path()
-                .extension()
-                .is_some_and(|ext| ext == "nasl" || ext == "notus")
-            {
-                let relative_path = e.path().strip_prefix(Path::new(&rp)).unwrap();
-                files.push(relative_path.to_owned());
-            }
+    let rp = loader.root_path();
+    for e in walkdir::WalkDir::new(rp).into_iter().filter_map(|e| e.ok()) {
+        if e.path().extension().is_some_and(|ext| ext == "nasl") {
+            let relative_path = e.path().strip_prefix(Path::new(&rp)).unwrap();
+            files.push(relative_path.to_owned());
         }
     }
     files
 }
 
 pub struct FakeVerifier<'a> {
-    loader: &'a FSPluginLoader,
+    loader: &'a Loader,
     files: Vec<PathBuf>,
 }
 
 impl<'a> FakeVerifier<'a> {
-    pub fn new(loader: &'a FSPluginLoader) -> Self {
+    pub fn new(loader: &'a Loader) -> Self {
         Self {
             loader,
             files: get_all_plugins(loader),

--- a/rust/src/feed_filter/main.rs
+++ b/rust/src/feed_filter/main.rs
@@ -6,8 +6,9 @@ mod error;
 
 use clap::Parser;
 use scannerlib::models::{Scan, VT};
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::nasl::syntax::grammar::{Ast, Atom, Expr, FnCall, Statement};
-use scannerlib::nasl::{Code, FSPluginLoader, nasl_std_functions};
+use scannerlib::nasl::{Code, nasl_std_functions};
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::io::{self};
@@ -401,13 +402,13 @@ impl ScriptPath {
 
 struct ScriptReader<'a> {
     feed_path: PathBuf,
-    loader: FSPluginLoader,
+    loader: Loader,
     builtins: &'a BuiltinFunctions,
 }
 
 impl<'a> ScriptReader<'a> {
     fn new(feed_path: PathBuf, builtins: &'a BuiltinFunctions) -> Self {
-        let loader = FSPluginLoader::new(&feed_path);
+        let loader = Loader::from_feed_path(&feed_path);
         Self {
             feed_path,
             loader,

--- a/rust/src/nasl/builtin/ssh/tests/mod.rs
+++ b/rust/src/nasl/builtin/ssh/tests/mod.rs
@@ -17,7 +17,6 @@ use server::AuthConfig;
 use server::TestServer;
 
 use crate::check_err_matches;
-use crate::nasl::NoOpLoader;
 use crate::nasl::builtin::ssh::SshError;
 use crate::nasl::builtin::ssh::error::SshErrorKind;
 use crate::nasl::builtin::ssh::sessions::MIN_SESSION_ID;
@@ -42,7 +41,7 @@ fn default_config() -> ServerConfig {
 }
 
 async fn run_test(
-    f: impl Fn(&mut TestBuilder<NoOpLoader, InMemoryStorage>) + Send + Sync + 'static,
+    f: impl Fn(&mut TestBuilder<InMemoryStorage>) + Send + Sync + 'static,
     config: ServerConfig,
 ) {
     // Acquire the global lock to prevent multiple
@@ -64,9 +63,7 @@ async fn run_test(
 }
 
 #[tokio::main]
-async fn run_client(
-    f: impl Fn(&mut TestBuilder<NoOpLoader, InMemoryStorage>) + Send + Sync + 'static,
-) {
+async fn run_client(f: impl Fn(&mut TestBuilder<InMemoryStorage>) + Send + Sync + 'static) {
     std::thread::sleep(Duration::from_millis(100));
     let mut t = TestBuilder::default();
     f(&mut t);

--- a/rust/src/nasl/code.rs
+++ b/rust/src/nasl/code.rs
@@ -3,9 +3,8 @@ use std::path::{Path, PathBuf};
 use codespan_reporting::files::SimpleFile;
 
 use super::{
-    Loader,
     error::Level,
-    syntax::{DescriptionBlock, LoadError, ParseError, Parser, Tokenizer, grammar::Ast},
+    syntax::{DescriptionBlock, LoadError, Loader, ParseError, Parser, Tokenizer, grammar::Ast},
 };
 
 fn parse(code: &str) -> Result<Ast, Vec<ParseError>> {
@@ -88,7 +87,7 @@ pub struct Code {
 }
 
 impl Code {
-    pub fn load(loader: &dyn Loader, path: impl AsRef<Path>) -> Result<Self, LoadError> {
+    pub fn load(loader: &Loader, path: impl AsRef<Path>) -> Result<Self, LoadError> {
         Ok(Self {
             code: loader.load(&path.as_ref().to_string_lossy())?,
             path: Some(path.as_ref().to_owned()),

--- a/rust/src/nasl/interpreter/include.rs
+++ b/rust/src/nasl/interpreter/include.rs
@@ -4,28 +4,12 @@
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, string::String};
+    use std::collections::HashMap;
 
+    use crate::nasl::syntax::Loader;
     use crate::nasl::test_utils::TestBuilder;
-    use crate::nasl::{Loader, syntax::LoadError};
 
     use crate::nasl::prelude::*;
-
-    struct FakeInclude {
-        plugins: HashMap<String, String>,
-    }
-
-    impl Loader for FakeInclude {
-        fn load(&self, key: &str) -> Result<String, LoadError> {
-            self.plugins
-                .get(key)
-                .cloned()
-                .ok_or_else(|| LoadError::NotFound(String::default()))
-        }
-        fn root_path(&self) -> Result<String, LoadError> {
-            Ok(String::default())
-        }
-    }
 
     #[test]
     fn function_variable() {
@@ -37,8 +21,7 @@ mod tests {
         }
         "#
         .to_string();
-        let plugins = HashMap::from([("example.inc".to_string(), example)]);
-        let loader = FakeInclude { plugins };
+        let loader = Loader::test().with_file("example.inc", example).build();
         let code = r#"
         include("example.inc");
         a;

--- a/rust/src/nasl/mod.rs
+++ b/rust/src/nasl/mod.rs
@@ -25,7 +25,6 @@ pub mod prelude {
     pub use super::code::Code;
     pub use super::interpreter::NaslValue;
     pub use super::interpreter::Register;
-    pub use super::syntax::FSPluginLoader;
     pub use super::syntax::Loader;
     pub use super::utils::ArgumentError;
     pub use super::utils::FnError;
@@ -48,8 +47,6 @@ pub mod prelude {
 pub use prelude::*;
 
 pub use builtin::nasl_std_functions;
-
-pub use syntax::NoOpLoader;
 
 #[cfg(test)]
 mod test_prelude {

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -277,7 +277,7 @@ pub struct ScanCtx<'a> {
     /// Storage
     storage: &'a dyn ContextStorage,
     /// Loader
-    loader: &'a dyn Loader,
+    loader: &'a Loader,
     /// Function executor.
     executor: &'a Executor,
     /// NVT object, which is put into the storage, when set
@@ -296,7 +296,7 @@ impl<'a> ScanCtx<'a> {
         target: CtxTarget,
         filename: PathBuf,
         storage: &'a dyn ContextStorage,
-        loader: &'a dyn Loader,
+        loader: &'a Loader,
         executor: &'a Executor,
         scan_preferences: ScanPrefs,
         alive_test_methods: Vec<AliveTestMethods>,
@@ -378,8 +378,9 @@ impl<'a> ScanCtx<'a> {
     pub fn storage(&self) -> &dyn ContextStorage {
         self.storage
     }
+
     /// Get the loader
-    pub fn loader(&self) -> &dyn Loader {
+    pub fn loader(&self) -> &Loader {
         self.loader
     }
 
@@ -640,7 +641,7 @@ pub struct ScriptCtx {
 
 pub struct ScanCtxBuilder<'a, P: AsRef<Path>> {
     pub storage: &'a dyn ContextStorage,
-    pub loader: &'a dyn Loader,
+    pub loader: &'a Loader,
     pub executor: &'a Executor,
     pub scan_id: ScanID,
     pub target: Target,

--- a/rust/src/notus/loader/fs.rs
+++ b/rust/src/notus/loader/fs.rs
@@ -131,10 +131,10 @@ where
         let p = self.root.as_ref().to_str().unwrap_or_default();
         check_signature(p)
     }
+
     /// Get the notus products root directory
-    fn get_root_dir(&self) -> Result<String, Error> {
-        let path = self.root.as_ref().to_str().unwrap();
-        Ok(path.to_string())
+    fn root_path(&self) -> &Path {
+        self.root.as_ref()
     }
 }
 

--- a/rust/src/notus/loader/hashsum.rs
+++ b/rust/src/notus/loader/hashsum.rs
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+use std::path::Path;
+
 use greenbone_scanner_framework::models::Product;
 
-use crate::nasl::syntax::{FSPluginLoader, Loader};
+use crate::nasl::syntax::Loader;
 
 use crate::feed::check_signature;
 use crate::feed::{HashSumNameLoader, SignatureChecker, VerifyError};
@@ -13,15 +15,15 @@ use crate::notus::error::{Error, LoadProductErrorKind};
 
 use super::{AdvisoryLoader, FeedStamp, ProductLoader};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HashsumProductLoader {
-    loader: FSPluginLoader,
+    loader: Loader,
 }
 
 impl SignatureChecker for HashsumProductLoader {}
 
 impl HashsumProductLoader {
-    pub fn new(loader: FSPluginLoader) -> Self {
+    pub fn new(loader: Loader) -> Self {
         Self { loader }
     }
 }
@@ -84,24 +86,24 @@ impl ProductLoader for HashsumProductLoader {
 
     /// Perform a signature check of the sha256sums file
     fn verify_signature(&self) -> Result<(), VerifyError> {
-        let path = self.loader.root_path().unwrap();
+        let path = self.loader.root_path();
         check_signature(&path)
     }
-    fn get_root_dir(&self) -> Result<String, Error> {
-        let p = self.loader.root_path().unwrap();
-        Ok(p)
+
+    fn root_path(&self) -> &Path {
+        self.loader.root_path()
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HashsumAdvisoryLoader {
-    loader: FSPluginLoader,
+    loader: Loader,
 }
 
 impl SignatureChecker for HashsumAdvisoryLoader {}
 
 impl HashsumAdvisoryLoader {
-    pub fn new(loader: FSPluginLoader) -> Result<Self, Error> {
+    pub fn new(loader: Loader) -> Result<Self, Error> {
         Ok(Self { loader })
     }
 }
@@ -150,11 +152,10 @@ impl AdvisoryLoader for HashsumAdvisoryLoader {
 
     /// Perform a signature check of the sha256sums file
     fn verify_signature(&self) -> Result<(), VerifyError> {
-        let path = self.loader.root_path().unwrap();
-        check_signature(&path)
+        check_signature(&self.loader.root_path())
     }
-    fn get_root_dir(&self) -> Result<String, Error> {
-        let p = self.loader.root_path().unwrap();
-        Ok(p)
+
+    fn root_path(&self) -> &Path {
+        self.loader.root_path()
     }
 }

--- a/rust/src/notus/loader/mod.rs
+++ b/rust/src/notus/loader/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::time::SystemTime;
+use std::{path::Path, time::SystemTime};
 
 // Maybe move products to notus so they are the same as advisories
 use greenbone_scanner_framework::models::Product;
@@ -35,7 +35,7 @@ pub trait ProductLoader {
     /// Verify the signature of the Hashsum file
     fn verify_signature(&self) -> Result<(), VerifyError>;
     /// Get the root directory of the notus products
-    fn get_root_dir(&self) -> Result<String, Error>;
+    fn root_path(&self) -> &Path;
 }
 
 /// Trait for an AdvisoryLoader
@@ -48,5 +48,5 @@ pub trait AdvisoryLoader {
     /// Verify the signature of the Hashsum file
     fn verify_signature(&self) -> Result<(), VerifyError>;
     /// Get the root directory of the notus products
-    fn get_root_dir(&self) -> Result<String, Error>;
+    fn root_path(&self) -> &Path;
 }

--- a/rust/src/notus/mod.rs
+++ b/rust/src/notus/mod.rs
@@ -27,7 +27,7 @@ pub use loader::hashsum::HashsumProductLoader;
 pub use notus::Notus;
 use tokio::sync::RwLock;
 
-use crate::nasl::FSPluginLoader;
+use crate::nasl::syntax::Loader;
 
 pub fn path_to_products<P>(
     path: P,
@@ -36,7 +36,7 @@ pub fn path_to_products<P>(
 where
     P: AsRef<Path>,
 {
-    let loader = FSPluginLoader::new(path);
+    let loader = Loader::from_feed_path(path);
     let loader = HashsumProductLoader::new(loader);
     Arc::new(RwLock::new(Notus::new(loader, signature_check)))
 }

--- a/rust/src/notus/notus.rs
+++ b/rust/src/notus/notus.rs
@@ -49,7 +49,7 @@ where
 
     fn load_new_product(&self, os: &str) -> Result<(Product, FeedStamp), Error> {
         tracing::debug!(
-            root=?self.loader.get_root_dir(),
+            root=?self.loader.root_path(),
             "Loading notus product",
         );
         let (product, stamp) = self.loader.load_product(os)?;

--- a/rust/src/openvasd/vts/mod.rs
+++ b/rust/src/openvasd/vts/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use greenbone_scanner_framework::{GetVTsError, StreamResult};
 use scannerlib::PinBoxFut;
-use scannerlib::nasl::FSPluginLoader;
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::notus::{AdvisoryLoader, HashsumAdvisoryLoader};
 use scannerlib::{
     models::{FeedState, FeedType, VTData},
@@ -39,7 +39,7 @@ fn sumfile_hash<S>(path: S) -> Result<String, scannerlib::feed::VerifyError>
 where
     S: AsRef<Path> + Clone + std::fmt::Debug + Sync + Send,
 {
-    let loader = scannerlib::nasl::FSPluginLoader::new(path);
+    let loader = Loader::from_feed_path(path);
     let verifier = scannerlib::feed::HashSumNameLoader::sha256(&loader)?;
     verifier.sumfile_hash()
 }
@@ -211,7 +211,7 @@ where
     };
 
     synchronize_json::<_, VulnerabilityData, _>(ps, &hash, move |sender| {
-        let loader = FSPluginLoader::new(&path);
+        let loader = Loader::from_feed_path(&path);
         let advisories_files =
             HashsumAdvisoryLoader::new(loader.clone()).map_err(error_vts_error)?;
         for filename in advisories_files

--- a/rust/src/scanner/mod.rs
+++ b/rust/src/scanner/mod.rs
@@ -39,35 +39,31 @@ use async_trait::async_trait;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
-use crate::nasl::syntax::{FSPluginLoader, Loader};
+use crate::nasl::syntax::Loader;
 use crate::nasl::utils::Executor;
 use crate::nasl::utils::scan_ctx::ContextStorage;
 use crate::scheduling::SchedulerStorage;
 use crate::scheduling::WaveExecutionPlan;
 use crate::storage::Remover;
 use crate::storage::ScanID;
-use crate::storage::inmemory::InMemoryStorage;
 use greenbone_scanner_framework::models;
 use running_scan::{RunningScan, RunningScanHandle};
-
-pub type DefaultScannerStack = (Arc<InMemoryStorage>, FSPluginLoader);
 
 /// Allows starting, stopping and managing the results of new scans.
 pub struct OpenvasdScanner<S: ScannerStack> {
     running: Arc<RwLock<HashMap<String, RunningScanHandle>>>,
     storage: Arc<S::Storage>,
-    loader: Arc<S::Loader>,
+    loader: Arc<Loader>,
     function_executor: Arc<Executor>,
 }
 
-impl<St, L> OpenvasdScanner<(St, L)>
+impl<St> OpenvasdScanner<St>
 where
     St: ContextStorage + SchedulerStorage + Sync + Send + Clone + 'static,
-    L: Loader + 'static,
 {
     // TODO: Actually use this or rewrite it.
     #[allow(unused)]
-    fn new(storage: St, loader: L, executor: Executor) -> Self {
+    fn new(storage: St, loader: Loader, executor: Executor) -> Self {
         Self {
             running: Arc::new(RwLock::new(HashMap::default())),
             storage: Arc::new(storage),

--- a/rust/src/scanner/running_scan.rs
+++ b/rust/src/scanner/running_scan.rs
@@ -10,7 +10,7 @@ use std::{
     time::SystemTime,
 };
 
-use crate::nasl::utils::Executor;
+use crate::nasl::{syntax::Loader, utils::Executor};
 use crate::scanner::Error;
 use crate::{
     scanner::scan_runner::ScanRunner,
@@ -29,7 +29,7 @@ use super::{ScannerStack, scan::Scan};
 pub struct RunningScan<S: ScannerStack> {
     scan: Scan,
     storage: Arc<S::Storage>,
-    loader: Arc<S::Loader>,
+    loader: Arc<Loader>,
     function_executor: Arc<Executor>,
     keep_running: Arc<AtomicBool>,
     status: Arc<RwLock<Status>>,
@@ -49,7 +49,7 @@ impl<S: ScannerStack> RunningScan<S> {
     pub fn start<Sch: ExecutionPlan + 'static>(
         scan: Scan,
         storage: Arc<S::Storage>,
-        loader: Arc<S::Loader>,
+        loader: Arc<Loader>,
         function_executor: Arc<Executor>,
     ) -> RunningScanHandle
     where
@@ -106,7 +106,7 @@ impl<S: ScannerStack> RunningScan<S> {
             .map_err(make_scheduling_error)?;
         ScanRunner::new(
             &*self.storage,
-            &*self.loader,
+            &self.loader,
             &self.function_executor,
             schedule,
             &self.scan,

--- a/rust/src/scanner/scan_runner.rs
+++ b/rust/src/scanner/scan_runner.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+use crate::nasl::syntax::Loader;
 use crate::nasl::utils::Executor;
 use crate::nasl::utils::scan_ctx::Target;
 use futures::{Stream, stream};
@@ -43,7 +44,7 @@ fn all_positions(hosts: Vec<Target>, vts: Vec<ConcurrentVT>) -> impl Iterator<It
 pub struct ScanRunner<'a, S: ScannerStack> {
     scan: &'a Scan,
     storage: &'a S::Storage,
-    loader: &'a S::Loader,
+    loader: &'a Loader,
     executor: &'a Executor,
     concurrent_vts: Vec<ConcurrentVT>,
 }
@@ -51,7 +52,7 @@ pub struct ScanRunner<'a, S: ScannerStack> {
 impl<'a, Stack: ScannerStack> ScanRunner<'a, Stack> {
     pub fn new<Sched>(
         storage: &'a Stack::Storage,
-        loader: &'a Stack::Loader,
+        loader: &'a Loader,
         executor: &'a Executor,
         schedule: Sched,
         scan: &'a Scan,

--- a/rust/src/scanner/scanner_stack.rs
+++ b/rust/src/scanner/scanner_stack.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use crate::nasl::syntax::Loader;
-
 use crate::nasl::utils::scan_ctx::ContextStorage;
 use crate::scheduling::{ConcurrentVT, ConcurrentVTResult, SchedulerStorage, VTError};
 
@@ -15,16 +13,14 @@ pub trait Schedule: Iterator<Item = ConcurrentVTResult> + Sized {
 
 impl<T> Schedule for T where T: Iterator<Item = ConcurrentVTResult> {}
 
+// TODO: Remove this trait, now that it is just one associated type?
 pub trait ScannerStack {
     type Storage: ContextStorage + SchedulerStorage + Clone + 'static;
-    type Loader: Loader + Send + 'static;
 }
 
-impl<S, L> ScannerStack for (S, L)
+impl<S> ScannerStack for S
 where
     S: ContextStorage + SchedulerStorage + Clone + 'static,
-    L: Loader + Send + 'static,
 {
     type Storage = S;
-    type Loader = L;
 }

--- a/rust/src/scanner/vt_runner.rs
+++ b/rust/src/scanner/vt_runner.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 
 use crate::nasl::interpreter::{ForkingInterpreter, InterpreterError};
+use crate::nasl::syntax::Loader;
 use crate::nasl::utils::lookup_keys::SCRIPT_PARAMS;
 use crate::nasl::utils::scan_ctx::{ContextStorage, Ports, Target};
 use crate::nasl::utils::{Executor, Register};
@@ -29,7 +30,7 @@ use super::{
 /// Runs a single VT to completion on a single host.
 pub struct VTRunner<'a, S: ScannerStack> {
     storage: &'a S::Storage,
-    loader: &'a S::Loader,
+    loader: &'a Loader,
     executor: &'a Executor,
 
     target: &'a Target,
@@ -49,7 +50,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub async fn run(
         storage: &'a Stack::Storage,
-        loader: &'a Stack::Loader,
+        loader: &'a Loader,
         executor: &'a Executor,
         target: &'a Target,
         ports: &'a Ports,

--- a/rust/src/scannerctl/feed/update.rs
+++ b/rust/src/scannerctl/feed/update.rs
@@ -4,9 +4,10 @@
 
 use std::path::Path;
 
+use scannerlib::feed;
 use scannerlib::feed::FakeVerifier;
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::nasl::utils::scan_ctx::ContextStorage;
-use scannerlib::{feed, nasl::FSPluginLoader};
 
 use crate::CliError;
 use crate::notus_update::update::signature_error;
@@ -18,9 +19,9 @@ where
     tracing::debug!("description run syntax in {path:?}.");
     // needed to strip the root path so that we can build a relative path
     // e.g. 2006/something.nasl
-    let loader = FSPluginLoader::new(path);
+    let loader = Loader::from_feed_path(path);
     let verifier = feed::HashSumNameLoader::sha256(&loader)?;
-    let updater = feed::Update::init("1", 5, &loader, &storage, verifier);
+    let updater = feed::Update::init("1", 5, loader.clone(), &storage, verifier);
 
     if signature_check {
         match updater.verify_signature() {
@@ -52,9 +53,9 @@ where
     tracing::debug!("description run syntax in {path:?}.");
     // needed to strip the root path so that we can build a relative path
     // e.g. 2006/something.nasl
-    let loader = FSPluginLoader::new(path);
+    let loader = Loader::from_feed_path(path);
     let verifier = FakeVerifier::new(&loader);
-    let updater = feed::Update::init("1", 5, &loader, &storage, verifier);
+    let updater = feed::Update::init("1", 5, loader.clone(), &storage, verifier);
 
     updater.perform_update().await?;
 

--- a/rust/src/scannerctl/notus_update/update.rs
+++ b/rust/src/scannerctl/notus_update/update.rs
@@ -10,7 +10,8 @@ use crate::{CliError, CliErrorKind};
 
 use scannerlib::feed;
 use scannerlib::nasl::WithErrorInfo;
-use scannerlib::nasl::syntax::{FSPluginLoader, LoadError};
+use scannerlib::nasl::syntax::LoadError;
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::notus::advisories::VulnerabilityData;
 use scannerlib::notus::{AdvisoryLoader, HashsumAdvisoryLoader};
 use scannerlib::storage::Dispatcher;
@@ -40,7 +41,7 @@ pub fn run<S>(storage: S, path: PathBuf, signature_check: bool) -> Result<(), Cl
 where
     S: NotusStorage,
 {
-    let loader = FSPluginLoader::new(path);
+    let loader = Loader::from_feed_path(path);
     let advisories_files = match HashsumAdvisoryLoader::new(loader.clone()) {
         Ok(loader) => loader,
         Err(_) => {

--- a/rust/src/scannerctl/syntax/check.rs
+++ b/rust/src/scannerctl/syntax/check.rs
@@ -4,25 +4,12 @@
 
 use std::path::Path;
 
-use scannerlib::nasl::syntax::LoadError;
+use scannerlib::nasl::Code;
+use scannerlib::nasl::syntax::Loader;
 use scannerlib::nasl::syntax::grammar::Statement;
-use scannerlib::nasl::syntax::load_non_utf8_path;
-use scannerlib::nasl::{Code, Loader};
 use walkdir::WalkDir;
 
 use crate::CliError;
-
-struct NonUtf8Loader;
-
-impl Loader for NonUtf8Loader {
-    fn load(&self, key: &str) -> Result<String, LoadError> {
-        load_non_utf8_path(key)
-    }
-
-    fn root_path(&self) -> Result<String, LoadError> {
-        Ok(".".to_owned())
-    }
-}
 
 fn print_results(path: &Path, verbose: bool) -> Result<usize, CliError> {
     let mut num_errors = 0;
@@ -30,8 +17,8 @@ fn print_results(path: &Path, verbose: bool) -> Result<usize, CliError> {
     let print_stmt = |stmt: &Statement| {
         println!("{}: {}", path.to_string_lossy(), stmt);
     };
-
-    let results = Code::load(&NonUtf8Loader, path)?.parse();
+    let loader = Loader::from_feed_path(".");
+    let results = Code::load(&loader, path)?.parse();
     num_errors += results.num_errors();
     if let Ok(stmts) = results.emit_errors()
         && verbose


### PR DESCRIPTION
Previously, we used a mix of proper generics (`L: Loader`)  and dynamic dispatch (`Box<dyn Loader>`). These are now replaced  with a single struct (`Loader`) encapsulating dynamic dispatch  internally. All `L: Loader` generics were removed.

The point of the `Loader` (now `NaslLoader`) trait is to allow  dependency injection for file loading in tests. There are two use cases  for this trait:
1. Loading directly from a file system in normal operation (sometimes also used in tests).
2. Loading fake files from given strings in tests.

Number 2 was either via an impl of the trait for `Fn(&str) -> String` closures or via custom trait impls at the test site. These are now provided via a single `TestLoader` that is visible via the `Loader::test()` API.
