### PR TITLE
Add: nix flakes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target/
 *.rsa
 *.pem
 *.snap.new
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1779130139,
-        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "lastModified": 1780099841,
+        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1779442979,
-        "narHash": "sha256-CtoDst6OfZYWAuqT7J5A9QduRYIL7+xTlBd9CS8RKOk=",
+        "lastModified": 1780130272,
+        "narHash": "sha256-iCNBDsTLvD5pK9xCbd/Kl4NabrLRws6WVkiElGM9U1Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e8d2e251fa22fd892997612423e16c733a8775c4",
+        "rev": "2118601eb824d47529307266d74e68dfd661c236",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1779796641,
+        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "25f538306313eae3927264466c70d7001dcea1df",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779303932,
-        "narHash": "sha256-alMOllPgosTsuXGjhvQvbGH0ekPOZW0QfGTI0NdJtbQ=",
+        "lastModified": 1780060635,
+        "narHash": "sha256-k+iiE7EUc732hT7u1YP3omk9rCElKBbc5evooZSskwU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "7f916ab1b1f669cec017960c2d91a9a87b4b7bae",
+        "rev": "5ebf65ce47fc047e8a2772297f2ddd988ab86c32",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1779442979,
+        "narHash": "sha256-CtoDst6OfZYWAuqT7J5A9QduRYIL7+xTlBd9CS8RKOk=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "e8d2e251fa22fd892997612423e16c733a8775c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779303932,
+        "narHash": "sha256-alMOllPgosTsuXGjhvQvbGH0ekPOZW0QfGTI0NdJtbQ=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "7f916ab1b1f669cec017960c2d91a9a87b4b7bae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
         in
         rec {
-          formatter = pkgs.nixfmt-rfc-style;
+          formatter = pkgs.nixfmt;
 
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,6 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
       ];
 
       perSystem =

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  description = "OpenVAS — Open Vulnerability Assessment Scanner";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { system, pkgs, ... }:
+        let
+          rustToolchain = pkgs.fenix.fromToolchainFile {
+            dir = self + /rust;
+            sha256 = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
+          };
+
+          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
+        in
+        rec {
+          formatter = pkgs.nixfmt-rfc-style;
+
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ inputs.fenix.overlays.default ];
+          };
+
+          packages = import ./nix/packages {
+            inherit pkgs craneLib;
+            src = self;
+          };
+
+          apps =
+            let
+              mkApp = name: {
+                type = "app";
+                program = "${packages.${name}}/bin/${name}";
+              };
+            in
+            {
+              openvasd = mkApp "openvasd";
+              scannerctl = mkApp "scannerctl";
+              feed-filter = mkApp "feed-filter";
+              openvas = mkApp "openvas";
+            };
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = builtins.attrValues packages;
+            buildInputs = with pkgs; [
+              cmake
+              gcc
+              pkg-config
+              bison
+              flex
+              doxygen
+              pandoc
+              glib
+              json-glib
+              libgcrypt
+              gpgme
+              libpcap
+              libssh
+              libksba
+              gnutls
+              curl
+              libbsd
+              krb5
+              file
+              net-snmp
+              nmap
+              redis
+              rustToolchain
+              clang-tools
+              gdb
+              valgrind
+            ];
+          };
+        };
+
+      flake.overlays.default = final: prev: {
+        inherit (self.packages.${final.system})
+          gvm-libs
+          openvasd
+          scannerctl
+          feed-filter
+          scannerlib
+          openvas
+          ;
+      };
+    };
+}

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -571,8 +571,9 @@ forge_tcp_packet (lex_ctxt *lexic)
     }
 
   ipsz = get_var_size_by_name (lexic, "ip");
-  if (ipsz > ip->ip_hl * 4)
-    ipsz = ip->ip_hl * 4;
+  const size_t ip_hlen = (size_t) ip->ip_hl * 4;
+  if (ipsz > ip_hlen)
+    ipsz = ip_hlen;
 
   data = get_str_var_by_name (lexic, "data");
   len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
@@ -583,7 +584,7 @@ forge_tcp_packet (lex_ctxt *lexic)
 
   bcopy (ip, tcp_packet, ipsz);
   /* recompute the ip checksum, because the ip length changed */
