### PR TITLE
Adjust README for rust project

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -36,8 +36,11 @@ To build and create the executables
 
 You have to execute
 ```
+make
 cargo build --release
 ```
+
+The `make` command builds required c libraries. For more information check [Documentation](./crates/nasl-c-lib/README.md)
 
 # Contribution
 


### PR DESCRIPTION
In https://github.com/greenbone/openvas-scanner/pull/2193 the build process was adjusted, but not the README in the rust root directory.