### PR TITLE
Fix: segmentation fault when a port is out of range

### DIFF
--- a/nasl/nasl_builtin_openvas_tcp_scanner.c
+++ b/nasl/nasl_builtin_openvas_tcp_scanner.c
@@ -283,6 +283,17 @@ banner_grab (const struct in6_addr *pia, const char *portrange,
                         }
                     }
                 }
+
+              if (po1 > 65535)
+                {
+                  g_message ("%s: Wrong port '%d'. It will be skipped.", __func__, po1);
+                  continue;
+                }
+              if (po2 > 65535)
+                {
+                  g_message ("%s: Wrong port '%d'. It will be skipped.", __func__, po2);
+                  continue;
+                }
             }
           for (i = po1; i <= po2; i++)
             {


### PR DESCRIPTION
**What**:
Jira: SC-1552
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
`openvas-nasl -X -r "22,79000" plugin_run_openvas_tcp_scanner.nasl -t 127.0.0.1`

```
plugin_run_openvas_tcp_scanner();

open = get_kb_item( "TCPScanner/OpenPortsNb" );
display( "Open Ports: " + open );

closed = get_kb_item( "TCPScanner/ClosedPortsNb" );
display( "Closed Ports: " + closed );

filtered = get_kb_item( "TCPScanner/FilteredPortsNb" );
display( "Filtered Ports: " + filtered );

rst = get_kb_item( "TCPScanner/RSTRateLimit" );
display( "RST Rate Limit: " + rst );

display();
display( "RTT Stats:");

display();
display( "open:");

mean_rtt = get_kb_item( "TCPScanner/open/MeanRTT");
display( "Mean RTT: " + mean_rtt );
mean_rtt1000 = get_kb_item( "TCPScanner/open/MeanRTT1000");
display( "Mean RTT (ms): " + mean_rtt1000 );
max_rtt = get_kb_item( "TCPScanner/open/MaxRTT");
display( "Max RTT: " + max_rtt );
max_rtt1000 = get_kb_item( "TCPScanner/open/MaxRTT1000");
display( "Max RTT (ms): " + max_rtt1000 );
sdrtt = get_kb_item( "TCPScanner/open/SDRTT");
display( "SD RTT: " + sdrtt );
sdrtt1000 = get_kb_item( "TCPScanner/open/SDRTT1000");
display( "SD RTT (ms): " + sdrtt1000 );
estimated_max_rtt = get_kb_item( "TCPScanner/open/EstimatedMaxRTT");
display( "Estimated Max RTT: " + estimated_max_rtt );
estimated_max_rtt1000 = get_kb_item( "TCPScanner/open/EstimatedMaxRTT1000");
display( "Estimated Max RTT (ms): " + estimated_max_rtt1000 );

display();
display( "closed:");
mean_rtt = get_kb_item( "TCPScanner/closed/MeanRTT");
display( "Mean RTT: " + mean_rtt );
mean_rtt1000 = get_kb_item( "TCPScanner/closed/MeanRTT1000");
display( "Mean RTT (ms): " + mean_rtt1000 );
max_rtt = get_kb_item( "TCPScanner/closed/MaxRTT");
display( "Max RTT: " + max_rtt );
max_rtt1000 = get_kb_item( "TCPScanner/closed/MaxRT1000");
display( "Max RTT (ms): " + max_rtt1000 );
sdrtt = get_kb_item( "TCPScanner/closed/SDRTT");
display( "SD RTT: " + sdrtt );
sdrtt1000 = get_kb_item( "TCPScanner/closed/SDRTT1000");
display( "SD RTT (ms): " + sdrtt1000 );
estimated_max_rtt = get_kb_item( "TCPScanner/closed/EstimatedMaxRTT");
display( "Estimated Max RTT: " + estimated_max_rtt );
estimated_max_rtt1000 = get_kb_item( "TCPScanner/closed/EstimatedMaxRTT1000");
display( "Estimated Max RTT (ms): " + estimated_max_rtt1000 );

display();
display( "unfiltered:");
mean_rtt = get_kb_item( "TCPScanner/unfiltered/MeanRTT");
display( "Mean RTT: " + mean_rtt );
mean_rtt1000 = get_kb_item( "TCPScanner/unfiltered/MeanRTT1000");
display( "Mean RTT (ms): " + mean_rtt1000 );
max_rtt = get_kb_item( "TCPScanner/unfiltered/MaxRTT");
display( "Max RTT: " + max_rtt );
max_rtt1000 = get_kb_item( "TCPScanner/unfiltered/MaxRTT1000");
display( "Max RTT (ms): " + max_rtt1000 );
sdrtt = get_kb_item( "TCPScanner/unfiltered/SDRTT");
display( "SD RTT: " + sdrtt );
sdrtt1000 = get_kb_item( "TCPScanner/unfiltered/SDRTT1000");
display( "SD RTT (ms): " + sdrtt1000 );
estimated_max_rtt = get_kb_item( "TCPScanner/unfiltered/EstimatedMaxRTT");
display( "Estimated Max RTT: " + estimated_max_rtt );
estimated_max_rtt1000 = get_kb_item( "TCPScanner/unfiltered/EstimatedMaxRTT1000");
display( "Estimated Max RTT (ms): " + estimated_max_rtt1000 );

for (port = 0; port < 65536; port++) {
    banner = get_kb_item( "Banner/" + port );
    if( banner ) {
        display();
        display( "Port: " + port );
        display( "Banner: " + banner );
    } else {
        continue;
    }

    rw_time = get_kb_item( "TCPScanner/RwTime/" + port);
    display( "RW Time: " + rw_time );

    rw_time1000 = get_kb_item( "TCPScanner/RwTime1000/" + port);
    display( "RW Time (ms): " + rw_time1000 );

    cnx_time = get_kb_item( "TCPScanner/CnxTime/" + port);
    display( "Connection Time: " + cnx_time );

    cnx_time1000 = get_kb_item( "TCPScanner/CnxTime1000/" + port);
    display( "Connection Time (ms): " + cnx_time1000 );
    
}
```
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
