### PR TITLE
Fix: removes hardcoded 10s loop for configuration option

### DIFF
--- a/compose/base.yaml
+++ b/compose/base.yaml
@@ -111,6 +111,7 @@ services:
       XDG_CACHE_HOME: /var/cache/
       STORAGE_TYPE: ${OPENVAS_SCANNER_STORAGE_TYPE:-fs}
       LISTENING: 0.0.0.0:3000
+      OPENVASD_LOG: DEBUG
     volumes:
       - openvas_data_vol:/etc/openvas
       - openvas_log_data_vol:/var/log/openvas

--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -87,11 +87,18 @@ max_connections = 1
 
 [container_image_scanner.image]
 extract_to = '/tmp/openvasd/cis'
-# Configures the amount of images that may be scanned concurrently
-max_scanning = 10
 # How many times an image scan should be retried on a failure that is retryable
 scanning_retries = 10
-# Configures the amount of images that should be processed in one batch synchronously
+# Configures the amount of images that may be scanned concurrently
+# The recommended configuration of max_scanning and batch_size is:
+# 10:2 for a 1000mb/s
+# 25:2 for a 2500mb/s
+# 50:2 for a 5000mb/s
+# 100:2 for a 10000mb/s
+# Assuming a median size of 100mb per image.
+max_scanning = 10
+# Configures the amount of images that should be processed in one batch synchronously.
+# Additionally this controls the amount of seconds a loop checks if images can be scanned.
 batch_size = 2
 # How long openvasd should pause before retrying
 retry_timeout = "1s"

--- a/rust/src/openvasd/container_image_scanner/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/mod.rs
@@ -1,9 +1,6 @@
 mod benchy;
 pub mod config;
-use std::{
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::sync::{Arc, RwLock};
 
 pub use config::Config;
 use futures::{Stream, StreamExt};
@@ -105,7 +102,7 @@ pub async fn init(
         products,
     );
     tokio::spawn(async move {
-        scheduler.run::<AllTypes>(Duration::from_secs(10)).await;
+        scheduler.run::<AllTypes>().await;
     });
 
     let scan = Scans {

--- a/rust/src/openvasd/container_image_scanner/scheduling/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/mod.rs
@@ -364,10 +364,21 @@ where
         Some(())
     }
 
-    pub async fn run<T>(mut self, check_interval: Duration)
+    pub async fn run<T>(mut self)
     where
         T: ToNotus,
     {
+        // we use the batch_size as the check_interval this allows customers to express:
+        // 10:2 for a 1000mb/s
+        // 25:2 for a 2500mb/s
+        // 50:2 for a 5000mb/s
+        // 100:2 for a 10000mb/s
+        // and so on.
+        let check_interval = Duration::from_secs(if self.config.image.batch_size == 0 {
+            1
+        } else {
+            self.config.image.batch_size as u64
+        });
         let mut interval = time::interval(check_interval);
         let config = self.config.clone();
 


### PR DESCRIPTION
Uses the batch_size to configure the amount of seconds of the processing loop within container_image_scanner.

This allows the customer to configure throughput without introducing friction of a secondary parameter.

For an example to configure a throughput of 1GB/s a customer can configure:

```toml
[container_image_scanner.image]
max_scanning = 10
batch_size = 2
```

assuming a median image size of 100mB.