### PR TITLE
Fix: Skiron Data parsing and result publishing

### DIFF
--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -454,7 +454,7 @@ advisories_new_skiron ()
 {
   advisories_t *advisories_list = g_malloc0 (sizeof (advisories_t));
   advisories_list->max_size = 100;
-  advisories_list->skiron_advisory =
+  advisories_list->skiron_advisories =
     g_malloc0_n (advisories_list->max_size, sizeof (skiron_advisory_t));
   advisories_list->type = SKIRON;
 
@@ -569,6 +569,17 @@ advisory_free (advisory_t *notus_advisory)
   notus_advisory = NULL;
 }
 
+static void
+skiron_advisory_free (skiron_advisory_t *skiron_advisory)
+{
+  if (skiron_advisory == NULL)
+    return;
+
+  g_free (skiron_advisory->oid);
+  g_free (skiron_advisory->message);
+  skiron_advisory = NULL;
+}
+
 /** @brief Free()'s an advisories
  *
  *  @param notus_advisory The advisories holder to be free()'ed.
@@ -579,9 +590,13 @@ advisories_free (advisories_t *advisories)
 {
   if (advisories == NULL)
     return;
-
   for (size_t i = 0; i < advisories->count; i++)
-    advisory_free (advisories->advisories[i]);
+    {
+      if (advisories->type == NOTUS)
+        advisory_free (advisories->advisories[i]);
+      else
+        skiron_advisory_free (advisories->skiron_advisories[i]);
+    }
   advisories = NULL;
 }
 

--- a/misc/table_driven_lsc.h
+++ b/misc/table_driven_lsc.h
@@ -91,7 +91,7 @@ struct advisories
   union
   {
     advisory_t **advisories;
-    skiron_advisory_t **skiron_advisory;
+    skiron_advisory_t **skiron_advisories;
   };
   advisory_type_t type;
   size_t count;

--- a/nasl/nasl_scanner_glue.c
+++ b/nasl/nasl_scanner_glue.c
@@ -1141,12 +1141,17 @@ security_notus (lex_ctxt *lexic)
   // type|||IP|||HOSTNAME|||package|||OID|||the result message|||URI
   kb_result = g_strdup_printf ("%s|||%s|||%s|||%s|||%s|||%s|||%s", "ALARM",
                                ip_str, " ", "package", oid, result_string, "");
-  g_free (result_string);
+
+  // Only free result_string for notus type, as skiron uses a reference to a
+  // nasl var
+  if (notus_type == NOTUS)
+    g_free (result_string);
+
   kb_item_push_str_with_main_kb_check (get_main_kb (), "internal/results",
                                        kb_result);
   g_free (kb_result);
 
-  return NULL;
+  return FAKE_CELL;
 }
 
 /**
@@ -1387,7 +1392,7 @@ parse_skiron (advisories_t *adv)
 
   for (size_t i = 0; i < adv->count; i++)
     {
-      skiron_advisory_t *advisory = adv->skiron_advisory[i];
+      skiron_advisory_t *advisory = adv->skiron_advisories[i];
       anon_nasl_var msg, oid;
 
       memset (&element, 0, sizeof (element));
@@ -1407,8 +1412,8 @@ parse_skiron (advisories_t *adv)
       add_var_to_array (&element.v.v_arr, "message", &msg);
       add_var_to_list (retc->x.ref_val, i, &element);
     }
-
   advisories_free (adv);
+
   return retc;
 }
 


### PR DESCRIPTION
There were 2 major flaws within the Skiron implementation:

1. When Skiron results were parsed und transformed to NASL, the origin struct was freed. This free was the same for notus and skiron advisories which lead to a segmentation fault

2. When publishing Skiron result, it is slightly different then Notus: Skiron results already contain the result message, where as in Notus results they have to be created first. In the end they were freed, which lead to a double free for Skiron, as the result string was just taken from a NASL var


Scan-Config for testing:
```json
{
    "target": {
        "hosts": [
            "127.0.0.1"
        ],
        "ports": [
            {
                "range": [
                    {
                        "start": 80
                    }
                ]
            },
            {
                "range": [
                    {
                        "start": 22
                    }
                ]
            },
            {
                "range": [
                    {
                        "start": 8080
                    }
                ]
            },
            {
                "range": [
                    {
                        "start": 443
                    }
                ]
            }
        ],
        "credentials": [
            {
                "service": "ssh",
                "port": 22,
                "up": {
                    "username": "user",
                    "password": "pw"
                }
            }
        ]
    },
    "vts": [
        {
            "oid": "1.3.6.1.4.1.25623.1.0.50282"
        }
    ]
}
```

The contained OID is `gather-package-list.nasl`, which triggers a notus scan

For a small Skiron test Server I implemented a small rust service with a static response:
```rust
use std::io::{Read, Write};
use std::net::{TcpListener, TcpStream};
use std::thread;

const RESPONSE_JSON: &str = r#"[
    {
        "oid": "1.3.6.1.4.1.25623.1.1.1.2.2022.3200",
        "message": "Vulnerable package:   libzmq3-dev\nInstalled version:    libzmq3-dev-4.3.0-4+deb10u1\nFixed version:       >=libzmq3-dev-4.3.1-4+deb10u2\n\nVulnerable package:   libzmq5\nInstalled version:    libzmq5-4.3.1-4+deb10u1\nFixed version:       >=libzmq5-4.3.1-4+deb10u2"
    },
    {
        "oid": "1.3.6.1.4.1.25623.1.1.1.2.2022.3201",
        "message": "Vulnerable package:   libzmq3-dev\nInstalled version:    libzmq3-dev-4.3.0-4+deb10u1\nFixed version:       >=libzmq3-dev-4.3.1-4+deb10u1"
    }
]"#;

fn main() -> std::io::Result<()> {
    let addr = "127.0.0.1:3001";
    let listener = TcpListener::bind(addr)?;
    println!("Starting server on http://{addr}");

    println!("Serving static JSON response for all requests:");
    println!("{}", RESPONSE_JSON);

    for stream in listener.incoming() {
        match stream {
            Ok(stream) => {
                thread::spawn(|| handle_client(stream));
            }
            Err(err) => eprintln!("Failed connection: {err}"),
        }
    }

    Ok(())
}

fn handle_client(mut stream: TcpStream) {
    println!("New connection from {}", stream.peer_addr().unwrap());
    let mut buffer = [0_u8; 4096];
    let _ = stream.read(&mut buffer);

    let body = RESPONSE_JSON.as_bytes();
    let response = format!(
        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
        body.len(),
        RESPONSE_JSON
    );

    let _ = stream.write_all(response.as_bytes());
    let _ = stream.flush();
}
```

Remember to adjust the `openvasd_server` in the `openvas.conf` file