### PR TITLE
Fix: no operating system or unknown OS scan failed

### DIFF
--- a/rust/src/notus/notus.rs
+++ b/rust/src/notus/notus.rs
@@ -79,8 +79,10 @@ where
 
     fn compare<P: Package>(packages: &Vec<P>, vts: &VulnerabilityTests<P>) -> NotusResults {
         let mut results: NotusResults = HashMap::new();
+        tracing::trace!(vts_keys = ?vts.keys().collect::<Vec<_>>(), packages=?packages.iter().map(|x|x.get_name()).collect::<Vec<_>>());
         for package in packages {
-            match vts.get(&package.get_name()) {
+            let pname = package.get_name();
+            match vts.get(&pname) {
                 Some(vts) => {
                     for vt in vts {
                         if vt.is_vulnerable(package) {
@@ -113,6 +115,11 @@ where
         vts: &VulnerabilityTests<P>,
     ) -> Result<NotusResults, Error> {
         let packages = Self::parse(packages)?;
+        tracing::debug!(
+            packages = packages.len(),
+            vts = vts.len(),
+            "vulnerability loaded."
+        );
         Ok(Self::compare(&packages, vts))
     }
 
@@ -161,6 +168,7 @@ where
                 &self.loaded_products[&os.to_string()].0
             }
         };
+        tracing::debug!(os, packages = packages.len(), "products known.");
 
         // Parse and compare package list depending on package type of loaded product
         let results = match product {


### PR DESCRIPTION
When there is no operating system information available (e.g. because it is a FROM scratch image) or if we just don't know the OS yet we should NOT consider the scan a failure.
