### PR TITLE
Fix: cached hashes

### DIFF
--- a/rust/src/openvasd/database/sqlite/vts.rs
+++ b/rust/src/openvasd/database/sqlite/vts.rs
@@ -183,12 +183,7 @@ impl orchestrator::Worker for FeedSynchronizer {
                 None
             }
         };
-        let feed_integrity_check = self.signature_check;
-
         Box::pin(async move {
-            if !feed_integrity_check {
-                return Ok(None);
-            }
             let rofl = (
                 transform(fetched.next().await),
                 transform(fetched.next().await),

--- a/rust/src/openvasd/vts/redis.rs
+++ b/rust/src/openvasd/vts/redis.rs
@@ -324,11 +324,7 @@ impl orchestrator::Worker for FeedSynchronizer {
                 .map_err(redis_error_to_worker_error)?;
             Ok(ck.pop())
         };
-        let feed_integrity_check = self.signature_check;
         Box::pin(async move {
-            if !feed_integrity_check {
-                return Ok(None);
-            }
             tokio::task::spawn_blocking(move || {
                 let vtc = feed_version(&address, FeedType::NASL)?;
                 let nc = feed_version(&address, FeedType::Advisories)?;


### PR DESCRIPTION
**What**:
Fix: cached hashes
SC-1597
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
If the integrity check is disabled, the cached_hashes() always returns None, which produces that the feeds is update each time that the scheduler runs.
<!-- Why are these changes necessary? -->

**How**:
run openvasd with `integrity_check = false` and check with `GET /health/ready` that the feed version flips from a hash to unavailable each time that the scheduler runs and checks the feed.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
