### PR TITLE
Fix: QueryBuilder reuse panic in try_store() on >2340-result scans

### DIFF
--- a/rust/src/openvasd/database/sqlite/results.rs
+++ b/rust/src/openvasd/database/sqlite/results.rs
@@ -237,3 +237,112 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scans::tests::create_pool;
+    use sqlx::query_scalar;
+
+    async fn insert_test_scan(pool: &SqlitePool) -> String {
+        let row = sqlx::query("INSERT INTO client_scan_map(client_id, scan_id) VALUES (?, ?)")
+            .bind("test-client")
+            .bind("test-scan-id")
+            .execute(pool)
+            .await
+            .unwrap();
+        let id = row.last_insert_rowid();
+        sqlx::query("INSERT INTO scans (id, auth_data) VALUES (?, ?)")
+            .bind(id)
+            .bind("")
+            .execute(pool)
+            .await
+            .unwrap();
+        id.to_string()
+    }
+
+    fn make_results(n: usize) -> Vec<models::Result> {
+        (0..n)
+            .map(|i| models::Result {
+                message: Some(format!("result-{i}")),
+                ..Default::default()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn store_single_chunk() -> crate::Result<()> {
+        let (_config, pool) = create_pool().await?;
+        let scan_id = insert_test_scan(&pool).await;
+
+        let results = make_results(10);
+        try_store(&pool, &scan_id, &results).await?;
+
+        let count: i64 = query_scalar("SELECT COUNT(*) FROM results WHERE scan_id = ?")
+            .bind(&scan_id)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, 10);
+
+        let ids: Vec<i64> = query_scalar("SELECT id FROM results WHERE scan_id = ? ORDER BY id")
+            .bind(&scan_id)
+            .fetch_all(&pool)
+            .await?;
+        assert_eq!(ids, (0..10).collect::<Vec<i64>>());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn store_multi_chunk_ids_are_sequential() -> crate::Result<()> {
+        let (_config, pool) = create_pool().await?;
+        let scan_id = insert_test_scan(&pool).await;
+
+        let chunk_size = SQLITE_LIMIT_VARIABLE_NUMBER / 14;
+        let n = chunk_size + 1;
+        let results = make_results(n);
+        try_store(&pool, &scan_id, &results).await?;
+
+        let count: i64 = query_scalar("SELECT COUNT(*) FROM results WHERE scan_id = ?")
+            .bind(&scan_id)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, n as i64);
+
+        let ids: Vec<i64> = query_scalar("SELECT id FROM results WHERE scan_id = ? ORDER BY id")
+            .bind(&scan_id)
+            .fetch_all(&pool)
+            .await?;
+        let expected: Vec<i64> = (0..n as i64).collect();
+        assert_eq!(ids, expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn append_results_continues_ids() -> crate::Result<()> {
+        let (_config, pool) = create_pool().await?;
+        let scan_id = insert_test_scan(&pool).await;
+
+        let first_batch = make_results(100);
+        try_store(&pool, &scan_id, &first_batch).await?;
+
+        let second_batch = make_results(50);
+        try_store(&pool, &scan_id, &second_batch).await?;
+
+        let count: i64 = query_scalar("SELECT COUNT(*) FROM results WHERE scan_id = ?")
+            .bind(&scan_id)
+            .fetch_one(&pool)
+            .await?;
+        assert_eq!(count, 150);
+
+        let ids: Vec<i64> = query_scalar("SELECT id FROM results WHERE scan_id = ? ORDER BY id")
+            .bind(&scan_id)
+            .fetch_all(&pool)
+            .await?;
+        let expected: Vec<i64> = (0..150).collect();
+        assert_eq!(ids, expected);
+
+        Ok(())
+    }
+}

--- a/rust/src/openvasd/database/sqlite/results.rs
+++ b/rust/src/openvasd/database/sqlite/results.rs
@@ -188,8 +188,10 @@ where
         }
     };
     tracing::trace!(id, base_id, "Results.");
-    let mut builder = QueryBuilder::new(
-        r#"
+    let mut offset = base_id;
+    for results in results.chunks(SQLITE_LIMIT_VARIABLE_NUMBER / 14) {
+        let mut builder = QueryBuilder::new(
+            r#"
             INSERT INTO results (
                 scan_id,
                 id,
@@ -207,14 +209,12 @@ where
                 source_description
             )
             "#,
-    );
-
-    for results in results.chunks(SQLITE_LIMIT_VARIABLE_NUMBER / 14) {
+        );
         builder.push_values(results.iter().enumerate(), |mut b, (idx, result)| {
             let result: models::Result = result.to_owned().into();
             let detail = result.detail.unwrap_or_default();
             b.push_bind(id)
-                .push_bind(idx as i64 + base_id)
+                .push_bind(idx as i64 + offset)
                 .push_bind(result.r_type.to_string())
                 .push_bind(result.ip_address.unwrap_or_default())
                 .push_bind(result.hostname.unwrap_or_default())
@@ -231,6 +231,7 @@ where
 
         let query = builder.build();
         query.execute(&mut *tx).await?;
+        offset += results.len() as i64;
     }
 
     tx.commit().await?;


### PR DESCRIPTION
> Apologies for the size of the original PR — it bundled four independent concerns that all came out of the same production incident, and in hindsight each of them deserved its own review. This one is now scoped to **just the results-storage panic fix**. The other three (`max_running_scans` typo, scheduler `catch_unwind` + `/health/ready` propagation, `last_activity_at` heartbeat) will follow as separate PRs.

## How I ran into this

I'm running openvas-scanner in production, and at some point I noticed scans had just stopped happening. Nothing obvious was broken — the API was still answering, `POST /scans` was still handing back fresh scan IDs, `GET /health/ready` was sitting at a cheerful **200 OK**. But the moment I tried to actually start a scan, `POST /scans/{id}` would come back with **`channel closed`**, and nothing on the worker side was moving. No progress, no new results, the logs just went quiet after a panic line. The service was talking to me, it just wasn't doing anything.

It took me a while to trust what I was seeing, because every health probe I had said the thing was fine.

## Root cause

The trail led to the scheduler task — the big `tokio::select!` in `scheduling.rs`. It had panicked while persisting results inside `try_store()` (`rust/src/openvasd/database/sqlite/results.rs`) and the whole task had gone down with it. Once the task was dead, the mpsc channel it owned was closed too, which is exactly the `channel closed` I kept getting on every start attempt. `/health/ready` was hardcoded to `JustReady`, so it had no idea the scheduler was gone — that part of the story (and the fix for it) belongs to a separate PR.

The panic itself was a small thing:

- `QueryBuilder::new(...)` was built **once, outside** the `results.chunks(...)` loop.
- `builder.build()` consumes the builder's internal state.
- First chunk wrote fine, second chunk panicked on the same builder.

The threshold to trip it is `SQLITE_LIMIT_VARIABLE_NUMBER / 14 = 32766 / 14 ≈ 2340` results — basically anything that needs a second chunk. My real scans cross that without breaking a sweat, which is how I ended up here.

While I was in those five lines I noticed a second bug riding along: `enumerate()` inside `push_values` restarts at `0` for every chunk, so chunk 2's rows would have collided with chunk 1's on the `(scan_id, id)` primary key anyway. Even without the panic, the second chunk wouldn't have persisted.

## Panic text

```
thread 'tokio-runtime-worker' panicked at
.../sqlx-core-x.y.z/src/query_builder.rs:NN:N:
QueryBuilder must be reset before reuse after `.build_*()`
```

Stack: `sqlx::query_builder::QueryBuilder::push_values` → `try_store` → `scheduling::on_schedule` → the scheduler's `tokio::select!` arm.

## Fix (about five lines)

- Move `QueryBuilder::new(...)` **inside** the `chunks(...)` loop so each chunk gets its own builder.
- Replace `idx as i64 + base_id` with a running `offset` counter incremented by `results.len()` after each chunk, so IDs stay sequential across chunks.

## Tests

`39ac491c` adds three regression tests in `rust/src/openvasd/database/sqlite/results.rs`:

- `store_single_chunk` — sanity check with 10 results.
- `store_multi_chunk_ids_are_sequential` — stores `chunk_size + 1` results and asserts IDs are `0..n`. Fails on the old code with the same sqlx message I saw in prod.
- `append_results_continues_ids` — verifies `base_id` offset is honored across separate `try_store()` calls.
