### PR TITLE
Fix: kb items for scannerctl

### DIFF
--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -439,7 +439,7 @@ impl<'a> ScanCtx<'a> {
         KbContextKey(
             (
                 self.scan.clone(),
-                storage::Target(self.target.original_target_str().to_string()),
+                storage::Target(self.target.ip_addr().to_string()),
             ),
             key,
         )
@@ -464,7 +464,7 @@ impl<'a> ScanCtx<'a> {
             .retrieve(&GetKbContextKey(
                 (
                     self.scan.clone(),
-                    storage::Target(self.target.original_target_str().into()),
+                    storage::Target(self.target.ip_addr().to_string()),
                 ),
                 key.clone(),
             ))?


### PR DESCRIPTION
There was a mismatch, when using a hostname instead of an IP address as a target. The kb items were written to the IP address, where as they were read using the original target string.

Here the corresponding KB Context Key: https://github.com/greenbone/openvas-scanner/blob/main/rust/src/scannerctl/interpret/mod.rs#L139

Jira: SC-1576