### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
       - run: cargo fmt --check
+      - run: cargo clippy -V
       - run: cargo clippy --all-targets -- -D warnings --no-deps
       - run: cargo clippy --all-targets --features native-rust-ssh -- -D warnings --no-deps
   Rust-Typos:

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Pins the rust version using `rust-toolchain.toml`. This will help with newer clippy/rustc versions causing sudden issues in the CI