### PR TITLE
Fix: scans stuck in running when catalog is not resolveable

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/host_info.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/host_info.rs
@@ -53,7 +53,6 @@ impl HostInfo {
 
     pub fn finish(&mut self) {
         self.remaining_vts_per_host.clear();
-        assert_eq!(self.queued, 0);
     }
 
     pub fn update_with(mut self, other: &HostInfo) -> Self {

--- a/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
@@ -312,8 +312,8 @@ pub async fn set_scan_images(
         });
         let query = builder.build();
         query.execute(&mut *tx).await?;
-        tx.commit().await?;
     }
+    tx.commit().await?;
     Ok(())
 }
 


### PR DESCRIPTION
When a scan has an unresolveable catalog (e.g. wrong credentials) then the scan was stuck in running because the tx.commit only happened if there were successful images.

The fix is to commit outside the successful branch instead of in it.

https://jira.greenbone.net/browse/SC-1507

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
