### PR TITLE
document elf dependencies

### DIFF
--- a/rust/src/openvasd/README.md
+++ b/rust/src/openvasd/README.md
@@ -21,7 +21,14 @@ Currently it is utilizing ospd-openvas.
 
 # Requirements
 
-It requires a running ospd-openvas instance.
+```
+> readelf -d ./openvasd-x86_64-unknown-linux-gnu | grep NEEDED
+ 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
+```
+
 
 # Configuration
 

--- a/rust/src/scannerctl/README.md
+++ b/rust/src/scannerctl/README.md
@@ -52,6 +52,18 @@ Run `cargo test` to test and `cargo build --release` to build it.
 
 `cargo install --path .`
 
+It requires the dependencies:
+
+```
+> readelf -d ./scannerctl-x86_64-unknown-linux-gnu  | grep NEEDED
+ 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libpcap.so.0.8]
+ 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
+```
+
 ## Commands
 
 ### execute


### PR DESCRIPTION
Add the dynamically linked C libraries required by the prebuilt openvasd and scannerctl Linux binaries to their README files.

The dependencies were determined from the release artifacts using readelf -d ... | grep NEEDED to clarify which runtime libraries must be present on target systems.