-  if (UNFIX (tcp_packet->ip_len) <= tcp_packet->ip_hl * 4)
+  if (UNFIX (tcp_packet->ip_len) <= (int) tcp_packet->ip_hl * 4)
     {
       if (get_int_var_by_name (lexic, "update_ip_len", 1))
         {
@@ -670,10 +671,10 @@ get_tcp_element (lex_ctxt *lexic)
 
   ip = (struct ip *) packet;
 
-  if (ip->ip_hl * 4 > ipsz)
+  if ((size_t) ip->ip_hl * 4 > ipsz)
     return NULL; /* Invalid packet */
 
-  if (UNFIX (ip->ip_len) > ipsz)
+  if ((size_t) UNFIX (ip->ip_len) > ipsz)
     return NULL; /* Invalid packet */
 
   tcp = (struct tcphdr *) (packet + ip->ip_hl * 4);
@@ -945,14 +946,14 @@ set_tcp_elements (lex_ctxt *lexic)
       return NULL;
     }
 
-  if (ip->ip_hl * 4 > pktsz)
+  if ((size_t) ip->ip_hl * 4 > pktsz)
     tcp =
       (struct tcphdr *) (pkt
                          + 20); /* ip->ip_hl is bogus, we work around that */
   else
     tcp = (struct tcphdr *) (pkt + ip->ip_hl * 4);
 
-  if (pktsz < UNFIX (ip->ip_len))
+  if (pktsz < (size_t) UNFIX (ip->ip_len))
     return NULL;
 
   if (data_len == 0)
@@ -1217,13 +1218,13 @@ insert_tcp_options (lex_ctxt *lexic)
   // Add EOL
   memcpy (ptr_opts_pos, &eol, 1);
 
-  if (ip->ip_hl * 4 > pktsz)
+  if ((size_t) ip->ip_hl * 4 > pktsz)
     // ip->ip_hl is bogus, we work around that
     tcp = (struct tcphdr *) (pkt + 20);
   else
     tcp = (struct tcphdr *) (pkt + ip->ip_hl * 4);
 
-  if (pktsz < UNFIX (ip->ip_len))
+  if (pktsz < (size_t) UNFIX (ip->ip_len))
     {
       g_free (opts);
       return NULL;
@@ -1404,7 +1405,8 @@ dump_tcp_packet (lex_ctxt *lexic)
       printf ("\n\tData     : ");
       c = (char *) ((char *) tcp + sizeof (struct tcphdr)
                     + sizeof (uint8_t) * 4 * (tcp->th_off - 5));
-      if (UNFIX (ip->ip_len) > (sizeof (struct ip) + sizeof (struct tcphdr)))
+      if (UNFIX (ip->ip_len)
+          > (int) (sizeof (struct ip) + sizeof (struct tcphdr)))
         for (j = 0; j < UNFIX (ip->ip_len) - sizeof (struct ip)
                           - sizeof (struct tcphdr)
                           - sizeof (uint8_t) * 4 * (tcp->th_off - 5)
@@ -1507,7 +1509,7 @@ forge_udp_packet (lex_ctxt *lexic)
           g_free (udpsumdata);
         }
 
-      if (UNFIX (udp_packet->ip_len) <= udp_packet->ip_hl * 4)
+      if (UNFIX (udp_packet->ip_len) <= (int) udp_packet->ip_hl * 4)
         {
           int v = get_int_var_by_name (lexic, "update_ip_len", 1);
           if (v != 0)
@@ -1799,14 +1801,14 @@ forge_icmp_packet (lex_ctxt *lexic)
       if (t == 13 || t == 14)
         len += 3 * sizeof (time_t);
 
-      if (ip->ip_hl * 4 > ip_sz)
+      if ((size_t) ip->ip_hl * 4 > ip_sz)
         return NULL;
 
       pkt = g_malloc0 (sizeof (struct icmp) + ip_sz + len);
       ip_icmp = (struct ip *) pkt;
 
       bcopy (ip, ip_icmp, ip_sz);
-      if (UNFIX (ip_icmp->ip_len) <= (ip_icmp->ip_hl * 4))
+      if (UNFIX (ip_icmp->ip_len) <= (int) ip_icmp->ip_hl * 4)
         {
           if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
             {
@@ -1990,7 +1992,7 @@ forge_igmp_packet (lex_ctxt *lexic)
 
       bcopy (ip, ip_igmp, ipsz);
 
-      if (UNFIX (ip_igmp->ip_len) <= ip_igmp->ip_hl * 4)
+      if (UNFIX (ip_igmp->ip_len) <= (int) ip_igmp->ip_hl * 4)
         {
           int v = get_int_var_by_name (lexic, "update_ip_len", 1);
           if (v != 0)

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -11,7 +11,7 @@ let
   # use this version for both the C scanner and the Rust binaries.
   version = builtins.head (
     builtins.match ".*project[[:space:]]*\\([^)]*VERSION[[:space:]]+([0-9.]+).*" (
-      builtins.readFile ./CMakeLists.txt
+      builtins.readFile (src + /CMakeLists.txt)
     )
   );
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -9,15 +9,11 @@ let
 
   # Read scanner release version from CMakeLists.txt — upstream releases
   # use this version for both the C scanner and the Rust binaries.
-  version =
-    let
-      cmake = builtins.replaceStrings [ "\n" ] [ " " ] (
-        builtins.readFile (src + "/CMakeLists.txt")
-      );
-    in
-      builtins.head (
-        builtins.match ".*project *\\( *openvas +VERSION +([0-9.]+).*" cmake
-      );
+  version = builtins.head (
+    builtins.match ".*project[[:space:]]*\\([^)]*VERSION[[:space:]]+([0-9.]+).*" (
+      builtins.readFile ./CMakeLists.txt
+    )
+  );
 
   cargoToml = fromTOML (builtins.readFile (src + "/rust/Cargo.toml"));
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -7,13 +7,25 @@
 let
   inherit (pkgs) gvm-libs;
 
+  # Read scanner release version from CMakeLists.txt — upstream releases
+  # use this version for both the C scanner and the Rust binaries.
+  version =
+    let
+      cmake = builtins.replaceStrings [ "\n" ] [ " " ] (
+        builtins.readFile (src + "/CMakeLists.txt")
+      );
+    in
+      builtins.head (
+        builtins.match ".*project *\\( *openvas +VERSION +([0-9.]+).*" cmake
+      );
+
   cargoToml = fromTOML (builtins.readFile (src + "/rust/Cargo.toml"));
 
   # Each binary is its own derivation (buildDepsOnly shared, see scannerlib.nix).
   rustOutputs = pkgs.callPackage ./scannerlib.nix {
     inherit craneLib;
     inherit gvm-libs;
-    inherit (cargoToml.package) version;
+    inherit version;
     pname = cargoToml.package.name;
     src = src + "/rust";
     repoRoot = src;
@@ -31,7 +43,7 @@ in
     ;
 
   openvas = pkgs.callPackage ./openvas.nix {
-    inherit src;
+    inherit src version;
     inherit gvm-libs;
   };
 }

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,37 @@
+{
+  pkgs,
+  craneLib,
+  src,
+}:
+
+let
+  inherit (pkgs) gvm-libs;
+
+  cargoToml = fromTOML (builtins.readFile (src + "/rust/Cargo.toml"));
+
+  # Each binary is its own derivation (buildDepsOnly shared, see scannerlib.nix).
+  rustOutputs = pkgs.callPackage ./scannerlib.nix {
+    inherit craneLib;
+    inherit gvm-libs;
+    inherit (cargoToml.package) version;
+    pname = cargoToml.package.name;
+    src = src + "/rust";
+    repoRoot = src;
+  };
+
+in
+{
+  inherit gvm-libs;
+
+  inherit (rustOutputs)
+    openvasd
+    scannerctl
+    feed-filter
+    scannerlib
+    ;
+
+  openvas = pkgs.callPackage ./openvas.nix {
+    inherit src;
+    inherit gvm-libs;
+  };
+}

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -74,12 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Install to the Nix store via DESTDIR while keeping runtime paths as
   # standard FHS locations (the binary reads openvas.conf at runtime).
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_PREFIX=/usr"
-    "-DLOCALSTATEDIR=/var"
-    "-DSYSCONFDIR=/etc"
-    "-DCMAKE_INSTALL_SYSCONFDIR=/etc"
-  ];
+  # /usr sets runtime prefix; DESTDIR below overlays $out on top.
+  cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=/usr" ];
 
   installPhase = ''
     runHook preInstall

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  version,
   autoPatchelfHook,
   cmake,
   pkg-config,
@@ -30,7 +31,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvas";
-  version = "23.45.5";
+  inherit version;
 
   inherit src;
 

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -30,14 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   inherit src;
 
-  # Upstream builds with -Werror; nixpkgs GCC 14+ triggers a sign-compare
-  # warning in the NASL packet-forgery code. Strip it rather than adding a
-  # blanket -Wno-error= flag.
-  postPatch = ''
-    substituteInPlace CMakeLists.txt nasl/CMakeLists.txt src/CMakeLists.txt misc/CMakeLists.txt \
-      --replace-warn "-Werror" ""
-  '';
-
   nativeBuildInputs = [
     autoPatchelfHook
     cmake

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -1,0 +1,107 @@
+{
+  stdenv,
+  lib,
+  autoPatchelfHook,
+  cmake,
+  pkg-config,
+  bison,
+  flex,
+  glib,
+  json-glib,
+  libgcrypt,
+  gpgme,
+  libpcap,
+  libssh,
+  libksba,
+  gnutls,
+  curl,
+  libbsd,
+  krb5,
+  file,
+  net-snmp,
+  nmap,
+  redis,
+  doxygen,
+  pandoc,
+  gvm-libs,
+  paho-mqtt-c,
+  src,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openvas";
+  version = "23.45.5";
+
+  inherit src;
+
+  # GCC 14+ flags a sign-compare warning in the NASL packet-forgery code
+  # that upstream treats as -Werror.  Strip -Werror rather than adding a
+  # blanket compiler flag.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt nasl/CMakeLists.txt src/CMakeLists.txt misc/CMakeLists.txt \
+      --replace-warn "-Werror" ""
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    pkg-config
+    bison
+    flex
+    doxygen
+    pandoc
+  ];
+
+  buildInputs = [
+    glib
+    json-glib
+    libgcrypt
+    gpgme
+    libpcap
+    libssh
+    libksba
+    gnutls
+    curl
+    libbsd
+    krb5
+    file
+    net-snmp
+    nmap
+    redis
+    gvm-libs
+    paho-mqtt-c
+  ];
+
+  # Install to the Nix store via DESTDIR while keeping runtime paths as
+  # standard FHS locations (the binary reads openvas.conf at runtime).
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=/usr"
+    "-DLOCALSTATEDIR=/var"
+    "-DSYSCONFDIR=/etc"
+    "-DCMAKE_INSTALL_SYSCONFDIR=/etc"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    DESTDIR="$out" cmake --install .
+
+    mkdir -p "$out/bin"
+    for bin in openvas openvas-nasl openvas-nasl-lint; do
+      if [ -x "$out/usr/sbin/$bin" ]; then
+        ln -s "$out/usr/sbin/$bin" "$out/bin/$bin"
+      elif [ -x "$out/usr/bin/$bin" ]; then
+        ln -s "$out/usr/bin/$bin" "$out/bin/$bin"
+      fi
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Open Vulnerability Assessment Scanner";
+    homepage = "https://github.com/greenbone/openvas";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "openvas";
+  };
+})

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -6,7 +6,6 @@
   cmake,
   pkg-config,
   bison,
-  flex,
   glib,
   json-glib,
   libgcrypt,
@@ -20,10 +19,6 @@
   krb5,
   file,
   net-snmp,
-  nmap,
-  redis,
-  doxygen,
-  pandoc,
   gvm-libs,
   paho-mqtt-c,
   src,
@@ -48,9 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     bison
-    flex
-    doxygen
-    pandoc
   ];
 
   buildInputs = [
@@ -67,8 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     krb5
     file
     net-snmp
-    nmap
-    redis
     gvm-libs
     paho-mqtt-c
   ];
@@ -91,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open Vulnerability Assessment Scanner";
     homepage = "https://github.com/greenbone/openvas";
     license = licenses.gpl2Plus;
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = platforms.linux;
     mainProgram = "openvas";
   };
 })

