### PR TITLE
CI: retry smokey on failure

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -44,7 +44,12 @@ jobs:
       - run: curl -L https://github.com/Orange-OpenSource/hurl/releases/download/7.1.0/hurl_7.1.0_amd64.deb -o hurl.deb
       - run: sudo apt-get install -y ./hurl.deb
       - run: cd compose && OPENVAS_IMAGE="${{ inputs.image }}" make test-environment-running
-      - run: cd compose/tests/smoketest && make
+      - run: |
+          for attempt in 1 2; do
+            ( cd compose/tests/smoketest && make > /dev/null 2>&1) && exit 0 || \
+              echo "smokey failed on attempt $attempt, retrying..."
+          done
+          cd compose/tests/smoketest && make
       - run: cd compose && make test-environment-logs
         if: always()
   tests:


### PR DESCRIPTION
Retries smokey up to 3 times before giving up.

Hopefully we can reduce the amount of manually clicking 'retry failed jobs' with that.
