### PR TITLE
Fix: Use newer product/protocol names in some service reportings.

### DIFF
--- a/misc/network.c
+++ b/misc/network.c
@@ -1778,7 +1778,7 @@ get_encaps_through (openvas_encaps_t code)
     case OPENVAS_ENCAPS_TLSv12:
     case OPENVAS_ENCAPS_TLSv13:
     case OPENVAS_ENCAPS_TLScustom:
-      return " through SSL";
+      return " through SSL/TLS";
     default:
       snprintf (str, sizeof (str),
                 " through unknown transport layer - code %d (0x%x)", code,

--- a/nasl/nasl_builtin_find_service.c
+++ b/nasl/nasl_builtin_find_service.c
@@ -404,7 +404,7 @@ mark_mysql (struct script_infos *desc, int port)
 {
   register_service (desc, port, "mysql");
   /* if (port != 3306) */
-  post_log (oid, desc, port, "A MySQL server is running on this port");
+  post_log (oid, desc, port, "A MySQL/MariaDB server is running on this port");
 }
 
 static void
@@ -1201,11 +1201,11 @@ port_to_name (int port)
     case 3128:
       return "Squid";
     case 3306:
-      return "MySQL";
+      return "MySQL/MariaDB";
     case 5000:
       return "VTUN";
     case 5432:
-      return "Postgres";
+      return "PostgreSQL";
     case 8080:
       return "HTTP-Alt";
     }

--- a/rust/data/osp/response_finished.xml
+++ b/rust/data/osp/response_finished.xml
@@ -9,14 +9,14 @@
       <result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A TLScustom server answered on this port
 
 </result>
-      <result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL
+      <result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL/TLS
 </result>
       <result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A TLScustom server answered on this port
 
 </result>
       <result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="22/tcp" qod="80" uri="">An ssh server is running on this port
 </result>
-      <result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL
+      <result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL/TLS
 </result>
       <result name="Traceroute" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.51662" port="general/tcp" qod="80" uri="">Network route from scanner (127.0.0.1) to target (127.0.0.1):
 

--- a/rust/data/osp/response_running.xml
+++ b/rust/data/osp/response_running.xml
@@ -1,11 +1,11 @@
 <get_scans_response status="200" status_text="OK"><scan id="925eb35a-f3b8-4e55-8f55-5aeb410ecd10" target="127.0.0.1,localhost" progress="14" status="running" start_time="1683537846" end_time="0"><results><result name="HOST_START" type="Log Message" severity="0.0" host="127.0.0.1" hostname="" test_id="" port="" qod="" uri="">Mon May  8 09:24:07 2023</result><result name="HOST_START" type="Log Message" severity="0.0" host="::1" hostname="" test_id="" port="" qod="" uri="">Mon May  8 09:24:07 2023</result><result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="22/tcp" qod="80" uri="">An ssh server is running on this port
 </result><result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A TLScustom server answered on this port
 
-</result><result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL
+</result><result name="Services" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL/TLS
 </result><result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A TLScustom server answered on this port
 
 </result><result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="22/tcp" qod="80" uri="">An ssh server is running on this port
-</result><result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL
+</result><result name="Services" type="Log Message" severity="0.0" host="::1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.10330" port="9090/tcp" qod="80" uri="">A web server is running on this port through SSL/TLS
 </result><result name="Traceroute" type="Log Message" severity="0.0" host="127.0.0.1" hostname="localhost" test_id="1.3.6.1.4.1.25623.1.0.51662" port="general/tcp" qod="80" uri="">Network route from scanner (127.0.0.1) to target (127.0.0.1):
 
 127.0.0.1


### PR DESCRIPTION
**What**:
- `MySQL` got changed to `MySQL/MariaDB` as the relevant code is actually already covering MariaDB via `|| strstr (buffer, "mariadb") != NULL)))`
- `Postgres` is called `PostgreSQL` these days and one text part `A PostgreSQL server is running on this port` already covered that
- `SSL` got changed to `SSL/TLS` as the `switch` / `case` call already covered both SSL 2.0 through SSL 3.0 as well as TLS 1.0 through TLS 1.3 and we should reflect this

**Why**:
Better / more up2date naming.

**How**:
N/A

**Checklist**:

- [ ] Tests
- [x] PR merge commit message adjusted