--- a/nix/packages/openvas.nix
+++ b/nix/packages/openvas.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   inherit src;
 
-  # GCC 14+ flags a sign-compare warning in the NASL packet-forgery code
-  # that upstream treats as -Werror.  Strip -Werror rather than adding a
-  # blanket compiler flag.
+  # Upstream builds with -Werror; nixpkgs GCC 14+ triggers a sign-compare
+  # warning in the NASL packet-forgery code. Strip it rather than adding a
+  # blanket -Wno-error= flag.
   postPatch = ''
     substituteInPlace CMakeLists.txt nasl/CMakeLists.txt src/CMakeLists.txt misc/CMakeLists.txt \
       --replace-warn "-Werror" ""
@@ -72,24 +72,17 @@ stdenv.mkDerivation (finalAttrs: {
     paho-mqtt-c
   ];
 
-  # Install to the Nix store via DESTDIR while keeping runtime paths as
-  # standard FHS locations (the binary reads openvas.conf at runtime).
-  # /usr sets runtime prefix; DESTDIR below overlays $out on top.
+  # CMAKE_INSTALL_PREFIX=/usr sets the *runtime* prefix baked into the
+  # binary (so it looks for /etc/openvas/openvas.conf at runtime).
+  # DESTDIR=$out overlays the Nix store on top at build time, and
+  # autoPatchelfHook fixes RPATH since libs land in $out/usr/lib/.
   cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=/usr" ];
 
   installPhase = ''
     runHook preInstall
     DESTDIR="$out" cmake --install .
-
     mkdir -p "$out/bin"
-    for bin in openvas openvas-nasl openvas-nasl-lint; do
-      if [ -x "$out/usr/sbin/$bin" ]; then
-        ln -s "$out/usr/sbin/$bin" "$out/bin/$bin"
-      elif [ -x "$out/usr/bin/$bin" ]; then
-        ln -s "$out/usr/bin/$bin" "$out/bin/$bin"
-      fi
-    done
-
+    ln -sf "$out/usr/sbin/openvas" "$out/bin/openvas"
     runHook postInstall
   '';
 

--- a/nix/packages/scannerlib.nix
+++ b/nix/packages/scannerlib.nix
@@ -133,7 +133,7 @@ let
           description = "OpenVAS — ${bin}";
           homepage = "https://github.com/greenbone/openvas";
           license = licenses.gpl2Plus;
-          platforms = platforms.linux ++ platforms.darwin;
+          platforms = platforms.linux;
           mainProgram = bin;
         };
       }
