### PR TITLE
Fix: resolve just on repository at a time

### DIFF
--- a/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/mod.rs
@@ -318,7 +318,7 @@ impl Iterator for RequestedScans {
 
 impl RequestedScans {
     pub async fn fetch(pool: &Pool<Sqlite>, limit: usize) -> RequestedScans {
-        let limit = if limit == 0 { -1 } else { limit as i64 };
+        let limit = if limit == 0 { 254 } else { limit as i64 };
         let mut stream = sqlx::query(
             r#"
         WITH running_count AS (
@@ -332,7 +332,10 @@ impl RequestedScans {
             WHERE status = 'requested'
             ORDER BY created_at ASC
             LIMIT (
-                SELECT MAX(? - running_total, 0)
+                SELECT CASE
+                    WHEN running_total < ? THEN 1
+                    ELSE 0
+                END
                 FROM running_count
             )
         )


### PR DESCRIPTION
To speed up concurrent starting of scans we should limit the fetching of requested to one scan instead of iterating through all possible scans.

This actually does speed up the starting of scans as they are now changed from running to requested each loop instead of having to wait until all the previously fetched requested scans are resolved.
