### PR TITLE
docs: add community Ansible Role for OpenVAS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ for the Greenbone Community Edition.
 
 > Please beware: The Greenbone Community Container are currently under development.
 
+## Community Resources
+
+- [Ansible Role for OpenVAS](https://gitlab.com/ndaal_open_source/ndaal_public_ansible_role_openvas_red_hat_9_debian_12_derivates) - Automated deployment for Debian 12 and AlmaLinux 9 with High Availability support
+
 ## Support
 
 For any question on the usage of `openvas` please use the [Greenbone


### PR DESCRIPTION
## Summary
Add a Community Resources section to README.md with a link to the community-maintained Ansible Role for OpenVAS.

## Details
This PR adds a reference to the Ansible Role created by ndaal Open Source team that provides:
- Automated deployment for Debian 12 and AlmaLinux 9
- High Availability support
- PostgreSQL 16 hardening
- SELinux/AppArmor integration

Closes #1918