@@ -159,7 +159,7 @@ in
         description = "OpenVAS Rust workspace — builds openvasd, scannerctl, and feed-filter together";
         homepage = "https://github.com/greenbone/openvas";
         license = licenses.gpl2Plus;
-        platforms = platforms.linux ++ platforms.darwin;
+        platforms = platforms.linux;
       };
     }
   );

--- a/nix/packages/scannerlib.nix
+++ b/nix/packages/scannerlib.nix
@@ -1,0 +1,166 @@
+{
+  lib,
+  perl,
+  gnumake,
+  pkg-config,
+  capnproto,
+  libgcrypt,
+  libgpg-error,
+  net-snmp,
+  krb5,
+  gvm-libs,
+  repoRoot ? null,
+  autoPatchelfHook,
+  openssl,
+  libpcap,
+  sqlite,
+  zstd,
+  bzip2,
+  pkgs,
+  libclang,
+  craneLib,
+  pname,
+  version,
+  src,
+}:
+
+let
+  # ── build-cache for nasl-c-lib -sys crates ─────────────────
+  #
+  # The -sys crates use a custom build_support.rs that discovers
+  # native libraries via $OPENVAS_ARCHIVES rather than pkg-config.
+  # We populate this directory from the Nix-provided shared .so
+  # libraries and patch the link directives to use dylib instead
+  # of static (see postPatch below).
+  #
+  # Using shared libraries is the natural Nix approach: nixpkgs
+  # ships .so files by default and the stdenv linker wrapper
+  # handles RPATH for standard buildInputs.  Because these crates
+  # bypass the wrapper by emitting their own cargo:rustc-link
+  # directives, we also use autoPatchelfHook to restore RPATH.
+  buildCache = pkgs.runCommand "nasl-build-cache" { } ''
+    mkdir -p "$out/include"
+    mkdir -p "$out/include/gssapi"
+
+    # ── gcrypt ──
+    ln -s "${lib.getLib libgcrypt}/lib/libgcrypt.so" "$out/libgcrypt.so"
+    ln -s "${lib.getLib libgpg-error}/lib/libgpg-error.so" "$out/libgpg-error.so"
+    for h in gcrypt.h gcrypt-module.h; do
+      f="${lib.getDev libgcrypt}/include/$h"
+      test -f "$f" && ln -s "$f" "$out/include/$h"
+    done
+    ln -s "${lib.getDev libgpg-error}/include/gpg-error.h" "$out/include/gpg-error.h"
+
+    # ── krb5 ──
+    ln -s ${lib.getLib krb5}/lib/{libgssapi_krb5,libkrb5,libk5crypto,libcom_err,libkrb5support}.so "$out/"
+    ln -s "${lib.getDev krb5}/include/krb5.h" "$out/include/krb5.h"
+    ln -s "${lib.getDev krb5}/include/gssapi/gssapi.h" "$out/include/gssapi/gssapi.h"
+    ln -s "${lib.getDev krb5}/include/gssapi/gssapi_krb5.h" "$out/include/gssapi/gssapi_krb5.h"
+  '';
+
+  commonArgs = {
+    inherit pname version;
+    src = craneLib.path src;
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      pkg-config
+      perl
+      gnumake
+      capnproto
+      pkgs.rustPlatform.bindgenHook
+      # Restore RPATH on binaries whose link directives bypass
+      # the Nix stdenv linker wrapper (see buildCache comment).
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      libclang
+      gvm-libs
+      libgcrypt
+      libgpg-error
+      net-snmp
+      krb5
+      openssl
+      libpcap
+      sqlite
+      zstd
+      bzip2
+    ];
+
+    OPENVAS_ARCHIVES = "${buildCache}";
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  # Shared postPatch — see comment block at the top of this file.
+  postPatch = ''
+    mkdir -p ../misc
+    ln -sf ${repoRoot}/misc/openvas-krb5.c ../misc/openvas-krb5.c
+    ln -sf ${repoRoot}/misc/openvas-krb5.h ../misc/openvas-krb5.h
+
+    substituteInPlace crates/nasl-c-lib/build_support.rs \
+      --replace-fail 'cargo:rustc-link-lib=static=' 'cargo:rustc-link-lib=dylib='
+    substituteInPlace crates/nasl-c-lib/libopenvas-krb5-sys/build.rs \
+      --replace-fail '.a"' '.so"'
+    substituteInPlace crates/nasl-c-lib/libcrypt-sys/build.rs \
+      --replace-fail '.a"' '.so"'
+  '';
+
+  # Build each workspace binary separately, reusing the dependency artifacts
+  # so the workspace is compiled once.  Each binary gets its own derivation
+  # with its own RPATH fixed up by autoPatchelfHook.
+  buildBin =
+    bin:
+    craneLib.buildPackage (
+      commonArgs
+      // {
+        inherit cargoArtifacts version postPatch;
+        BIN_VERSION = version;
+        pname = bin;
+
+        cargoExtraArgs = "--bin ${bin}";
+
+        preCheck = ''
+          export LD_LIBRARY_PATH=${
+            pkgs.lib.makeLibraryPath commonArgs.buildInputs
+          }
+        '';
+
+        cargoTestExtraArgs = "-- --skip container_image_scanner";
+
+        meta = with lib; {
+          description = "OpenVAS — ${bin}";
+          homepage = "https://github.com/greenbone/openvas";
+          license = licenses.gpl2Plus;
+          platforms = platforms.linux ++ platforms.darwin;
+          mainProgram = bin;
+        };
+      }
+    );
+in
+{
+  openvasd = buildBin "openvasd";
+  scannerctl = buildBin "scannerctl";
+  feed-filter = buildBin "feed-filter";
+  # Full workspace build still available as a single derivation.
+  scannerlib = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts version postPatch;
+      BIN_VERSION = version;
+      # Full workspace --lib tests hit sandbox-unfriendly tests
+      # (e.g. nasl::builtin::sys::tests::find_in_path aborts).
+      # Per-binary builds (openvasd, scannerctl, feed-filter) run
+      # the same tests individually and pass — see buildBin above.
+      doCheck = false;
+
+      meta = with lib; {
+        description = "OpenVAS Rust workspace — builds openvasd, scannerctl, and feed-filter together";
+        homepage = "https://github.com/greenbone/openvas";
+        license = licenses.gpl2Plus;
+        platforms = platforms.linux ++ platforms.darwin;
+      };
+    }
+  );
+}

