### PR TITLE
Fix: handling of images with sha256sum instead of tag

### DIFF
--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -16,6 +16,23 @@ pub struct Image {
     tag: Option<String>,
 }
 
+impl Image {
+    pub fn image(&self) -> Option<&str> {
+        self.image.as_ref().map(|x| x as &str)
+    }
+
+    fn is_sha256(&self) -> bool {
+        self.tag
+            .as_ref()
+            .map(|x| x.starts_with("sha256:"))
+            .unwrap_or_default()
+    }
+
+    pub fn tag(&self) -> Option<&str> {
+        self.tag.as_ref().map(|x| x as &str)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ImageParseError {
     #[error("Empty input")]
@@ -64,7 +81,13 @@ impl Display for Image {
                 registry,
                 image: Some(image),
                 tag: Some(tag),
-            } => write!(f, "oci://{registry}/{image}:{tag}"),
+            } => {
+                if self.is_sha256() {
+                    write!(f, "oci://{registry}/{}@{}", image, tag)
+                } else {
+                    write!(f, "oci://{registry}/{image}:{tag}")
+                }
+            }
         }
     }
 }
@@ -91,7 +114,16 @@ impl FromStr for Image {
 
         let full_image = image_parts.join("/");
         let (image, tag) = match full_image.rsplit_once(':') {
-            Some((img, t)) => (img.to_string(), Some(t.to_string())),
+            Some((img, t)) => {
+                if img.ends_with("@sha256") {
+                    (
+                        img.strip_suffix("@sha256").unwrap_or_default().to_string(),
+                        Some(format!("sha256:{t}")),
+                    )
+                } else {
+                    (img.to_string(), Some(t.to_string()))
+                }
+            }
             None => (full_image, None),
         };
         result.image = Some(image);
@@ -117,6 +149,25 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parse_shasum() {
+        let user_input = "narf.io/myuser/myimage@sha256:abc1234def56789";
+        let parsed = user_input.parse();
+        assert_eq!(
+            parsed,
+            Ok(Image {
+                registry: "narf.io".to_owned(),
+                image: Some("myuser/myimage".to_owned()),
+                tag: Some("sha256:abc1234def56789".to_owned())
+            })
+        );
+        assert_eq!(
+            parsed.unwrap().to_string(),
+            "oci://narf.io/myuser/myimage@sha256:abc1234def56789"
+        )
+    }
+
     #[test]
     fn parse_tag_with_port() {
         let user_input = "oci://myregistry:6969/myimage:mytag";

--- a/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
@@ -123,6 +123,7 @@ async fn start_scan(pool: &Pool<Sqlite>, id: &str) -> Result<(), sqlx::error::Er
         .bind(status)
         .bind(id)
     }
+
     with_scan_status(pool, id, |status| {
         let mut queries = Vec::new();
 
@@ -335,7 +336,9 @@ pub async fn set_scan_images(
     if success_count > 0 {
         let mut builder = QueryBuilder::new("INSERT OR IGNORE INTO images (id, image)");
         builder.push_values(images.into_iter().filter_map(|x| x.ok()), |mut b, image| {
-            b.push_bind(id).push_bind(image.to_string());
+            let oci = image.to_string();
+            tracing::debug!(oci, "Resolved");
+            b.push_bind(id).push_bind(oci);
         });
         let query = builder.build();
         query.execute(&mut *tx).await?;


### PR DESCRIPTION
When images don't have explicit tags set they use a sha256sum in the form of 'sha256sum:...'.

https://jira.greenbone.net/browse/SC-1516