### PR TITLE
Fix: segmentation fault when calling rs-notus

### DIFF
--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -1052,6 +1052,13 @@ call_rs_notus (const char *ip_str, const char *hostname, const char *pkg_list,
     return -1;
 
   advisories = lsc_process_response (body, strlen (body));
+  g_free (body);
+
+  if (!advisories)
+    {
+      g_message ("%s: Unable to process response", __func__);
+      return -1;
+    }
 
   // Process the advisories, generate results and store them in the kb
   for (size_t i = 0; i < advisories->count; i++)


### PR DESCRIPTION
**What**:

The current patch fixes an issue that produced a segmentation fault when the notus response didn't have advisories. 
Also, fix a leak.
Jira: SC-1529

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Missing null check before accessing a pointer.
<!-- Why are these changes necessary? -->

**How**:
This issue is only reproducible using an outdated feed which still runs a table driven lsc, with a openvas-scanner version >= 23.34.0

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