--- a/nix/packages/scannerlib.nix
+++ b/nix/packages/scannerlib.nix
@@ -10,53 +10,146 @@
   krb5,
   gvm-libs,
   repoRoot ? null,
-  autoPatchelfHook,
   openssl,
   libpcap,
   sqlite,
   zstd,
   bzip2,
-  pkgs,
   libclang,
   craneLib,
   pname,
   version,
+  rustPlatform,
+  stdenvNoCC,
   src,
+  libnl,
+  keyutils,
+  libedit,
+  libverto,
 }:
 
 let
-  # ── build-cache for nasl-c-lib -sys crates ─────────────────
-  #
-  # The -sys crates use a custom build_support.rs that discovers
-  # native libraries via $OPENVAS_ARCHIVES rather than pkg-config.
-  # We populate this directory from the Nix-provided shared .so
-  # libraries and patch the link directives to use dylib instead
-  # of static (see postPatch below).
-  #
-  # Using shared libraries is the natural Nix approach: nixpkgs
-  # ships .so files by default and the stdenv linker wrapper
-  # handles RPATH for standard buildInputs.  Because these crates
-  # bypass the wrapper by emitting their own cargo:rustc-link
-  # directives, we also use autoPatchelfHook to restore RPATH.
-  buildCache = pkgs.runCommand "nasl-build-cache" { } ''
-    mkdir -p "$out/include"
-    mkdir -p "$out/include/gssapi"
+  libgpgErrorStatic = libgpg-error.overrideAttrs (old: {
+    dontDisableStatic = true;
+    configureFlags = (old.configureFlags or [ ]) ++ [ "--enable-static" ];
+  });
 
