### PR TITLE
Add: benchmarks for container-image-scanner

### DIFF
--- a/rust/src/openvasd/container_image_scanner/benchy.rs
+++ b/rust/src/openvasd/container_image_scanner/benchy.rs
@@ -1,0 +1,164 @@
+use std::time::Duration;
+
+use sqlx::{SqlitePool, query};
+use tokio::time::Instant;
+
+#[derive(Default, Debug, Copy, Clone)]
+pub enum BenchType {
+    #[default]
+    Download,
+    Extraction,
+    Scan,
+    All,
+}
+
+impl From<&str> for BenchType {
+    fn from(value: &str) -> Self {
+        match value {
+            "download" => Self::Download,
+            "extraction" => Self::Extraction,
+            "all" => Self::All,
+            _ => Self::Scan,
+        }
+    }
+}
+
+impl AsRef<str> for BenchType {
+    fn as_ref(&self) -> &str {
+        match self {
+            BenchType::Download => "download",
+            BenchType::Extraction => "extraction",
+            BenchType::Scan => "scan",
+            BenchType::All => "download + extraction + scan",
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Benched {
+    kind: BenchType,
+    micro_seconds: u128,
+    layer_index: Option<usize>,
+}
+
+impl Benched {
+    pub fn new(layer_index: Option<usize>, kind: BenchType, micro_seconds: u128) -> Self {
+        Self {
+            kind,
+            micro_seconds,
+            layer_index,
+        }
+    }
+
+    pub fn download(layer_index: usize, duration: &Duration) -> Self {
+        Self::new(Some(layer_index), BenchType::Download, duration.as_micros())
+    }
+
+    pub fn scan(duration: &Duration) -> Self {
+        Self::new(None, BenchType::Scan, duration.as_micros())
+    }
+
+    pub fn extraction(layer_index: usize, duration: &Duration) -> Self {
+        Self::new(
+            Some(layer_index),
+            BenchType::Extraction,
+            duration.as_micros(),
+        )
+    }
+
+    pub fn kind(&self) -> BenchType {
+        self.kind
+    }
+
+    pub fn micro_seconds(&self) -> u128 {
+        self.micro_seconds
+    }
+
+    pub fn msg(&self) -> String {
+        if let Some(layer_index) = self.layer_index {
+            format!(
+                "layer({}) {} took {}ms ({}μs)",
+                layer_index,
+                self.kind.as_ref(),
+                self.micro_seconds / 1000,
+                self.micro_seconds
+            )
+        } else {
+            format!(
+                "{} took {}ms ({}μs)",
+                self.kind.as_ref(),
+                self.micro_seconds / 1000,
+                self.micro_seconds
+            )
+        }
+    }
+
+    pub async fn store(&self, pool: &SqlitePool, scan_id: &str, image: &str) {
+        if let Err(error) = query(
+            r#"INSERT INTO timed_layer (scan_id, image, layer_index, kind, micro_seconds)
+            VALUES(?, ?, ?, ?, ?)"#,
+        )
+        .bind(scan_id)
+        .bind(image)
+        .bind(self.layer_index.map(|x| x as i64).unwrap_or_default())
+        .bind(self.kind.as_ref())
+        .bind(self.micro_seconds as i64)
+        .execute(pool)
+        .await
+        {
+            tracing::warn!(?self, %error, "Unable to store. Layer duration lost.")
+        }
+    }
+    pub async fn retrieve(pool: &SqlitePool, scan_id: &str, image: &str) -> Vec<Benched> {
+        use sqlx::Row;
+        let result = query(
+            r#"SELECT layer_index, kind, micro_seconds
+               FROM timed_layer
+               WHERE scan_id = ? AND image = ? "#,
+        )
+        .bind(scan_id)
+        .bind(image)
+        .fetch_all(pool)
+        .await;
+
+        if let Err(error) = &result {
+            tracing::warn!(scan_id, image, %error, "Unable to retrieve. Layer duration lost.")
+        }
+        result
+            .unwrap_or_default()
+            .iter()
+            .map(|row| Benched {
+                kind: BenchType::from(row.get::<&str, _>("kind")),
+                // it's very unlikely that we ever reach the duration limit of i64
+                micro_seconds: row.get::<i64, _>("micro_seconds") as u128,
+                layer_index: Some(row.get::<i64, _>("layer_index") as usize),
+            })
+            .collect()
+    }
+}
+
+pub struct Measured<T>(Duration, T);
+
+impl<T> Measured<T> {
+    pub fn unpack(self) -> (Duration, T) {
+        (self.0, self.1)
+    }
+}
+
+pub async fn measure<F, Out>(f: F) -> Measured<Out>
+where
+    F: Future<Output = Out>,
+{
+    let start = Instant::now();
+    let result = f.await;
+    let elapsed = start.elapsed();
+    Measured(elapsed, result)
+}
+
+pub async fn measure_result<F, OK, ERR>(f: F) -> Result<Measured<OK>, ERR>
+where
+    F: Future<Output = Result<OK, ERR>>,
+{
+    let start = Instant::now();
+    f.await.map(|x| Measured(start.elapsed(), x))
+}

--- a/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
+++ b/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
@@ -902,7 +902,8 @@ mod test {
             // internal log messages per found host
             assert_eq!(
                 internal.len(),
-                fakes.success_scan().target.hosts.len(),
+                // one os and architecture, download, extract, scan, combined timings per image
+                fakes.success_scan().target.hosts.len() * 5,
                 "Expected internal log messages"
             );
             assert_eq!(

--- a/rust/src/openvasd/container_image_scanner/image/extractor/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/extractor/mod.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use thiserror::Error;
 use tokio::{fs::File, io::BufReader};
@@ -47,10 +47,11 @@ where
     where
         Self: Sized + Send + Sync;
 
-    fn push(&mut self, layer: PackedLayer) -> PinBoxFut<Result<(), ExtractorError>>;
+    /// Extracts the given Layer and returns the duration needed to extract
+    fn extract(&mut self, layer: PackedLayer) -> PinBoxFut<Result<Duration, ExtractorError>>;
 
     /// Returns an Locator per architecture
-    fn extract(self) -> PinBoxFut<Vec<Self::Item>>;
+    fn locator(self) -> PinBoxFut<Vec<Self::Item>>;
 }
 
 pub trait Locator {

--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::{fmt::Display, str::FromStr, time::Duration};
 
 mod registry;
 pub use registry::{
@@ -46,6 +46,7 @@ pub struct PackedLayer {
     pub data: Vec<u8>,
     pub index: usize,
     pub arch: String,
+    pub download_time: Duration,
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/openvasd/container_image_scanner/messages.rs
+++ b/rust/src/openvasd/container_image_scanner/messages.rs
@@ -1,0 +1,153 @@
+use std::fmt::Display;
+
+use scannerlib::{SQLITE_LIMIT_VARIABLE_NUMBER, models};
+use sqlx::{Acquire, QueryBuilder, Row, SqlitePool, query};
+
+#[derive(Debug, Clone)]
+pub struct CustomerMessage<T> {
+    kind: models::ResultType,
+    image: Option<T>,
+    msg: String,
+    detail: Option<models::Detail>,
+}
+
+impl<T> CustomerMessage<T> {
+    fn new(
+        kind: models::ResultType,
+        image: Option<T>,
+        msg: String,
+        detail: Option<models::Detail>,
+    ) -> Self {
+        Self {
+            kind,
+            image,
+            msg,
+            detail,
+        }
+    }
+
+    pub fn log(image: Option<T>, msg: String, detail: Option<models::Detail>) -> Self {
+        Self::new(models::ResultType::Log, image, msg, detail)
+    }
+
+    pub fn error(image: Option<T>, msg: String, detail: Option<models::Detail>) -> Self {
+        Self::new(models::ResultType::Error, image, msg, detail)
+    }
+}
+
+impl<T> CustomerMessage<T>
+where
+    T: Display + Clone,
+{
+    pub async fn store(self, pool: &SqlitePool, scan_id: &str) {
+        store(pool, scan_id, &[self]).await
+    }
+}
+
+impl<T> From<CustomerMessage<T>> for models::Result
+where
+    T: Display,
+{
+    fn from(val: CustomerMessage<T>) -> Self {
+        models::Result {
+            id: 0, // id is set on storage
+            r_type: val.kind,
+            ip_address: None,
+            hostname: val.image.map(|x| x.to_string()),
+            oid: Some("openvasd/container-image-scanner".to_owned()),
+            port: None,
+            protocol: None,
+            message: Some(val.msg),
+            detail: val.detail,
+        }
+    }
+}
+
+pub async fn store<'a, T>(pool: &SqlitePool, id: &str, results: &'a [T])
+where
+    T: 'a + Into<models::Result> + Clone,
+{
+    if let Err(error) = try_store(pool, id, results).await {
+        tracing::warn!(%error, id, amount_of_results=results.len(), "Scan results lost.");
+    }
+}
+
+pub async fn try_store<'a, T>(
+    pool: &SqlitePool,
+    id: &str,
+    results: &'a [T],
+) -> Result<(), sqlx::Error>
+where
+    T: 'a + Into<models::Result> + Clone,
+{
+    if results.is_empty() {
+        return Ok(());
+    }
+    let mut conn = pool.acquire().await?;
+    let mut tx = conn.begin().await?;
+    let base_id = match query(
+        r#"
+                SELECT COUNT(*) AS result_count
+                FROM results
+                WHERE scan_id = ? "#,
+    )
+    .bind(id)
+    .fetch_one(&mut *tx)
+    .await
+    {
+        Ok(x) => x.get::<i64, _>("result_count"),
+        Err(sqlx::Error::RowNotFound) => 0,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+    tracing::trace!(id, base_id, "Results.");
+    let mut builder = QueryBuilder::new(
+        r#"
+            INSERT INTO results (
+                scan_id,
+                id,
+                type,
+                ip_address,
+                hostname,
+                oid,
+                port,
+                protocol,
+                message,
+                detail_name,
+                detail_value,
+                source_type,
+                source_name,
+                source_description
+            ) 
+            "#,
+    );
+
+    for results in results.chunks(SQLITE_LIMIT_VARIABLE_NUMBER / 14) {
+        builder.push_values(results.iter().enumerate(), |mut b, (idx, result)| {
+            let result: models::Result = result.to_owned().into();
+            let detail = result.detail.unwrap_or_default();
+            b.push_bind(id)
+                .push_bind(idx as i64 + base_id)
+                .push_bind(result.r_type.to_string())
+                .push_bind(result.ip_address.unwrap_or_default())
+                .push_bind(result.hostname.unwrap_or_default())
+                .push_bind(result.oid.unwrap_or_default())
+                .push_bind(result.port.unwrap_or_default())
+                .push_bind(result.protocol.map(|x| x.to_string()).unwrap_or_default())
+                .push_bind(result.message.unwrap_or_default())
+                .push_bind(detail.name)
+                .push_bind(detail.value)
+                .push_bind(detail.source.s_type)
+                .push_bind(detail.source.name)
+                .push_bind(detail.source.description);
+        });
+
+        let query = builder.build();
+        query.execute(&mut *tx).await?;
+    }
+
+    tx.commit().await?;
+
+    Ok(())
+}

--- a/rust/src/openvasd/container_image_scanner/migrations/20260105085544_image-time-tracking.sql
+++ b/rust/src/openvasd/container_image_scanner/migrations/20260105085544_image-time-tracking.sql
@@ -1,0 +1,13 @@
+-- Is used to track the micro seconds it took to download and extract each layer
+
+
+CREATE TABLE timed_layer(
+    layer_index INTEGER NOT NULL,
+    scan_id INTEGER NOT NULL,
+    image TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK(kind IN ('download', 'extraction')),
+    micro_seconds INTEGER, 
+    PRIMARY KEY (layer_index, scan_id, image, kind),
+    FOREIGN KEY (scan_id, image) REFERENCES images(id, image) ON DELETE CASCADE
+);
+

--- a/rust/src/openvasd/container_image_scanner/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/mod.rs
@@ -1,3 +1,4 @@
+mod benchy;
 pub mod config;
 use std::{
     sync::{Arc, RwLock},
@@ -13,6 +14,7 @@ use sqlx::migrate::Migrator;
 mod detection;
 pub mod endpoints;
 mod image;
+mod messages;
 mod notus;
 mod scheduling;
 pub(crate) use scannerlib::{ExternalError, PinBoxFut, PinBoxFutRef, Streamer};


### PR DESCRIPTION
To allow customers to benchmark container-image-scanner this adds log
messages for tracking the time of:
- download of all image layer
- extraction of all image layer
- scan of all image layers
- scan + download + extraction of all image layers

in the form of results of type `log`.

As an example:
```json
  {
    "id": 6,
    "type": "log",
    "ip_address": "",
    "hostname": "oci://example/image:tag",
    "oid": "openvasd/container-image-scanner",
    "port": 0,
    "message": "scan took 17ms (17057μs)",
    "detail": {
      "name": "",
      "value": "",
      "source": {
        "type": "",
        "name": "",
        "description": ""
      }
    }
  },
  {
    "id": 7,
    "type": "log",
    "ip_address": "",
    "hostname": "oci://example/image:tag",
    "oid": "openvasd/container-image-scanner",
    "port": 0,
    "message": "extraction took 673ms (673621μs)",
    "detail": {
      "name": "",
      "value": "",
      "source": {
        "type": "",
        "name": "",
        "description": ""
      }
    }
  },
  {
    "id": 8,
    "type": "log",
    "ip_address": "",
    "hostname": "oci://example/image:tag",
    "oid": "openvasd/container-image-scanner",
    "port": 0,
    "message": "download took 103330ms (103330481μs)",
    "detail": {
      "name": "",
      "value": "",
      "source": {
        "type": "",
        "name": "",
        "description": ""
      }
    }
  },
  {
    "id": 9,
    "type": "log",
    "ip_address": "",
    "hostname": "oci://example/image:tag",
    "oid": "openvasd/container-image-scanner",
    "port": 0,
    "message": "download + extraction + scan took 104021ms (104021159μs)",
    "detail": {
      "name": "",
      "value": "",
      "source": {
        "type": "",
        "name": "",
        "description": ""
      }
    }
  },
```

https://jira.greenbone.net/browse/SC-1525