### PR TITLE
Kerberos CCache

### DIFF
--- a/misc/openvas-krb5.c
+++ b/misc/openvas-krb5.c
@@ -382,6 +382,10 @@ okrb5_gss_authenticate (const OKrb5Credential *creds,
   (void) gss_release_name (&min_stat, &gss_username);
   CHECK_MAJOR_STAT ();
 
+  maj_stat = gss_store_cred (&min_stat, cred, GSS_C_INITIATE, GSS_C_NO_OID, 1,
+                             1, NULL, NULL);
+  CHECK_MAJOR_STAT ();
+
   // let spnego only use the desired mechs
   maj_stat = gss_set_neg_mechs (&min_stat, cred, &spnego_mechs);
   CHECK_MAJOR_STAT ();

--- a/misc/openvas-krb5.c
+++ b/misc/openvas-krb5.c
@@ -375,22 +375,34 @@ okrb5_gss_authenticate (const OKrb5Credential *creds,
     gss_import_name (&min_stat, &userbuf, GSS_C_NT_USER_NAME, &gss_username);
   CHECK_MAJOR_STAT ();
 
-  maj_stat = gss_acquire_cred_with_password (&min_stat, gss_username, &pwbuf, 0,
-                                             &creds_mechs, GSS_C_INITIATE,
-                                             &cred, NULL, NULL);
+  // Try to acquire credentials from the CCache first
+  maj_stat = gss_acquire_cred (&min_stat, gss_username, 0, &creds_mechs,
+                               GSS_C_INITIATE, &cred, NULL, NULL);
+  if (maj_stat != GSS_S_COMPLETE)
+    {
+      // No cached credential found, authenticate with password
+      maj_stat = gss_acquire_cred_with_password (
+        &min_stat, gss_username, &pwbuf, 0, &creds_mechs, GSS_C_INITIATE, &cred,
+        NULL, NULL);
 
-  (void) gss_release_name (&min_stat, &gss_username);
-  CHECK_MAJOR_STAT ();
+      CHECK_MAJOR_STAT ();
 
-  maj_stat = gss_store_cred (&min_stat, cred, GSS_C_INITIATE, GSS_C_NO_OID, 1,
-                             1, NULL, NULL);
-  CHECK_MAJOR_STAT ();
+      // Store the new credential in the CCache for future use
+      maj_stat = gss_store_cred (&min_stat, cred, GSS_C_INITIATE, GSS_C_NO_OID,
+                                 1, 1, NULL, NULL);
+      CHECK_MAJOR_STAT ();
+    }
 
   // let spnego only use the desired mechs
   maj_stat = gss_set_neg_mechs (&min_stat, cred, &spnego_mechs);
   CHECK_MAJOR_STAT ();
   gss_creds->gss_creds = cred;
+  cred = GSS_C_NO_CREDENTIAL;
 result:
+  if (cred != GSS_C_NO_CREDENTIAL)
+    gss_release_cred (&min_stat, &cred);
+  if (gss_username != GSS_C_NO_NAME)
+    gss_release_name (&min_stat, &gss_username);
   if (user_principal != NULL)
     free (user_principal);
   return result;

--- a/nasl/nasl_krb5.c
+++ b/nasl/nasl_krb5.c
@@ -106,6 +106,12 @@ build_krb5_credential (lex_ctxt *lexic)
       snprintf (default_config_path, sizeof (default_config_path),
                 "/tmp/krb5_%s.conf", ip_str);
       setenv ("KRB5_CONFIG", default_config_path, 1);
+
+      char default_ccache_path[256];
+      snprintf (default_ccache_path, sizeof (default_ccache_path),
+                "/tmp/krb5cc_%s", ip_str);
+      setenv ("KRB5CCNAME", default_ccache_path, 1);
+
       okrb5_set_slice_from_str (credential.config_path, default_config_path);
     }
 

--- a/nasl/nasl_krb5.c
+++ b/nasl/nasl_krb5.c
@@ -54,6 +54,8 @@ static bool gss_update_context_more = false;
 
 // Stores the path to the generated krb5 config file for cleanup.
 static char *generated_config_path = NULL;
+// Stores the path to the generated CCache file for cleanup.
+static char *generated_ccache_path = NULL;
 
 #define SET_SLICE_FROM_LEX_OR_ENV(lexic, slice, name, env_name)            \
   do                                                                       \
@@ -90,28 +92,38 @@ build_krb5_credential (lex_ctxt *lexic)
 
   char *kdc = NULL;
 
-  SET_SLICE_FROM_LEX_OR_ENV (lexic, credential.config_path, "config_path",
-                             "KRB5_CONFIG");
-  if (credential.config_path.len == 0)
+  char *ip_str = addr6_as_str (lexic->script_infos->ip);
+  for (int i = 0; ip_str[i] != '\0'; i++)
     {
-      char *ip_str = addr6_as_str (lexic->script_infos->ip);
-      for (int i = 0; ip_str[i] != '\0'; i++)
+      if (ip_str[i] == '.' || ip_str[i] == ':')
         {
-          if (ip_str[i] == '.' || ip_str[i] == ':')
-            {
-              ip_str[i] = '_';
-            }
+          ip_str[i] = '_';
         }
-      char default_config_path[256];
-      snprintf (default_config_path, sizeof (default_config_path),
-                "/tmp/krb5_%s.conf", ip_str);
-      setenv ("KRB5_CONFIG", default_config_path, 1);
+    }
 
+  // Set a per-target CCache path unconditionally, unless one is already
+  // provided via parameter or environment.
+  if (getenv ("KRB5CCNAME") == NULL
+      && get_str_var_by_name (lexic, "ccache_path") == NULL)
+    {
       char default_ccache_path[256];
       snprintf (default_ccache_path, sizeof (default_ccache_path),
                 "/tmp/krb5cc_%s", ip_str);
       setenv ("KRB5CCNAME", default_ccache_path, 1);
 
+      if (generated_ccache_path != NULL)
+        free (generated_ccache_path);
+      generated_ccache_path = strdup (default_ccache_path);
+    }
+
+  SET_SLICE_FROM_LEX_OR_ENV (lexic, credential.config_path, "config_path",
+                             "KRB5_CONFIG");
+  if (credential.config_path.len == 0)
+    {
+      char default_config_path[256];
+      snprintf (default_config_path, sizeof (default_config_path),
+                "/tmp/krb5_%s.conf", ip_str);
+      setenv ("KRB5_CONFIG", default_config_path, 1);
       okrb5_set_slice_from_str (credential.config_path, default_config_path);
     }
 
@@ -361,6 +373,12 @@ nasl_okrb5_clean (void)
       unlink (generated_config_path);
       free (generated_config_path);
       generated_config_path = NULL;
+    }
+  if (generated_ccache_path != NULL)
+    {
+      unlink (generated_ccache_path);
+      free (generated_ccache_path);
+      generated_ccache_path = NULL;
     }
 }
 

