### PR TITLE
Fix: do start and stop immediately instead of via scheduling

### DIFF
--- a/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
+++ b/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
@@ -7,20 +7,15 @@ use greenbone_scanner_framework::{
     models::{PreferenceValue, ScanPreferenceInformation},
     prelude::*,
 };
-use tokio::sync::mpsc::Sender;
 use tracing::instrument;
 
 use crate::{
-    container_image_scanner::scheduling::{
-        self,
-        db::{DBResults, DataBase, scan::DBScan},
-    },
-    database::dao::{DAOError, DBViolation, Execute, Fetch, StreamFetch},
+    container_image_scanner::scheduling::db::{DBResults, DataBase, scan::DBScan},
+    database::dao::{DAOError, DBViolation, Execute, Fetch, RetryExec, StreamFetch},
 };
 
 pub struct Scans {
     pub pool: DataBase,
-    pub scheduling: Sender<scheduling::Message>,
 }
 
 impl Prefixed for Scans {
@@ -180,10 +175,9 @@ impl PostScansId for Scans {
         id: String,
         action: models::Action,
     ) -> Pin<Box<dyn Future<Output = Result<(), PostScansIDError>> + Send + '_>> {
-        let sender = self.scheduling.clone();
         Box::pin(async move {
-            sender
-                .send(scheduling::Message::new(id, action))
+            DBScan::new(&self.pool, (id, action))
+                .retry_exec()
                 .await
                 .map_err(PostScansIDError::from_external)
         })
@@ -204,7 +198,9 @@ impl DeleteScansId for Scans {
             if phase.is_running() {
                 return Err(DeleteScansIDError::Running);
             }
-            db.exec().await.map_err(DeleteScansIDError::from_external)
+            db.retry_exec()
+                .await
+                .map_err(DeleteScansIDError::from_external)
         })
     }
 }
