### PR TITLE
Fix: rpm exception handling

### DIFF
--- a/rust/src/notus/packages/rpm.rs
+++ b/rust/src/notus/packages/rpm.rs
@@ -76,7 +76,7 @@ pub struct Rpm {
     module: (String, String),
 }
 
-static EXCEPTIONS: [&str; 2] = ["_fips", ".ksplice"];
+static EXCEPTIONS: [&str; 2] = [".fips", ".ksplice"];
 
 fn find_any_exception(name: &str) -> String {
     for exception in EXCEPTIONS.iter() {


### PR DESCRIPTION
In a later patch all rpm package versions are normalized and separators are replaced with a single `.`. A exception, when we do not want to compare packages, is when a package contained `_fips`. The underscore is now replaced by a `.`. So just adjusting this separator.

Jira: SC-1572