--- a/rust/src/nasl/builtin/krb5/mod.rs
+++ b/rust/src/nasl/builtin/krb5/mod.rs
@@ -253,6 +253,14 @@ impl Krb5 {
             path
         };
 
+        if std::env::var("KRB5CCNAME").is_err() {
+            let ccache_path = format!(
+                "/tmp/krb5cc_{}",
+                context.target().ip_addr().to_string().replace(".", "_")
+            );
+            unsafe { std::env::set_var("KRB5CCNAME", &ccache_path) };
+        }
+
         self.config_path = Some(config_path.clone());
 
         let realm = get_var_or_env!(realm, "KRB5_REALM")?;

--- a/rust/src/nasl/builtin/krb5/mod.rs
+++ b/rust/src/nasl/builtin/krb5/mod.rs
@@ -179,6 +179,7 @@ pub struct Krb5 {
     to_application: Arc<Mutex<*mut OKrb5Slice>>,
     gss_context_needs_more: bool,
     config_path: Option<String>,
+    ccache_path: Option<String>,
 }
 
 impl Drop for Krb5 {
@@ -202,6 +203,9 @@ impl Drop for Krb5 {
         }
         if let Some(config_path) = &self.config_path {
             let _ = std::fs::remove_file(config_path);
+        }
+        if let Some(ccache_path) = &self.ccache_path {
+            let _ = std::fs::remove_file(ccache_path);
         }
     }
 }
@@ -247,7 +251,11 @@ impl Krb5 {
         } else {
             let path = format!(
                 "/tmp/krb5_{}.conf",
-                context.target().ip_addr().to_string().replace(".", "_")
+                context
+                    .target()
+                    .ip_addr()
+                    .to_string()
+                    .replace(['.', ':'], "_")
             );
             unsafe { std::env::set_var("KRB5_CONFIG", &path) };
             path
@@ -256,9 +264,14 @@ impl Krb5 {
         if std::env::var("KRB5CCNAME").is_err() {
             let ccache_path = format!(
                 "/tmp/krb5cc_{}",
-                context.target().ip_addr().to_string().replace(".", "_")
+                context
+                    .target()
+                    .ip_addr()
+                    .to_string()
+                    .replace(['.', ':'], "_")
             );
             unsafe { std::env::set_var("KRB5CCNAME", &ccache_path) };
+            self.ccache_path = Some(ccache_path);
         }
 
         self.config_path = Some(config_path.clone());


### PR DESCRIPTION
This PR enables the CCache. It is set to the location `/tmp/krb5cc_<ip>` and the env variable `KRB5CCNAME` is set accordingly. The default can be overwritten, if the env variable is set manually.

SC-1509