### PR TITLE
Remove all `dbg!` calls

### DIFF
--- a/rust/src/nasl/builtin/raw_ip/tcp_ping.rs
+++ b/rust/src/nasl/builtin/raw_ip/tcp_ping.rs
@@ -72,7 +72,6 @@ pub fn forge_tcp_ping_ipv4(
     tcp_flag: u8,
 ) -> Result<Ipv4Packet<'static>, RawIpError> {
     let mut tcp_buf = tcp_ping(*dport, tcp_flag);
-    dbg!(&tcp_buf);
     forge_ipv4_packet_for_tcp(&mut tcp_buf, dst)
 }
 

--- a/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/images.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/images.rs
@@ -303,13 +303,10 @@ mod test {
             ids.push(scan_id);
         }
         let validate = async |rounds, ids| {
-            for round in 0..rounds {
-                dbg!(round);
-
+            for _ in 0..rounds {
                 for id in &ids {
                     let mut requested = DBImages::new(&pool, (0, 1)).exec().await.unwrap();
                     assert_eq!(requested.len(), 1);
-                    dbg!(&requested);
                     let rid = requested.pop().unwrap().0;
                     assert_eq!(id, &rid.id);
                     // mark as failed to trigger host_finished trigger
@@ -321,13 +318,10 @@ mod test {
             }
         };
 
-        dbg!(&ids);
         validate(3, ids.clone()).await;
         ids.remove(1);
-        dbg!(&ids);
         validate(2, ids.clone()).await;
         ids.remove(1);
-        dbg!(&ids);
         validate(5, ids.clone()).await;
     }
 }

--- a/rust/src/openvasd/database/sqlite/vts.rs
+++ b/rust/src/openvasd/database/sqlite/vts.rs
@@ -261,7 +261,6 @@ mod tests {
         // we just verify if we got oids.
         let oids = endpoint.get_oids("moep".into()).collect::<Vec<_>>().await;
         let oids = oids.into_iter().filter_map(|x| x.ok()).collect::<Vec<_>>();
-        dbg!(&oids);
         assert!(!oids.is_empty());
 
         let vts = endpoint.get_vts("moep".into()).collect::<Vec<_>>().await;

--- a/rust/src/openvasd/scans/mod.rs
+++ b/rust/src/openvasd/scans/mod.rs
@@ -720,7 +720,6 @@ pub mod tests {
                 .get_scans_id_results(id.clone(), None, None)
                 .collect::<Vec<_>>()
                 .await;
-            dbg!(&result);
             assert_eq!(result.into_iter().filter_map(|x| x.ok()).count(), 2);
             let result = undertest
                 .get_scans_id_results(id.clone(), Some(1), None)

--- a/rust/src/osp/response.rs
+++ b/rust/src/osp/response.rs
@@ -861,7 +861,6 @@ mod tests {
 </get_scans_response>
             "#;
         let response: Response = from_str(xml).unwrap();
-        dbg!(&response);
         let results: Vec<greenbone_scanner_framework::models::Result> =
             response.try_into().unwrap();
         assert_eq!(results.len(), 1);

--- a/rust/src/scannerctl/scan_config.rs
+++ b/rust/src/scannerctl/scan_config.rs
@@ -317,7 +317,6 @@ where
         //consider it a scan preference if there is no associated VT
         if !oid.is_empty() {
             let parameters = preference_lookup.entry(oid).or_default();
-            dbg!(&p.id, &p.value, &p.name);
             parameters.push(Parameter {
                 id: p.id,
                 value: p.value.clone(),


### PR DESCRIPTION
Highly controversial. Remove all `dbg` statements we have lingering around the codebase in various places.