@@ -218,20 +214,14 @@ pub mod scans_utils {
     use tokio::sync::Mutex;
 
     use super::Scans;
-    use crate::{
-        container_image_scanner::{
-            Config, MIGRATOR,
-            config::DBLocation,
-            image::{
-                DockerRegistryV2, DockerRegistryV2Mock, RegistrySetting, extractor::filtered_image,
-                packages::AllTypes,
-            },
-            scheduling::{
-                Scheduler,
-                db::{DataBase, scan::DBScan},
-            },
+    use crate::container_image_scanner::{
+        Config, MIGRATOR,
+        config::DBLocation,
+        image::{
+            DockerRegistryV2, DockerRegistryV2Mock, RegistrySetting, extractor::filtered_image,
+            packages::AllTypes,
         },
-        database::dao::Execute,
+        scheduling::{Scheduler, db::DataBase},
     };
     use scannerlib::notus::path_to_products;
 
@@ -257,15 +247,12 @@ pub mod scans_utils {
         let products_path: &str =
             concat!(env!("CARGO_MANIFEST_DIR"), "/examples/feed/notus/products");
 
-        let (sender, scheduler) = Scheduler::<R, E>::init(
+        let scheduler = Scheduler::<R, E>::init(
             config.into(),
             pool.clone(),
             path_to_products(products_path, false),
         );
-        let scans = super::Scans {
-            pool: pool.clone(),
-            scheduling: sender,
-        };
+        let scans = super::Scans { pool: pool.clone() };
         (scheduler, scans)
     }
 
@@ -276,16 +263,6 @@ pub mod scans_utils {
     }
 
     impl Fakes {
-        async fn recv(&mut self) {
-            let msg = self.scheduler.receiver().recv().await;
-            if let Some(msg) = msg {
-                DBScan::new(&self.scheduler.pool(), (msg.id, msg.action))
-                    .exec()
-                    .await
-                    .unwrap();
-            }
-        }
-
         pub async fn internal_id(&self, client_id: &str, scan_id: &str) -> String {
             self.entry
                 .contains_scan_id(client_id, scan_id)
@@ -304,8 +281,6 @@ pub mod scans_utils {
                 .post_scans_id(id.clone(), models::Action::Stop)
                 .await
                 .unwrap();
-
-            self.recv().await;
 
             self.entry.get_scans_id_status(id).await.unwrap()
         }
@@ -327,8 +302,6 @@ pub mod scans_utils {
                 .post_scans_id(id.clone(), models::Action::Start)
                 .await
                 .unwrap();
-
-            self.recv().await;
 
             (scan_id, self.entry.get_scans_id_status(id).await.unwrap())
         }

--- a/rust/src/openvasd/container_image_scanner/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/mod.rs
@@ -97,7 +97,7 @@ pub async fn init(
         .await?;
     MIGRATOR.run(&pool).await?;
 
-    let (sender, scheduler) = Scheduler::<DockerRegistryV2, filtered_image::Extractor>::init(
+    let scheduler = Scheduler::<DockerRegistryV2, filtered_image::Extractor>::init(
         config.into(),
         pool.clone(),
         products,
@@ -106,10 +106,7 @@ pub async fn init(
         scheduler.run::<AllTypes>().await;
     });
 
-    let scan = Scans {
-        pool,
-        scheduling: sender,
-    };
+    let scan = Scans { pool };
     let vts = VTEndpoints::new(
         SqlPluginStorage::from(vt_pool),
         feed_state,

--- a/rust/src/openvasd/container_image_scanner/scheduling/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/mod.rs
@@ -9,10 +9,7 @@ use container_image_scanner::{
 use futures::StreamExt;
 use greenbone_scanner_framework::models;
 use tokio::{
-    sync::{
-        Mutex, RwLock,
-        mpsc::{Receiver, Sender},
-    },
+    sync::{Mutex, RwLock},
     task::JoinSet,
     time,
 };
@@ -60,17 +57,6 @@ pub struct ProcessingImage {
     pub image: Vec<Result<Image, ImageParseError>>,
     pub credentials: Option<Credential>,
 }
-#[derive(Debug)]
-pub struct Message {
-    pub id: String,
-    pub action: models::Action,
-}
-
-impl Message {
-    pub fn new(id: String, action: models::Action) -> Self {
-        Self { id, action }
-    }
-}
 
 /// Scheduler is responsible to start, stop and storing results of scans.
 ///
@@ -78,7 +64,6 @@ impl Message {
 /// It then sets the status of that scan to queued and regularly verifies if a scan can be started
 /// when the scan is finished it also sets the status to either succeed or failed.
 pub struct Scheduler<Registry, Extractor> {
-    receiver: Receiver<Message>,
     pool: DataBase,
     config: Arc<Config>,
     registry: PhantomData<Registry>,
@@ -89,12 +74,10 @@ pub struct Scheduler<Registry, Extractor> {
 impl<Registry, Extractor> Scheduler<Registry, Extractor> {
     fn new(
         config: Arc<Config>,
-        receiver: Receiver<Message>,
         pool: DataBase,
         products: Arc<RwLock<Notus<HashsumProductLoader>>>,
     ) -> Self {
         Scheduler {
-            receiver,
             pool,
             config,
             registry: PhantomData,
@@ -107,9 +90,8 @@ impl<Registry, Extractor> Scheduler<Registry, Extractor> {
         config: Arc<Config>,
         pool: DataBase,
         products: Arc<RwLock<Notus<HashsumProductLoader>>>,
-    ) -> (Sender<Message>, Scheduler<Registry, Extractor>) {
-        let (sender, receiver) = tokio::sync::mpsc::channel(10);
-        (sender, Self::new(config, receiver, pool, products))
+    ) -> Scheduler<Registry, Extractor> {
+        Self::new(config, pool, products)
     }
 }
 
@@ -129,11 +111,6 @@ where
     #[cfg(test)]
     pub fn pool(&self) -> DataBase {
         self.pool.clone()
-    }
-
-    #[cfg(test)]
-    pub fn receiver(&mut self) -> &mut Receiver<Message> {
-        &mut self.receiver
     }
 
     #[cfg(test)]
@@ -215,7 +192,7 @@ where
     ) where
         T: ToNotus,
     {
-        tracing::debug!("checking for requested and scanning");
+        tracing::trace!("checking for requested and scanning");
         let pool = conn.lock().await;
         let requested = match DBImages::new(&pool, config.max_scans).fetch().await {
             Ok(r) => r,
@@ -343,7 +320,7 @@ where
         js.join_all().await;
     }
 
-    pub async fn run<T>(mut self)
+    pub async fn run<T>(self)
     where
         T: ToNotus,
     {
@@ -367,19 +344,7 @@ where
         let conn = Arc::new(Mutex::new(conn));
         loop {
             tokio::select! {
-                Some(msg) = self.receiver.recv() => {
-                let pool = self.pool.clone();
 
-                tokio::spawn(async move {
-                    let id = msg.id.clone();
-
-                    if let Err(e) = DBScan::new(&pool, (msg.id, msg.action))
-                        .retry_exec()
-                        .await {
-                        warn!(error=%e, id, "Unable to handle message");
-                    }
-                });
-                }
 
                 _ = interval.tick() => {
                 let products = self.products.clone();


### PR DESCRIPTION
Instead of handling start and stop action via the scheduler it is done
immediately. This helps to reflect the actual status to the client
instead of doing it in the background.

Although the request may potentially take longer it prevents race
conditions as it should ensure that the change is known to the database
on return.

