### PR TITLE
Fix: add detail version to best_os_cpe as other component

### DIFF
--- a/rust/src/openvasd/container_image_scanner/detection.rs
+++ b/rust/src/openvasd/container_image_scanner/detection.rs
@@ -8,7 +8,7 @@ use tokio::{
 
 use crate::container_image_scanner::image::extractor::{Locator, LocatorError};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, PartialOrd)]
 pub struct OperatingSystem {
     pub name: String,
     pub version: String,
@@ -65,7 +65,7 @@ where
     Err(OperatingSystemDetectionError::NotFound)
 }
 
-struct OperatingSystemDetector<T> {
+pub(crate) struct OperatingSystemDetector<T> {
     reader: T,
 }
 
@@ -77,7 +77,7 @@ where
         OperatingSystemDetector { reader }
     }
 
-    async fn detect_operating_system(
+    pub(crate) async fn detect_operating_system(
         self,
     ) -> Result<OperatingSystem, OperatingSystemDetectionError> {
         #[rustfmt::skip]

--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -11,7 +11,7 @@ pub use registry::docker_v2::fake::RegistryMock as DockerRegistryV2Mock;
 
 pub mod packages;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq)]
 pub struct Image {
     pub registry: String,
     pub image: Option<String>,

--- a/rust/src/openvasd/container_image_scanner/messages.rs
+++ b/rust/src/openvasd/container_image_scanner/messages.rs
@@ -52,6 +52,7 @@ impl<T> CustomerMessage<T> {
     }
 }
 
+#[derive(Debug, PartialEq, PartialOrd)]
 pub enum DetailPair<'a> {
     OS(&'a OperatingSystem),
     OSCpe(&'a OperatingSystem),
@@ -79,7 +80,19 @@ impl<'a> DetailPair<'a> {
             DetailPair::Packages(items) => items.join(","),
             DetailPair::OSCpe(os) => {
                 // as requested by customer.
-                format!("cpe:/o:{}:{}:{}", os.name, os.name, os.version_id)
+                format!(
+                    "cpe:/o:{}:{}:{}::~~~~~{}",
+                    os.name,
+                    os.name,
+                    os.version_id,
+                    os.version
+                        .chars()
+                        .map(|x| match x {
+                            x if x.is_ascii_alphanumeric() => x,
+                            _ => '_',
+                        })
+                        .collect::<String>()
+                )
             }
             DetailPair::HostName(image) => image.to_string(),
         }
@@ -182,5 +195,41 @@ where
 {
     if let Err(error) = DBResults::new(pool, (id, results)).retry_exec().await {
         tracing::warn!(%error, id, amount_of_results=results.len(), "Scan results lost.");
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::container_image_scanner::{
+        detection::OperatingSystemDetector, messages::DetailPair,
+    };
+
+    #[tokio::test]
+    async fn test_different_cpe() {
+        let content = r#"
+        Name="EulerOS"
+        VERSION="2.0 (SP12)"
+        ID="euleros"
+        VERSION_ID="2.0"
+        "#;
+        let os = OperatingSystemDetector::from(content)
+            .detect_operating_system()
+            .await
+            .unwrap();
+        let content = r#"
+        Name="EulerOS"
+        VERSION="2.0 (SP12 x86_64)"
+        ID="euleros"
+        VERSION_ID="2.0"
+        "#;
+        let os_2 = OperatingSystemDetector::from(content)
+            .detect_operating_system()
+            .await
+            .unwrap();
+        assert_ne!(
+            DetailPair::OSCpe(&os).value(),
+            DetailPair::OSCpe(&os_2).value()
+        )
     }
 }


### PR DESCRIPTION
To make it possible to display "2.0 (SP12 x86_64)" and VERSION="2.0 (SP12)" as different operating systems instead of combining them the whole version is added as other component within the cpe of best_os_cpe.