-    # ── gcrypt ──
-    ln -s "${lib.getLib libgcrypt}/lib/libgcrypt.so" "$out/libgcrypt.so"
-    ln -s "${lib.getLib libgpg-error}/lib/libgpg-error.so" "$out/libgpg-error.so"
-    for h in gcrypt.h gcrypt-module.h; do
-      f="${lib.getDev libgcrypt}/include/$h"
-      test -f "$f" && ln -s "$f" "$out/include/$h"
-    done
-    ln -s "${lib.getDev libgpg-error}/include/gpg-error.h" "$out/include/gpg-error.h"
+  libgcryptStatic =
+    (libgcrypt.override {
+      libgpg-error = libgpgErrorStatic;
+    }).overrideAttrs
+      (old: {
+        dontDisableStatic = true;
+        configureFlags = (old.configureFlags or [ ]) ++ [ "--enable-static" ];
+      });
 
-    # ── krb5 ──
-    ln -s ${lib.getLib krb5}/lib/{libgssapi_krb5,libkrb5,libk5crypto,libcom_err,libkrb5support}.so "$out/"
-    ln -s "${lib.getDev krb5}/include/krb5.h" "$out/include/krb5.h"
-    ln -s "${lib.getDev krb5}/include/gssapi/gssapi.h" "$out/include/gssapi/gssapi.h"
-    ln -s "${lib.getDev krb5}/include/gssapi/gssapi_krb5.h" "$out/include/gssapi/gssapi_krb5.h"
-  '';
+  libpcapStatic = libpcap.overrideAttrs (old: {
+    dontDisableStatic = true;
+
+    configureFlags = (old.configureFlags or [ ]) ++ [
+      "--disable-dbus"
+      "--without-libnl"
+    ];
+
+    buildInputs = lib.remove libnl (old.buildInputs or [ ]);
+
+    propagatedBuildInputs = lib.remove (lib.getDev libnl) (old.propagatedBuildInputs or [ ]);
+  });
+
+  krb5OpenvasStatic = krb5.overrideAttrs (old: {
+    dontDisableStatic = true;
+
+    configureFlags = lib.remove "--with-libedit" (old.configureFlags or [ ]) ++ [
+      "--enable-static"
+      "--disable-shared"
+      "--without-system-verto"
+      "--without-libedit"
+      "--without-keyutils"
+      "--disable-rpath"
+    ];
+
+    buildInputs = lib.remove keyutils (
+      lib.remove libedit (lib.remove libverto (old.buildInputs or [ ]))
+    );
+
+    propagatedBuildInputs = lib.remove (lib.getDev keyutils) (
+      lib.remove (lib.getDev libedit) (
+        lib.remove (lib.getDev libverto) (old.propagatedBuildInputs or [ ])
+      )
+    );
+
+    buildPhase = ''
+      runHook preBuild
+
+      for dir in \
+        util/support \
+        util/et \
+        util/profile \
+        include \
+        lib/crypto \
+        lib/krb5 \
+        lib/gssapi
+      do
+        make -C "$dir" -j"$NIX_BUILD_CORES"
+      done
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      make install-mkdirs
+
+      for dir in \
+        util/support \
+        util/et \
+        util/profile \
+        include \
+        lib/crypto \
+        lib/krb5 \
+        lib/gssapi
+      do
+        make -C "$dir" install
+      done
+
+      runHook postInstall
+    '';
+  });
+
+  # ── archive cache for nasl-c-lib -sys crates ────────────────
+  #
+  # The -sys crates use custom build scripts that discover native
+  # libraries via $OPENVAS_ARCHIVES rather than pkg-config.
+  #
+  # Upstream expects this directory to contain static archives (.a)
+  # and headers.
+  openvasArchives = stdenvNoCC.mkDerivation {
+    pname = "openvas-archives";
+    inherit version;
+
+    dontUnpack = true;
+
+    installPhase = ''
+      mkdir -p "$out"
+      mkdir -p "$out/include"
+
+      ln -s "${lib.getLib libgcryptStatic}/lib/libgcrypt.a" "$out/libgcrypt.a"
+      ln -s "${lib.getLib libgpgErrorStatic}/lib/libgpg-error.a" "$out/libgpg-error.a"
+      ln -s "${lib.getLib libpcapStatic}/lib/libpcap.a" "$out/libpcap.a"
+
+      ln -s "${lib.getLib krb5OpenvasStatic}/lib/libgssapi_krb5.a" "$out/libgssapi_krb5.a"
+      ln -s "${lib.getLib krb5OpenvasStatic}/lib/libkrb5.a" "$out/libkrb5.a"
+      ln -s "${lib.getLib krb5OpenvasStatic}/lib/libk5crypto.a" "$out/libk5crypto.a"
+      ln -s "${lib.getLib krb5OpenvasStatic}/lib/libcom_err.a" "$out/libcom_err.a"
+      ln -s "${lib.getLib krb5OpenvasStatic}/lib/libkrb5support.a" "$out/libkrb5support.a"
+
+      cp -r "${lib.getDev libgcryptStatic}/include/"* "$out/include/"
+      cp -r "${lib.getDev libgpgErrorStatic}/include/"* "$out/include/"
+      cp -r "${lib.getDev libpcapStatic}/include/"* "$out/include/"
+      cp -r "${lib.getDev krb5OpenvasStatic}/include/"* "$out/include/"
+    '';
+  };
 
   commonArgs = {
     inherit pname version;
@@ -68,10 +161,7 @@ let
       perl
       gnumake
       capnproto
-      pkgs.rustPlatform.bindgenHook
-      # Restore RPATH on binaries whose link directives bypass
-      # the Nix stdenv linker wrapper (see buildCache comment).
-      autoPatchelfHook
+      rustPlatform.bindgenHook
     ];
 
     buildInputs = [
@@ -88,7 +178,8 @@ let
       bzip2
     ];
 
