### PR TITLE
Doc: improve documentation about arrays element order

### DIFF
--- a/doc/manual/nasl/built-in-functions/misc/keys.md
+++ b/doc/manual/nasl/built-in-functions/misc/keys.md
@@ -13,6 +13,11 @@
 ## DESCRIPTION
 
 Keys returns an array with the keys of a dict.
+Memory for each key-value tuple is reserved separately and allocated memory do
+not necessarily return contiguous memory addresses because of how dynamic
+memory allocation works in C and how the operating system manages memory.
+Therefore, key-value tuples do not necessarily keep the order in which
+they were stored.
 
 ## Returns
 

--- a/doc/manual/nasl/built-in-functions/misc/make_array.md
+++ b/doc/manual/nasl/built-in-functions/misc/make_array.md
@@ -15,6 +15,12 @@
 Takes any even number of unnamed arguments and returns an dictionary made from them.
 Each uneven argument will be the key while each even argument is the value.
 
+Memory for each key-value tuple is reserved separately and allocated memory do not
+necessarily return contiguous memory addresses because of how dynamic memory allocation
+works in C and how the operating system manages memory. Therefore, key-value tuples
+do not necessarily keep the order in which they were stored.
+
+
 ## RETURN VALUE
 
 Returns a dictionary made out of the arguments.

--- a/doc/manual/nasl/built-in-functions/misc/make_list.md
+++ b/doc/manual/nasl/built-in-functions/misc/make_list.md
@@ -16,6 +16,10 @@ Takes any number of unnamed arguments and returns an array made from them.
 
 It can also be used to flatten arrays.
 
+Internally, make list `realloc()`ates memory, which guarantees that
+the returned memory block is contiguous. Therefore, elements keep the
+order in which they were stored.
+
 ## RETURN VALUE
 
 Returns an indexed array made out of the arguments. The index starts at 0.


### PR DESCRIPTION
**What**:
Improve documentation about arrays element order
Jira: SC-1506
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Nasl doesn't keep the order in which elements are added to a nasl array. This is because nasl individually allocates memory for each element, and the memory address is not contiguous. This depends on C language and the operating system.

On the oder hand, `make_list()` keeps the order, since it `realloc()`s for each element, and guarantees that the returned memory block is contiguous

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
