### PR TITLE
Remove experimental

### DIFF
--- a/.docker/prod-oldstable.Dockerfile
+++ b/.docker/prod-oldstable.Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /source/rust
 RUN apt update && apt install -y \
     capnproto \
     ca-certificates \
+    libclang-dev \
+    libpcap-dev \
     libsnmp-dev
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /source/rust
 RUN apt update && apt install -y \
     capnproto \
     ca-certificates \
+    libclang-dev \
+    libpcap-dev \
     libsnmp-dev
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings --no-deps
-      - run: cargo clippy --all-targets --features experimental -- -D warnings --no-deps
+      - run: cargo clippy --all-targets --features native-rust-ssh -- -D warnings --no-deps
   Rust-Typos:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,4 @@ jobs:
       - name: unit-tests
         run: cargo test --lib --tests --workspace
       - name: experimental unit-tests
-        run: cargo test --lib --tests --workspace --features experimental
+        run: cargo test --lib --tests --workspace --features native-rust-ssh

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -62,21 +62,21 @@ libc = "0.2"
 md-5 = "0.10.5"
 md2 = "0.10.2"
 md4 = "0.10.2"
-mtu = { version = "0.2.9", optional = true }
+mtu = { version = "0.2.9" }
 nix = { version = "0.29", features = ["resource"] }
 nt-time = "0.12.1"
 num-bigint = "0.4.6"
 pathdiff = "0.2.3"
 pbkdf2 = { version = "0.12.2", features = ["password-hash"] }
-pcap = { version = "2.3.0", optional = true, features = ["capture-stream"] }
+pcap = { version = "2.3.0", features = ["capture-stream"] }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem", "std"] }
-pnet = { version = "0.35.0", optional = true }
-pnet_base = { version = "0.35.0", optional = true }
-pnet_macros = { version = "0.35.0", optional = true }
-pnet_macros_support = { version = "0.35.0", optional = true }
+pnet = { version = "0.35.0" }
+pnet_base = { version = "0.35.0" }
+pnet_macros = { version = "0.35.0" }
+pnet_macros_support = { version = "0.35.0" }
 quick-xml = { version = "0.38.1", features = [
-    "serde",
-    "serde-types",
+    "serde", 
+    "serde-types", 
     "serialize",
 ] }
 rand = "0.9.2"
@@ -123,11 +123,11 @@ uuid = { workspace = true }
 libssh-rs = { version = "0.3.5", features = [
     "vendored-openssl",
     "vendored",
-], optional = true }
+] }
 
 nasl-function-proc-macro = { path = "crates/nasl-function-proc-macro" }
 greenbone-scanner-framework = { path = "crates/greenbone-scanner-framework" }
-nasl-c-lib = { path = "crates/nasl-c-lib", optional = true }
+nasl-c-lib = { path = "crates/nasl-c-lib" }
 rpmdb = { path = "crates/rpmdb-rs" }
 tar = "0"
 libflate = "2"
@@ -152,16 +152,7 @@ tar = "0"
 
 [features]
 default = ["enforce-no-trailing-arguments"]
-nasl-builtin-raw-ip = [
-    "mtu",
-    "pcap",
-    "pnet_base",
-    "pnet",
-    "pnet_macros",
-    "pnet_macros_support",
-]
-nasl-builtin-libssh = ["libssh-rs"]
-experimental = ["nasl-builtin-raw-ip", "nasl-builtin-libssh", "nasl-c-lib"]
+native-rust-ssh = []
 enforce-no-trailing-arguments = []
 
 [workspace.package]

--- a/rust/README.md
+++ b/rust/README.md
@@ -21,10 +21,8 @@ The implementation is split into multiple parts that are reflected in the direct
 - rust toolchain
 - openssl
 - libnetsnmp
-
-Additionally for the features defined as experimental you need:
-
 - libpcap
+- openssl
 - pkg-config
 - zlib
 
@@ -38,12 +36,6 @@ To build and create the executables
 You have to execute
 ```
 cargo build --release
-```
-
-To enable the experimental features:
-
-```
-cargo build -F experimental --release
 ```
 
 # Contribution

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,9 +10,8 @@
 // https://github.com/rust-lang/rust/issues/124735
 // so we have to allow it library wide.
 // See src/nasl/builtin/raw_ip/packet_forgery.rs
-#![cfg_attr(feature = "nasl-builtin-raw-ip", allow(unexpected_cfgs))]
+#![allow(unexpected_cfgs)]
 
