### PR TITLE
Fix: Log message for 0 notus results

### DIFF
--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -653,8 +653,7 @@ lsc_process_response_notus (JsonReader *reader)
 
   if (!members || !members[0])
     {
-      g_debug ("No members found");
-      return NULL;
+      return advisories;
     }
 
   for (int i = 0; members[i]; i++)
@@ -755,7 +754,7 @@ lsc_process_response_notus (JsonReader *reader)
               g_free (installed_version);
               g_free (item1);
               g_free (item2);
-              advisory_free(notus_advisory);
+              advisory_free (notus_advisory);
               advisories_free (advisories);
               return NULL;
             }


### PR DESCRIPTION
In case Notus did not detect any vulnerabilities, the result parser logged a message, that could lead to the conclusion that some error occured: `Unable to process the response`.

Jira: SC-1559