### PR TITLE
Fix: remove micro seconds from timing log

### DIFF
--- a/rust/src/openvasd/container_image_scanner/benchy.rs
+++ b/rust/src/openvasd/container_image_scanner/benchy.rs
@@ -77,18 +77,16 @@ impl Benched {
     pub fn msg(&self) -> String {
         if let Some(layer_index) = self.layer_index {
             format!(
-                "layer({}) {} took {}ms ({}μs)",
+                "layer({}) {} took {}ms",
                 layer_index,
                 self.kind.as_ref(),
                 self.micro_seconds / 1000,
-                self.micro_seconds
             )
         } else {
             format!(
-                "{} took {}ms ({}μs)",
+                "{} took {}ms",
                 self.kind.as_ref(),
                 self.micro_seconds / 1000,
-                self.micro_seconds
             )
         }
     }


### PR DESCRIPTION
Somewhere, somehow there is a parsing error that prevents the `μ` to be shown in the reports generated by gvmd as we are downloading layers and then scanning them I don't think anyone cares about micro seconds anyway.