-#[cfg(feature = "nasl-builtin-raw-ip")]
 pub mod alive_test;
 pub mod feed;
 pub mod nasl;

--- a/rust/src/nasl/builtin/cryptographic/aes_gmac.rs
+++ b/rust/src/nasl/builtin/cryptographic/aes_gmac.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
 use crate::function_set;
-#[cfg(feature = "nasl-c-lib")]
 use crate::nasl::{prelude::*, utils::function::StringOrData};
 
-#[cfg(feature = "nasl-c-lib")]
 pub fn aes_gmac(data: &[u8], key: &[u8], iv: &[u8]) -> Result<NaslValue, FnError> {
     use nasl_c_lib::cryptographic::mac::aes_gmac;
 
@@ -21,7 +19,6 @@ pub fn aes_gmac(data: &[u8], key: &[u8], iv: &[u8]) -> Result<NaslValue, FnError
 /// NASL function to calculate GMAC with AES128.
 ///
 /// This function expects 3 named arguments key, data and iv either in a string or data type.
-#[cfg(feature = "nasl-c-lib")]
 #[nasl_function(named(key, iv, data))]
 fn nasl_aes_gmac(
     key: StringOrData,
@@ -33,17 +30,9 @@ fn nasl_aes_gmac(
 
 pub struct AesGmac;
 
-#[cfg(feature = "nasl-c-lib")]
 function_set! {
     AesGmac,
     (
         (nasl_aes_gmac, "aes_mac_gcm"),
-    )
-}
-
-#[cfg(not(feature = "nasl-c-lib"))]
-function_set! {
-    AesGmac,
-    (
     )
 }

--- a/rust/src/nasl/builtin/cryptographic/smb.rs
+++ b/rust/src/nasl/builtin/cryptographic/smb.rs
@@ -16,7 +16,6 @@ fn smb_cmac_aes_signature(key: StringOrData, buf: StringOrData) -> Result<NaslVa
     aes_cmac(key.data(), buf.data())
 }
 
-#[cfg(feature = "nasl-c-lib")]
 #[nasl_function(named(key, buf, iv))]
 fn smb_gmac_aes_signature(
     key: StringOrData,
@@ -83,21 +82,10 @@ fn smb3kdf(
 }
 
 pub struct Smb;
-#[cfg(feature = "nasl-c-lib")]
 function_set! {
     Smb,
     (
         smb_gmac_aes_signature,
-        smb_cmac_aes_signature,
-        smb3kdf,
-        get_smb2_signature,
-    )
-}
-
-#[cfg(not(feature = "nasl-c-lib"))]
-function_set! {
-    Smb,
-    (
         smb_cmac_aes_signature,
         smb3kdf,
         get_smb2_signature,

--- a/rust/src/nasl/builtin/error.rs
+++ b/rust/src/nasl/builtin/error.rs
@@ -14,7 +14,6 @@ use super::find_service::FindServiceError;
 use super::host::HostError;
 use super::http::HttpError;
 use super::isotime::IsotimeError;
-#[cfg(feature = "nasl-builtin-raw-ip")]
 use super::raw_ip::RawIpError;
 use super::regex::RegexError;
 use super::snmp::SnmpError;
@@ -51,7 +50,6 @@ pub enum BuiltinError {
     FindService(FindServiceError),
     #[error("{0}")]
     Snmp(SnmpError),
-    #[cfg(feature = "nasl-builtin-raw-ip")]
     #[error("{0}")]
     RawIp(RawIpError),
     #[error("{0}")]
@@ -101,6 +99,4 @@ builtin_error_variant!(CertError, Cert);
 builtin_error_variant!(SysError, Sys);
 builtin_error_variant!(FindServiceError, FindService);
 builtin_error_variant!(SnmpError, Snmp);
-
-#[cfg(feature = "nasl-builtin-raw-ip")]
 builtin_error_variant!(RawIpError, RawIp);

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -19,7 +19,6 @@ pub mod network;
 mod snmp;
 
 mod preferences;
-#[cfg(feature = "nasl-builtin-raw-ip")]
 pub mod raw_ip;
 mod regex;
 mod report_functions;
@@ -66,9 +65,7 @@ pub fn nasl_std_functions() -> Executor {
         .add_set(snmp::Snmp)
         .add_set(cert::NaslCerts::default());
 
-    #[cfg(feature = "nasl-builtin-raw-ip")]
     executor.add_set(raw_ip::RawIp);
-    #[cfg(feature = "nasl-builtin-raw-ip")]
     executor.add_global_vars(raw_ip::RawIp);
     executor.add_global_vars(network::socket::SocketFns);
 

--- a/rust/src/nasl/builtin/network/mod.rs
+++ b/rust/src/nasl/builtin/network/mod.rs
@@ -4,7 +4,6 @@
 
 use std::{fmt::Display, net::IpAddr};
 
-#[cfg(feature = "nasl-builtin-raw-ip")]
 use crate::nasl::raw_ip_utils::raw_ip_utils;
 use crate::{
     nasl::{prelude::*, utils::DefineGlobalVars},
@@ -26,12 +25,6 @@ const MTU: usize = 512 - 60 - 8;
 /// Standard port for networking functions
 const DEFAULT_PORT: u16 = 33435;
 
-// Get the max MTU possible for network communication
-#[cfg(not(feature = "nasl-builtin-raw-ip"))]
-fn mtu(_: IpAddr) -> usize {
-    MTU
-}
-#[cfg(feature = "nasl-builtin-raw-ip")]
 fn mtu(target_ip: IpAddr) -> usize {
     match raw_ip_utils::get_mtu(target_ip) {
         Ok(mtu) => mtu,

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -143,7 +143,6 @@ impl NaslSocket {
         }
     }
 
-    #[cfg(feature = "nasl-builtin-raw-ip")]
     pub fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
             NaslSocket::Tcp(tcp_connection) => tcp_connection.write(buf),

--- a/rust/src/nasl/builtin/ssh/error.rs
+++ b/rust/src/nasl/builtin/ssh/error.rs
@@ -15,14 +15,14 @@ use super::SessionId;
 #[error("{0}")]
 struct LibError(String);
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 impl From<libssh_rs::Error> for LibError {
     fn from(e: libssh_rs::Error) -> Self {
         Self(format!("{e}"))
     }
 }
 
-#[cfg(not(feature = "nasl-builtin-libssh"))]
+#[cfg(feature = "native-rust-ssh")]
 impl From<russh::Error> for LibError {
     fn from(e: russh::Error) -> Self {
         Self(format!("{e}"))
@@ -129,7 +129,7 @@ impl WithErrorInfo<SessionId> for SshError {
     }
 }
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 impl WithErrorInfo<libssh_rs::Error> for SshError {
     type Error = SshError;
 
@@ -139,7 +139,7 @@ impl WithErrorInfo<libssh_rs::Error> for SshError {
     }
 }
 
-#[cfg(not(feature = "nasl-builtin-libssh"))]
+#[cfg(feature = "native-rust-ssh")]
 impl WithErrorInfo<russh::Error> for SshError {
     type Error = SshError;
 

--- a/rust/src/nasl/builtin/ssh/mod.rs
+++ b/rust/src/nasl/builtin/ssh/mod.rs
@@ -6,14 +6,14 @@ mod error;
 mod sessions;
 mod utils;
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 mod libssh;
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 use libssh::{AuthMethods, SessionId, Socket, SshSession};
 
-#[cfg(not(feature = "nasl-builtin-libssh"))]
+#[cfg(feature = "native-rust-ssh")]
 mod russh;
-#[cfg(not(feature = "nasl-builtin-libssh"))]
+#[cfg(feature = "native-rust-ssh")]
 use russh::{AuthMethods, SessionId, Socket, SshSession};
 
 #[cfg(test)]
@@ -31,7 +31,7 @@ use crate::nasl::prelude::*;
 use error::SshErrorKind;
 use utils::CommaSeparated;
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 mod libssh_uses {
     pub use crate::nasl::utils::function::{Maybe, StringOrData};
     pub use libssh_rs::{AuthStatus, PublicKeyHashType};
@@ -39,7 +39,7 @@ mod libssh_uses {
     pub use tracing::debug;
 }
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 use libssh_uses::*;
 
 type Result<T> = std::result::Result<T, FnError>;
@@ -67,7 +67,7 @@ impl Output {
     }
 }
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 function_set! {
     Ssh,
     (
@@ -93,7 +93,7 @@ function_set! {
     )
 }
 
-#[cfg(not(feature = "nasl-builtin-libssh"))]
+#[cfg(feature = "native-rust-ssh")]
 function_set! {
     Ssh,
     (
@@ -325,7 +325,7 @@ impl Ssh {
     }
 }
 
-#[cfg(feature = "nasl-builtin-libssh")]
+#[cfg(not(feature = "native-rust-ssh"))]
 impl Ssh {
     /// Given a socket, return the corresponding session id if available.
     #[nasl_function]

--- a/rust/src/nasl/builtin/ssh/sessions.rs
+++ b/rust/src/nasl/builtin/ssh/sessions.rs
@@ -57,7 +57,7 @@ impl SshSessions {
         Ok(())
     }
 
-    #[cfg(feature = "nasl-builtin-libssh")]
+    #[cfg(not(feature = "native-rust-ssh"))]
     pub fn ids(&self) -> impl Iterator<Item = &SessionId> {
         self.sessions.keys()
     }

--- a/rust/src/nasl/builtin/ssh/tests/mod.rs
+++ b/rust/src/nasl/builtin/ssh/tests/mod.rs
@@ -90,7 +90,7 @@ async fn ssh_connect() {
                 ArgumentError::WrongArgument(_)
             );
             // Without a matching key algorithm, we should not be able to connect
-            #[cfg(not(feature = "nasl-builtin-libssh"))]
+            #[cfg(feature = "native-rust-ssh")]
             check_err_matches!(
                 t,
                 format!(r#"id = ssh_connect(port:{PORT}, keytype: "ssh-rsa");"#),
@@ -143,7 +143,7 @@ async fn ssh_userauth() {
 // the bug does not appear when connected to an openssh
 // server. To fix this, I'd need to understand the
 // russh server code in more detail.
-#[cfg_attr(feature = "nasl-builtin-libssh", ignore)]
+#[cfg_attr(not(feature = "native-rust-ssh"), ignore)]
 async fn ssh_request_exec() {
     run_test(
         |t| {

--- a/rust/src/nasl/mod.rs
+++ b/rust/src/nasl/mod.rs
@@ -13,7 +13,6 @@ mod version;
 #[cfg(test)]
 mod test_utils;
 
-#[cfg(feature = "nasl-builtin-raw-ip")]
 pub mod raw_ip_utils {
     pub use super::builtin::raw_ip::RawIpError;
     pub use super::builtin::raw_ip::raw_ip_utils;

--- a/rust/src/nasl/test_utils.rs
+++ b/rust/src/nasl/test_utils.rs
@@ -452,7 +452,7 @@ where
         self
     }
 
-    #[cfg(all(test, feature = "experimental"))]
+    #[cfg(test)]
     /// Return a new `TestBuilder` with the given `target`.
     pub fn with_target(mut self, target: String) -> Self {
         self.target = target;

--- a/rust/src/nasl/utils/mod.rs
+++ b/rust/src/nasl/utils/mod.rs
@@ -24,8 +24,6 @@ pub type NaslResult = Result<NaslValue, FnError>;
 
 /// Allows the definition of global variables
 /// belonging to certain builtin functions.
-// This is currently only used with `experimental` feature,
-// so we mark it as public in order to save many feature gates.
 pub trait DefineGlobalVars {
     fn get_global_vars() -> Vec<(&'static str, NaslValue)>;
 }

--- a/rust/src/scannerctl/main.rs
+++ b/rust/src/scannerctl/main.rs
@@ -7,7 +7,6 @@
 // but should eventually solve this.
 #![allow(clippy::result_large_err)]
 
-#[cfg(feature = "nasl-builtin-raw-ip")]
 mod alivetest;
 mod error;
 mod execute;
@@ -87,7 +86,6 @@ enum Action {
     Execute(ExecuteArgs),
     NotusUpdate(NotusUpdateArgs),
     Feed(FeedArgs),
-    #[cfg(feature = "nasl-builtin-raw-ip")]
     Alivetest(alivetest::AliveTestArgs),
 }
 
@@ -124,7 +122,6 @@ async fn run(action: Action, verbose: bool, quiet: bool) -> Result<(), CliError>
         Action::Execute(args) => execute::run(args).await,
         Action::NotusUpdate(args) => notus_update::scanner::run(args).await,
         Action::Feed(args) => feed::run(args).await,
-        #[cfg(feature = "nasl-builtin-raw-ip")]
         Action::Alivetest(args) => alivetest::run(args).await,
     }
 }


### PR DESCRIPTION
Relates to #2121 : Go all the way and remove the `experimental` feature gate, make it the default and hide the native russh implementation behind a new `native-rust-ssh` feature.