### PR TITLE
Fix dead link to the authentication methods in the installation guide

### DIFF
--- a/RELICENSE/tgurr.md
+++ b/RELICENSE/tgurr.md
@@ -1,0 +1,80 @@
+Thank you for your interest in the project openvas-scanner managed by Greenbone.
+In order for you to make Contributions now or in the future to this
+project, You agree to license your Contributions under the MIT-0 license (see below).
+Please note that You remain the copyright owner, and anyone receives the right to
+use your Contribution in proprietary and open source software without any
+attribution.
+ 
+..................
+ 
+MIT No Attribution (MIT-0)
+ 
+Copyright <YEAR> <COPYRIGHT HOLDER>
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ 
+.........................
+ 
+Please note that You remain the copyright owner, and anyone receives the
+right to use your Contribution in proprietary and open source software
+without attribution. However, we will include your name as a Contributor
+in our CREDITS list as long as your Contribution is used in the project
+openvas-scanner.
+ 
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is submitted by you
+to Greenbone for inclusion in the project openvas-scanner.
+ 
+Greenbone requires that each Contribution you submit now or in the
+future to comply with the following commitments documented in the
+Developer Certificate of Origin (DCO) [https://developercertificate.org/]:
+ 
+........
+ 
+Developer Certificate of Origin
+ 
+Version 1.1
+ 
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+ 
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+ 
+Developer's Certificate of Origin 1.1
+ 
+By making a contribution to this project, I certify that:
+ 
+(a) The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+ 
+(b) The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+ 
+(c) The contribution was provided directly to me by some other
+   person who certified (a), (b) or (c) and I have not modified
+   it.
+ 
+(d) I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.
+ 
+.....

--- a/doc/full_installation_guide.md
+++ b/doc/full_installation_guide.md
@@ -691,7 +691,7 @@ EOF
 
 <i>WARNING
 
-The systemd setup only includes the API-key setup. Please follow the instructions at https://github.com/greenbone/openvas-scanner/tree/main/rust/openvasd for more information about authentication methods.
+The systemd setup only includes the API-key setup. Please follow the instructions at https://github.com/greenbone/openvas-scanner/tree/main/rust/src/openvasd#authentication for more information about authentication methods.
 </i>
 
 Systemd service file for openvasd:


### PR DESCRIPTION
**What**: Fix dead link.

**Why**:

Error 404: https://github.com/greenbone/openvas-scanner/tree/main/rust/openvasd

**How**:

Replace with: https://github.com/greenbone/openvas-scanner/tree/main/rust/src/openvasd#authentication

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] PR merge commit message adjusted N/A