-    OPENVAS_ARCHIVES = "${buildCache}";
+    OPENVAS_ARCHIVES = "${openvasArchives}";
+    LIBPCAP_LIBDIR = "${openvasArchives}";
   };
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -98,18 +189,10 @@ let
     mkdir -p ../misc
     ln -sf ${repoRoot}/misc/openvas-krb5.c ../misc/openvas-krb5.c
     ln -sf ${repoRoot}/misc/openvas-krb5.h ../misc/openvas-krb5.h
-
-    substituteInPlace crates/nasl-c-lib/build_support.rs \
-      --replace-fail 'cargo:rustc-link-lib=static=' 'cargo:rustc-link-lib=dylib='
-    substituteInPlace crates/nasl-c-lib/libopenvas-krb5-sys/build.rs \
-      --replace-fail '.a"' '.so"'
-    substituteInPlace crates/nasl-c-lib/libcrypt-sys/build.rs \
-      --replace-fail '.a"' '.so"'
   '';
 
   # Build each workspace binary separately, reusing the dependency artifacts
-  # so the workspace is compiled once.  Each binary gets its own derivation
-  # with its own RPATH fixed up by autoPatchelfHook.
+  # so the workspace is compiled once.
   buildBin =
     bin:
     craneLib.buildPackage (
@@ -122,9 +205,7 @@ let
         cargoExtraArgs = "--bin ${bin}";
 
         preCheck = ''
-          export LD_LIBRARY_PATH=${
-            pkgs.lib.makeLibraryPath commonArgs.buildInputs
-          }
+          export LD_LIBRARY_PATH=${lib.makeLibraryPath commonArgs.buildInputs}
         '';
 
         cargoTestExtraArgs = "-- --skip container_image_scanner";


### PR DESCRIPTION
**What**:

A `flake.nix` that builds the entire openvas-scanner workspace — the C `openvas` scanner and the Rust `openvasd`/`scannerctl`/`feed-filter` binaries — pinned to the same source tree.

```
nix build .#openvasd
nix run   .#scannerctl -- --help
nix flake check
```

**Why**:

I think it's interesting to have Nix flakes to make a way of native building and distribution.

**How**:

**C scanner:** built from source with CMake. Reuses `gvm-libs` from nixpkgs (22.31.1 — the scanner only needs ≥22.4). Uses `substituteInPlace` to strip `-Werror` from the CMake files rather than a blanket `NIX_CFLAGS_COMPILE`. Installs via `DESTDIR` with standard FHS paths; `autoPatchelfHook` fixes RPATH since the non-standard install layout bypasses the Nix linker wrapper.

**Rust scanner:** built with [crane](https://github.com/ipetkov/crane) and [fenix](https://github.com/nix-community/fenix). Each workspace binary is its own derivation sharing a single `buildDepsOnly` cache. The `nasl-c-lib` `-sys` crates are the trickiest part — they use a custom `build_support.rs` that discovers native libraries through `$OPENVAS_ARCHIVES` rather than pkg-config. The flake works around this with:

- A `buildCache` derivation that symlinks `libgcrypt`, `libgpg-error`, and Kerberos `.so` files + headers into the flat layout the `-sys` crates expect.
- A `postPatch` that switches `cargo:rustc-link-lib=static=` → `dylib=` and `.a` → `.so` so Nix's shared libraries are used instead of the upstream static archive convention (those static archives are produced by an upstream Docker-only "build-archives" stage and aren't reproducible outside that environment).
- `autoPatchelfHook` restores RPATH on the final binaries since the `-sys` crates emit direct `cargo:rustc-link` directives that bypass the stdenv linker wrapper.

**Tests:** enabled by default (`doCheck = true`) on the per-binary builds — 64 pass. The `container_image_scanner` tests are skipped (they need a Docker registry in the sandbox). The full workspace build has `doCheck = false` because `cargo test --lib` hits `nasl::builtin::sys::tests::find_in_path` which SIGABRTs in the sandbox; no coverage is lost since the per-binary builds exercise the same code.

### Fragility notes

- `sha256` in `fromToolchainFile` (flake.nix:31) — needs updating when `rust/rust-toolchain.toml` changes channel. 

### To be discused

Depending on the level of adoption of flakes, some points must be discussed:

- **CI** — `nix flake check` should gate PRs.
- Supporting nixos or home manager modules would be interesting for easy deploying & configuration. They would be tested by using the nixos' vm output.
- Version actually parsed from `CMakeLists.txt` on the `openvas` project. Maybe we should use a easier way to declare version. 
- At the moment we use nixpkgs' `gvm-libs`, but it may be interesting to package it here.
- Fill manteiners on meta block
- Also package `ospd-openvas`?
- Make nmap dependency optional

**Checklist**:

- [X] Test - x86_64-linux
- [ ] Test - aarch64-linux
- [ ] PR merge commit message adjusted
