### PR TITLE
Fix: allow multiple inc with the same name on openvas -u

### DIFF
--- a/nasl/exec.c
+++ b/nasl/exec.c
@@ -1654,7 +1654,7 @@ exec_nasl_script (struct script_infos *script_infos, int mode)
   else
     ctx.kb = plug_get_kb (script_infos);
 
-  if (init_nasl_ctx (&ctx, name) == 0)
+  if (init_nasl_ctx (&ctx, NULL, name) == 0)
     {
       err = naslparse (&ctx, &error_counter);
       if (err != 0 || error_counter > 0)

--- a/nasl/nasl_global_ctxt.h
+++ b/nasl/nasl_global_ctxt.h
@@ -30,7 +30,7 @@ typedef struct
 } naslctxt;
 
 int
-init_nasl_ctx (naslctxt *, const char *);
+init_nasl_ctx (naslctxt *, const char *, const char *);
 
 void
 nasl_clean_ctx (naslctxt *);


### PR DESCRIPTION
When updating the feed the inc files should not be limited to the
basename, as those could be duplicated.

Instead it uses the relative path as defined in the sha256sums file for
inc files while sticking to full path for nasl files.

The reason is that init_nasl_ctx is called with the full path, except
when it was called from an include instruction. In that case it uses the
specified call parameter which typically is as defined in the
sha256sums file. 

To normalize this we exclude the base path when we have a full qualified path.

To tryout the issue as well as the fix, create an feed with the following content:

`a/me.inc`:
```nasl
function hello() {
    display("a");
}
```

`b/me.inc`:
```nasl
function hello() {
    display("c");
}
```

`1.nasl`:
```nasl
if (description)
{
  script_oid("0.0.0.0.0.0.0.0.0.1");
  script_version("2023-02-23T13:33:44+0000");
  script_tag(name:"last_modification", value:"2020-12-07 13:33:44 +0000 (Mon, 07 Dec 2020)");
  script_tag(name:"creation_date", value:"2009-05-12 22:04:51 +0200 (Tue, 12 May 2009)");
  script_tag(name:"cvss_base_vector", value:"AV:N/AC:L/Au:N/C:N/I:N/A:N");
  script_name("Application Server Detection (HTTP)");
  script_category(ACT_GATHER_INFO);
  script_tag(name:"qod_type", value:"remote_banner");
  script_family("Product detection");
  script_copyright("Copyright (C) 2023 Greenbone AG");
  script_tag(name:"summary", value:"HTTP AS detection");
  script_xref(name:"URL", value:"https://greenbone.net/");
  exit(0);
}
include("a/me.inc");
hello();
exit(0);
```
`sha256sums`:

```sha256sums
0637f694d109ff0a3fea47214142e206e980d89b65000c5506bafeb4ea0caef5  a/me.inc
6a7f3eb2e1ac39953d7492e1d3b3ae2e5327caee923f49cf8a3d4e52806a8047  b/me.inc
713755c135210414689bfc151c7f33e38131fed17f38ead9c1bd6a598b10f7c6  1.nasl
2013e8591ee3c1c754731960153df29252896b065e09f4899986d1e0a14a2396  plugin_feed_info.inc
```

and then configure openvas to use that feed while calling `openvas -u`.

The order of `a/me.inc` and `b/me.inc` does matter when you try to reproduce the bug without this patch.

With this patch you should not see any sha256sum miss-match messages within the log
anymore.

https://jira.greenbone.net/browse/SC-1561