### PR TITLE
Changes default for container-image-scanner parallel scans / batch size

### DIFF
--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -100,5 +100,5 @@ max_connections = 1
 
 [container_image_scanner.image]
 extract_to = '/tmp/openvasd/cis'
-max_scanning = 1
-batch_size = 1
+max_scanning = 23
+batch_size = 5

--- a/rust/src/openvasd/container_image_scanner/config/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/config/mod.rs
@@ -205,8 +205,8 @@ impl Default for Image {
     fn default() -> Self {
         Self {
             extract_to: Default::default(),
-            max_scanning: 1,
-            batch_size: 1,
+            max_scanning: 23, // 23 scans
+            batch_size: 5,    // 5 concurrent images
         }
     }
 }


### PR DESCRIPTION
Changes the default amount of parallel scans within container-image-scanner to 23 and the batch size to 5.

Which means it could potentially open 23 * 5 concurrent connections.