### PR TITLE
Fix: Add deprecation notice for scanning member of host_info

### DIFF
--- a/rust/doc/openapi.yml
+++ b/rust/doc/openapi.yml
@@ -973,7 +973,13 @@ components:
           type: "integer"
           format: "int32"
         scanning:
-          description: "The IP Addresses of the currently scanned hosts."
+          deprecated: true
+          description: |
+            The current implementation is not implemented in accordance with the
+            API spec as it does not return a list of hosts (strings) but a list of host (string) : progress (int32) pairs.
+
+            Although still available, we highly recommend not using it for progress information/calculation.
+            A more suitable API definition and implementation will be done in the next major API version. We apologize for the inconvenience.
           type: "array"
           items:
             type: "string"
@@ -1311,7 +1317,11 @@ components:
               "alive": 6,
               "queued": 1,
               "finished": 1,
-              "scanning": ["127.0.0.1", "10.0.5.1", "10.0.5.2", "10.0.5.3"],
+              "scanning": [
+                "127.0.0.1": 80,
+                "10.0.5.1": 55,
+                "10.0.5.3": 40
+              ]
             },
         }
 


### PR DESCRIPTION
The current implementation is not implemented in accordance with the API spec as it does not return a list of hosts (strings) but a list of host (string) : progress (int32) pairs.

Although still available, we highly recommend not using it for progress information/calculation. We will change this scanning member to provide more granular information that can be used for per-host progress calculation by the API user. This will be part of the next major version.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
