### PR TITLE
Add: Restructure feed-filter and add dependency filter functionality

### DIFF
--- a/rust/src/feed_filter/builtins.rs
+++ b/rust/src/feed_filter/builtins.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use scannerlib::nasl::nasl_std_executor;
+use scannerlib::nasl::syntax::grammar::Ast;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::utils::iter_fn_calls;
+
+#[derive(Eq, Hash, PartialEq, Clone)]
+pub enum BuiltinStatus {
+    Used,
+    Unused,
+    Deprecated,
+}
+
+/// This struct holds information about implemented and unimplemented built-in functions
+/// based on the documentation files and rust implementation of NASL. It also tracks
+/// functions that are present in the rust implementation but not documented.
+pub struct BuiltinFunctions {
+    /// HashMap<function_name, (category, deprecated)>
+    implemented: HashMap<String, (String, bool)>,
+    /// HashMap<function_name, (category, deprecated)>
+    unimplemented: HashMap<String, (String, bool)>,
+    /// Set of undocumented functions
+    pub undocumented: HashSet<String>,
+}
+
+impl BuiltinFunctions {
+    pub fn new(doc_path: PathBuf) -> Self {
+        let mut implemented = HashMap::new();
+        let mut unimplemented = HashMap::new();
+
+        let exec = nasl_std_executor();
+        let mut implemented_funcs = exec.iter().map(|f| f.to_string()).collect::<HashSet<_>>();
+
+        for entry in fs::read_dir(doc_path).unwrap() {
+            let entry = entry.unwrap();
+            let category_path = entry.path();
+            let category = category_path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+
+            if category_path.is_dir() {
+                for func_entry in fs::read_dir(category_path).unwrap() {
+                    let func_path = func_entry.unwrap().path();
+                    let function = func_path
+                        .file_stem()
+                        .unwrap()
+                        .to_string_lossy()
+                        .into_owned();
+
+                    if function == "index" {
+                        continue;
+                    }
+
+                    let content = fs::read_to_string(func_path.clone())
+                        .unwrap()
+                        .to_ascii_lowercase();
+
+                    let deprecated = content.contains("## deprecated");
+
+                    if implemented_funcs.take(&function).is_some() {
+                        implemented.insert(function, (category.clone(), deprecated));
+                    } else {
+                        unimplemented.insert(function, (category.clone(), deprecated));
+                    }
+                }
+            }
+        }
+        Self {
+            implemented,
+            unimplemented,
+            undocumented: implemented_funcs,
+        }
+    }
+
+    pub fn implemented(&self) -> &HashMap<String, (String, bool)> {
+        &self.implemented
+    }
+
+    pub fn unimplemented(&self) -> &HashMap<String, (String, bool)> {
+        &self.unimplemented
+    }
+
+    pub fn script_is_runnable(&self, ast: &Ast) -> bool {
+        for call in iter_fn_calls(ast) {
+            let function = call.fn_name.to_string();
+            if let Some((_, deprecated)) = self.unimplemented().get(&function)
+                && !deprecated
+            {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/rust/src/feed_filter/dep_filter.rs
+++ b/rust/src/feed_filter/dep_filter.rs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+use scannerlib::nasl::Code;
+use scannerlib::nasl::syntax::Loader;
+
+use crate::script::ScriptPath;
+use crate::utils::oid_from_ast;
+
+/// Dependencies of a script.
+pub struct ScriptDepsInfo {
+    /// include deps
+    pub includes: Vec<ScriptPath>,
+    /// script_dependencies deps
+    pub script_dependencies: Vec<ScriptPath>,
+    /// The OID of this script, if present.
+    pub oid: Option<String>,
+}
+
+impl ScriptDepsInfo {
+    pub fn all_deps(&self) -> impl Iterator<Item = &ScriptPath> {
+        self.includes.iter().chain(self.script_dependencies.iter())
+    }
+}
+
+/// Map from every script in the feed to its dependency info.
+pub type DepMap = HashMap<ScriptPath, ScriptDepsInfo>;
+
+/// Reads the feed and builds the full dependency map.
+pub struct DepReader {
+    feed_path: PathBuf,
+    loader: Loader,
+}
+
+impl DepReader {
+    pub fn new(feed_path: PathBuf) -> Self {
+        let loader = Loader::from_feed_path(&feed_path);
+        Self { feed_path, loader }
+    }
+
+    /// Read the given root scripts and all their dependencies recursively.
+    ///
+    /// Only the files that are actually reachable from `roots` are read from
+    /// disk; the rest of the feed is never touched.
+    pub fn read_from_roots(&mut self, roots: &[ScriptPath]) -> DepMap {
+        let mut map: DepMap = HashMap::default();
+        let mut queue: VecDeque<ScriptPath> = roots.iter().cloned().collect();
+
+        while let Some(path) = queue.pop_front() {
+            if map.contains_key(&path) {
+                continue;
+            }
+            let full_path = self.feed_path.join(&path.0);
+            match self.read_one(&full_path) {
+                Some(info) => {
+                    for dep in info.all_deps() {
+                        if !map.contains_key(dep) {
+                            queue.push_back(dep.clone());
+                        }
+                    }
+                    map.insert(path, info);
+                }
+                None => {
+                    eprintln!("Warning: could not read {}", path.0);
+                }
+            }
+        }
+
+        map
+    }
+
+    fn read_one(&mut self, path: &Path) -> Option<ScriptDepsInfo> {
+        let code = Code::load(&self.loader, path).ok()?;
+        let ast = code.parse().emit_errors().ok()?;
+        Some(extract_deps(&ast, &self.feed_path))
+    }
+}
+
+fn extract_deps(ast: &scannerlib::nasl::syntax::grammar::Ast, feed_path: &Path) -> ScriptDepsInfo {
+    let sp = search_path::SearchPath::from(feed_path.to_path_buf());
+
+    let includes = ast
+        .iter_includes()
+        .filter_map(|inc| {
+            sp.find_file(&PathBuf::from(&inc.path))
+                .map(|p| ScriptPath::new(feed_path, &p))
+        })
+        .collect();
+
+    let script_dependencies = ast
+        .iter_fn_calls()
+        .filter(|call| call.fn_name.to_string() == "script_dependencies")
+        .flat_map(|call| {
+            call.args.items.iter().filter_map(|arg| {
+                let s = arg.to_string();
+                // Args are double-quoted string literals: `"filename.nasl"`
+                let name = if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+                    s[1..s.len() - 1].to_string()
+                } else {
+                    return None;
+                };
+                sp.find_file(&PathBuf::from(&name))
+                    .map(|p| ScriptPath::new(feed_path, &p))
+            })
+        })
+        .collect();
+
+    let oid = oid_from_ast(ast);
+
+    ScriptDepsInfo {
+        includes,
+        script_dependencies,
+        oid,
+    }
+}
+
+pub fn resolve_script(feed_path: &Path, script: &Path) -> Option<ScriptPath> {
+    if script.is_absolute() {
+        pathdiff::diff_paths(script, feed_path)
+            .map(|rel| ScriptPath(rel.to_string_lossy().into_owned()))
+    } else {
+        let full = feed_path.join(script);
+        if full.exists() {
+            Some(ScriptPath(script.to_string_lossy().into_owned()))
+        } else {
+            None
+        }
+    }
+}

--- a/rust/src/feed_filter/error.rs
+++ b/rust/src/feed_filter/error.rs
@@ -7,12 +7,14 @@ use std::fmt;
 #[derive(Debug)]
 pub(crate) enum CliError {
     Io(std::io::Error),
+    Message(String),
 }
 
 impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CliError::Io(error) => write!(f, "{error}"),
+            CliError::Message(msg) => write!(f, "{msg}"),
         }
     }
 }
@@ -20,6 +22,12 @@ impl fmt::Display for CliError {
 impl From<std::io::Error> for CliError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+impl From<&str> for CliError {
+    fn from(value: &str) -> Self {
+        Self::Message(value.to_string())
     }
 }
 

--- a/rust/src/feed_filter/main.rs
+++ b/rust/src/feed_filter/main.rs
@@ -2,29 +2,49 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
+mod builtins;
+mod dep_filter;
 mod error;
+mod output;
+mod script;
+mod stats;
+mod utils;
 
-use clap::Parser;
-use scannerlib::models::{Scan, VT};
-use scannerlib::nasl::syntax::Loader;
-use scannerlib::nasl::syntax::grammar::{Ast, Atom, Expr, FnCall, Statement};
-use scannerlib::nasl::{Code, nasl_std_executor};
-use std::collections::HashSet;
-use std::fmt::Display;
-use std::io::{self};
+use clap::{Parser, Subcommand};
+use std::fs;
 use std::path::PathBuf;
-use std::{collections::HashMap, fs, path::Path};
-use walkdir::WalkDir;
 
+use crate::builtins::BuiltinFunctions;
+use crate::dep_filter::{DepReader, resolve_script};
 use crate::error::CliError;
+use crate::output::{
+    copy_dep_feed, copy_feed, print_dep_scripts, print_scripts, write_dep_scan_config,
+    write_scan_config,
+};
+use crate::script::{RunnableScripts, ScriptReader};
+use crate::stats::BuiltinStats;
 
-#[derive(clap::Parser)]
+#[derive(Parser)]
 #[command(
     name = "feed-filter",
-    about = "Filters scripts from the feed which aren't runnable with the current set of builtins in the openvasd implementation.",
+    about = "Utilities for filtering and analysing NASL feed scripts.",
     version = env!("CARGO_PKG_VERSION")
 )]
-struct FilterArgs {
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Filter feed based on built-in function coverage.
+    Builtin(BuiltinArgs),
+    /// Filter feed based on given root scripts and their dependencies.
+    Dep(DepArgs),
+}
+
+#[derive(clap::Args)]
+struct BuiltinArgs {
     /// Path to the feed that should be read and filtered.
     feed_path: PathBuf,
     /// Path to the documentation nasl builtin base directory.
@@ -39,7 +59,7 @@ struct FilterArgs {
     /// unimplemented built-in function usage will be written to this file.
     #[clap(long)]
     stat_out: Option<PathBuf>,
-    /// List all runnable scripts to stdout
+    /// List all runnable scripts to stdout.
     #[clap(short, long)]
     list: bool,
     /// If present, a template scan json containing the OIDs of all
@@ -48,544 +68,7 @@ struct FilterArgs {
     scan_config: Option<PathBuf>,
 }
 
-#[derive(Eq, Hash, PartialEq, Clone)]
-enum BuiltinStatus {
-    Used,
-    Unused,
-    Deprecated,
-}
-
-struct CategoryStats {
-    implemented: Vec<(String, usize)>,
-    unimplemented: HashMap<BuiltinStatus, Vec<(String, usize)>>,
-}
-
-struct BuiltinStats {
-    undocumented: Vec<String>,
-    categories: HashMap<String, CategoryStats>,
-}
-
-impl BuiltinStats {
-    fn new(scripts: &Scripts, builtins: &BuiltinFunctions) -> Self {
-        let mut category_stats = HashMap::new();
-        let mut function_calls = HashMap::new();
-
-        // Initialize all built-in functions with zero calls
-        for (func, _) in builtins.unimplemented().iter() {
-            function_calls.entry(func.clone()).or_insert(0);
-        }
-        for (func, _) in builtins.implemented().iter() {
-            function_calls.entry(func.clone()).or_insert(0);
-        }
-
-        // Count function calls in all scripts
-        for (_, script) in scripts.iter() {
-            for call in iter_fn_calls(&script.ast) {
-                let function = call.fn_name.to_string();
-                *function_calls.entry(function).or_insert(0) += 1;
-            }
-        }
-
-        for (func, calls) in function_calls.iter() {
-            if let Some((category, _)) = builtins.implemented().get(func) {
-                let stats = category_stats
-                    .entry(category.clone())
-                    .or_insert(CategoryStats {
-                        implemented: vec![],
-                        unimplemented: HashMap::new(),
-                    });
-                stats.implemented.push((func.clone(), *calls));
-            } else if let Some((category, deprecated)) = builtins.unimplemented().get(func) {
-                let stats = category_stats
-                    .entry(category.clone())
-                    .or_insert(CategoryStats {
-                        implemented: vec![],
-                        unimplemented: HashMap::new(),
-                    });
-                let status = if *deprecated {
-                    BuiltinStatus::Deprecated
-                } else if *calls > 0 {
-                    BuiltinStatus::Used
-                } else {
-                    BuiltinStatus::Unused
-                };
-                stats
-                    .unimplemented
-                    .entry(status)
-                    .or_insert(vec![])
-                    .push((func.clone(), *calls));
-            }
-        }
-
-        Self {
-            undocumented: builtins.undocumented.iter().cloned().collect(),
-            categories: category_stats,
-        }
-    }
-}
-
-impl Display for BuiltinStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "# Coverage of NASL built-in functions per Category\n")?;
-        let mut num_functions = 0;
-        let mut num_implemented = 0;
-        for (category, stats) in self.categories.iter() {
-            let num_unimplemented: usize = stats.unimplemented.values().map(|v| v.len()).sum();
-            num_functions += stats.implemented.len() + num_unimplemented;
-            num_implemented += stats.implemented.len();
-            writeln!(f, "## {}\n", category)?;
-            writeln!(f, "<b>")?;
-            writeln!(
-                f,
-                "Functions: {}\n",
-                stats.implemented.len() + num_unimplemented
-            )?;
-            writeln!(f, "Implemented: {}\n", stats.implemented.len())?;
-            writeln!(
-                f,
-                "Percentage implemented: {:.2}%",
-                (stats.implemented.len() as f64
-                    / (stats.implemented.len() + num_unimplemented) as f64)
-                    * 100.0
-            )?;
-            writeln!(f, "</b>\n")?;
-            if !stats.implemented.is_empty() {
-                writeln!(f, "### Implemented Functions\n")?;
-                let mut funcs = stats.implemented.clone();
-                funcs.sort_by_key(|(_, a)| *a);
-                funcs.reverse();
-                for (func, count) in funcs {
-                    writeln!(f, "- {} (used {} times)", func, count)?;
-                }
-                writeln!(f)?;
-            }
-            writeln!(f, "### Unimplemented Functions\n")?;
-            let statuses = [
-                BuiltinStatus::Used,
-                BuiltinStatus::Unused,
-                BuiltinStatus::Deprecated,
-            ];
-            for status in statuses {
-                if let Some(funcs) = stats.unimplemented.get(&status)
-                    && !funcs.is_empty()
-                {
-                    match status {
-                        BuiltinStatus::Used => {
-                            writeln!(f, "#### Used\n")?;
-                        }
-                        BuiltinStatus::Unused => {
-                            writeln!(f, "#### Unused\n")?;
-                        }
-                        BuiltinStatus::Deprecated => {
-                            writeln!(f, "#### Deprecated\n")?;
-                        }
-                    }
-                    let mut funcs = funcs.clone();
-                    funcs.sort_by_key(|(_, a)| *a);
-                    funcs.reverse();
-                    for (func, count) in funcs {
-                        writeln!(f, "- {} (used {} times)", func, count)?;
-                    }
-                    writeln!(f)?;
-                }
-            }
-        }
-        writeln!(f, "# Overall Coverage\n")?;
-        writeln!(f, "<b>")?;
-        writeln!(f, "Total Functions: {}\n", num_functions)?;
-        writeln!(f, "Total Implemented: {}\n", num_implemented)?;
-        writeln!(f, "Total Missing: {}\n", num_functions - num_implemented)?;
-        writeln!(
-            f,
-            "Overall Percentage implemented: {:.2}%",
-            (num_implemented as f64 / num_functions as f64) * 100.0
-        )?;
-        writeln!(f, "</b>\n")?;
-        writeln!(f, "## Undocumented Functions (Rust Only)\n")?;
-        for func in self.undocumented.iter() {
-            writeln!(f, "- {}", func)?;
-        }
-        Ok(())
-    }
-}
-
-/// This struct holds information about implemented and unimplemented built-in functions
-/// based on the documentation files and rust implementation of NASL. It also tracks
-/// functions that are present in the rust implementation but not documented.
-struct BuiltinFunctions {
-    /// HashMap<function_name, (category, deprecated)>
-    implemented: HashMap<String, (String, bool)>,
-    /// HashMap<function_name, (category, deprecated)>
-    unimplemented: HashMap<String, (String, bool)>,
-    /// Set of undocumented functions
-    undocumented: HashSet<String>,
-}
-
-impl BuiltinFunctions {
-    fn new(doc_path: PathBuf) -> Self {
-        let mut implemented = HashMap::new();
-        let mut unimplemented = HashMap::new();
-
-        let exec = nasl_std_executor();
-        let mut implemented_funcs = exec.iter().map(|f| f.to_string()).collect::<HashSet<_>>();
-
-        for entry in fs::read_dir(doc_path).unwrap() {
-            let entry = entry.unwrap();
-            let category_path = entry.path();
-            let category = category_path
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .into_owned();
-
-            if category_path.is_dir() {
-                for func_entry in fs::read_dir(category_path).unwrap() {
-                    let func_path = func_entry.unwrap().path();
-                    let function = func_path
-                        .file_stem()
-                        .unwrap()
-                        .to_string_lossy()
-                        .into_owned();
-
-                    if function == "index" {
-                        continue;
-                    }
-
-                    let content = fs::read_to_string(func_path.clone())
-                        .unwrap()
-                        .to_ascii_lowercase();
-
-                    let deprecated = content.contains("## deprecated");
-
-                    if implemented_funcs.take(&function).is_some() {
-                        implemented.insert(function, (category.clone(), deprecated));
-                    } else {
-                        unimplemented.insert(function, (category.clone(), deprecated));
-                    }
-                }
-            }
-        }
-        Self {
-            implemented,
-            unimplemented,
-            undocumented: implemented_funcs,
-        }
-    }
-
-    fn implemented(&self) -> &HashMap<String, (String, bool)> {
-        &self.implemented
-    }
-
-    fn unimplemented(&self) -> &HashMap<String, (String, bool)> {
-        &self.unimplemented
-    }
-
-    fn script_is_runnable(&self, ast: &Ast) -> bool {
-        for call in iter_fn_calls(ast) {
-            let function = call.fn_name.to_string();
-            if let Some((_, deprecated)) = self.unimplemented().get(&function)
-                && !deprecated
-            {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-fn iter_fn_calls(ast: &Ast) -> impl Iterator<Item = &FnCall> {
-    ast.iter_exprs().filter_map(|expr| {
-        if let Expr::Atom(Atom::FnCall(fn_call)) = expr {
-            Some(fn_call)
-        } else {
-            None
-        }
-    })
-}
-
-// poor mans TQDM
-fn progress<T>(x: Vec<T>) -> impl Iterator<Item = T> {
-    let num = x.len();
-    let mut last_whole = 0;
-    eprintln!("Reading Scripts...");
-    x.into_iter().enumerate().map(move |(i, x)| {
-        let completed_fraction = (i + 1) as f64 / num as f64;
-        let percentage = (completed_fraction * 100.0) as usize;
-        if percentage > last_whole {
-            last_whole = percentage;
-            if i + 1 == num {
-                eprintln!("\rProgress: 100%");
-            } else {
-                eprint!("\rProgress: {}%", percentage);
-            }
-        }
-        x
-    })
-}
-
-fn oid_from_ast(ast: &Ast) -> Option<String> {
-    iter_fn_calls(ast)
-        .find(|call| call.fn_name.to_string() == "script_oid")
-        .map(|call| {
-            call.args
-                .items
-                .first()
-                .unwrap()
-                .to_string()
-                .replace('\"', "")
-        })
-}
-
-type Scripts = HashMap<ScriptPath, Script>;
-
-#[derive(Clone, Debug)]
-enum ScriptKind {
-    Runnable,
-    NotRunnable,
-    Dependencies(Vec<ScriptPath>),
-}
-
-#[derive(Clone, Debug)]
-struct Script {
-    kind: ScriptKind,
-    ast: Ast,
-    oid: Option<String>,
-}
-
-impl Script {
-    fn new(kind: ScriptKind, ast: Ast) -> Self {
-        Self {
-            kind,
-            oid: oid_from_ast(&ast),
-            ast,
-        }
-    }
-
-    fn runnable(ast: Ast) -> Self {
-        Self::new(ScriptKind::Runnable, ast)
-    }
-
-    fn not_runnable(ast: Ast) -> Self {
-        Self::new(ScriptKind::NotRunnable, ast)
-    }
-
-    fn dependencies(deps: Vec<ScriptPath>, ast: Ast) -> Self {
-        Self::new(ScriptKind::Dependencies(deps), ast)
-    }
-
-    fn iter_dependencies(&self) -> impl Iterator<Item = &ScriptPath> {
-        if let ScriptKind::Dependencies(dependencies) = &self.kind {
-            dependencies.iter()
-        } else {
-            panic!("iter_dependencies() called on non-dependencies variant")
-        }
-    }
-
-    fn is_runnable(&self) -> bool {
-        matches!(self.kind, ScriptKind::Runnable)
-    }
-
-    fn is_not_runnable(&self) -> bool {
-        matches!(self.kind, ScriptKind::NotRunnable)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct ScriptPath(String);
-
-impl ScriptPath {
-    fn new(feed_path: &Path, path: &Path) -> Self {
-        let relative = pathdiff::diff_paths(path, feed_path).unwrap();
-        Self(relative.as_os_str().to_str().unwrap().to_string())
-    }
-}
-
-struct ScriptReader<'a> {
-    feed_path: PathBuf,
-    loader: Loader,
-    builtins: &'a BuiltinFunctions,
-}
-
-impl<'a> ScriptReader<'a> {
-    fn new(feed_path: PathBuf, builtins: &'a BuiltinFunctions) -> Self {
-        let loader = Loader::from_feed_path(&feed_path);
-        Self {
-            feed_path,
-            loader,
-            builtins,
-        }
-    }
-
-    fn read_scripts(&mut self) -> Scripts {
-        let mut scripts = HashMap::default();
-        let entries: Vec<_> = WalkDir::new(&self.feed_path).into_iter().collect();
-        for entry in progress(entries) {
-            let entry = entry.unwrap();
-            if entry.file_type().is_file() {
-                let path = entry.path();
-                if path
-                    .extension()
-                    .is_none_or(|ext| ext != "nasl" && ext != "inc")
-                {
-                    continue;
-                }
-                let script_path = ScriptPath::new(&self.feed_path, path);
-                if let Some(script) = self.script_from_path(path) {
-                    scripts.insert(script_path, script);
-                }
-            }
-        }
-        scripts
-    }
-
-    fn script_from_path(&mut self, path: &Path) -> Option<Script> {
-        let ast = self.ast_from_path(path)?;
-        let script = self.script_from_ast(ast);
-        Some(script)
-    }
-
-    fn ast_from_path(&mut self, path: &Path) -> Option<Ast> {
-        let code = Code::load(&self.loader, path).unwrap();
-        let ast = code.parse().emit_errors().unwrap();
-        Some(ast)
-    }
-
-    fn script_from_ast(&mut self, ast: Ast) -> Script {
-        let is_runnable = self.builtins.script_is_runnable(&ast);
-        let dependencies = self.get_dependencies(&ast);
-        if !is_runnable {
-            Script::not_runnable(ast)
-        } else if dependencies.is_empty() {
-            Script::runnable(ast)
-        } else {
-            Script::dependencies(dependencies, ast)
-        }
-    }
-
-    fn get_dependencies(&self, ast: &Ast) -> Vec<ScriptPath> {
-        ast.iter_stmts()
-            .filter_map(|stmt| {
-                if let Statement::Include(include) = stmt {
-                    let sp = search_path::SearchPath::from(self.feed_path.clone());
-                    sp.find_file(&PathBuf::from(include.path.as_str()))
-                        .map(|i| ScriptPath::new(&self.feed_path, &i))
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-}
-
-struct RunnableScripts(Scripts);
-
-impl RunnableScripts {
-    fn new(unresolved: Scripts) -> Self {
-        let resolved = Self::resolve(unresolved);
-        Self(
-            resolved
-                .into_iter()
-                .filter(|(_, script)| script.is_runnable())
-                .collect(),
-        )
-    }
-
-    fn resolve(mut unresolved: Scripts) -> Scripts {
-        let mut resolved: Scripts = HashMap::default();
-        loop {
-            let (newly_resolved, newly_unresolved) = unresolved
-                .into_iter()
-                .partition::<HashMap<_, _>, _>(|(_, script)| {
-                    script.is_runnable() || script.is_not_runnable()
-                });
-            unresolved = newly_unresolved;
-            let new_length = newly_resolved.len();
-            resolved.extend(newly_resolved);
-            if unresolved.is_empty() {
-                return resolved;
-            }
-            if new_length == 0 {
-                for (k, v) in unresolved.iter() {
-                    for dep in v.iter_dependencies() {
-                        assert!(
-                            resolved.keys().any(|k| k.0 == dep.0)
-                                || unresolved.keys().any(|k| k.0 == dep.0),
-                            "References to non-existent file: {}. dep: {}",
-                            k.0,
-                            dep.0
-                        );
-                    }
-                }
-            }
-            for v in unresolved.values_mut() {
-                let any_not_runnable = v
-                    .iter_dependencies()
-                    .any(|dep| resolved.get(dep).is_some_and(|s| s.is_not_runnable()));
-                if any_not_runnable {
-                    v.kind = ScriptKind::NotRunnable;
-                    continue;
-                }
-                let all_resolved = v.iter_dependencies().all(|dep| resolved.contains_key(dep));
-                if !all_resolved {
-                    continue;
-                }
-                v.kind = ScriptKind::Runnable;
-            }
-        }
-    }
-
-    fn iter(&self) -> impl Iterator<Item = (&ScriptPath, &Script)> {
-        self.0.iter()
-    }
-}
-
-fn copy_feed(
-    runnable: &RunnableScripts,
-    feed_path: &Path,
-    output_path: &Path,
-) -> Result<(), io::Error> {
-    fs::create_dir_all(output_path)?;
-    for (path, _) in runnable.iter() {
-        let src = feed_path.join(&path.0);
-        let dst = output_path.join(&path.0);
-        fs::create_dir_all(dst.parent().unwrap())?;
-        std::fs::copy(src, dst)?;
-    }
-    Ok(())
-}
-
-fn print_scripts(runnable: &RunnableScripts) {
-    for (path, _) in runnable.iter() {
-        println!("{path:?}");
-    }
-}
-
-fn write_scan_config(
-    runnable: &RunnableScripts,
-    feed_path: &Path,
-    scan_config: &PathBuf,
-) -> Result<(), io::Error> {
-    let scan = get_scan_config(feed_path, runnable);
-    fs::write(scan_config, serde_json::to_string(&scan).unwrap())
-}
-
-fn get_scan_config(_feed_path: &Path, runnable: &RunnableScripts) -> Scan {
-    let vts: Vec<_> = runnable
-        .iter()
-        .filter_map(|(_, script)| {
-            script.oid.as_ref().map(|oid| VT {
-                oid: oid.clone(),
-                parameters: vec![],
-            })
-        })
-        .collect();
-    Scan {
-        vts,
-        ..Default::default()
-    }
-}
-
-fn run(args: FilterArgs) -> Result<(), CliError> {
+fn run_builtin_filter(args: BuiltinArgs) -> Result<(), CliError> {
     let builtins = BuiltinFunctions::new(args.doc_path.clone());
     let mut reader = ScriptReader::new(args.feed_path.to_owned(), &builtins);
     let scripts = reader.read_scripts();
@@ -606,18 +89,76 @@ fn run(args: FilterArgs) -> Result<(), CliError> {
     Ok(())
 }
 
+#[derive(clap::Args)]
+struct DepArgs {
+    /// Path to the feed directory.
+    feed_path: PathBuf,
+    /// One or more .nasl scripts (paths relative to the feed root) to use as
+    /// the starting points. All transitive dependencies are included.
+    #[clap(required = true)]
+    scripts: Vec<PathBuf>,
+    /// Copy the filtered feed (root scripts + all dependencies) to this directory.
+    #[clap(long)]
+    feed_out: Option<PathBuf>,
+    /// List all collected scripts to stdout.
+    #[clap(short, long)]
+    list: bool,
+    /// Write a scan-config JSON with the OIDs of all collected scripts to this path.
+    #[clap(short, long)]
+    scan_config: Option<PathBuf>,
+}
+
+fn run_dep_filter(args: DepArgs) -> Result<(), CliError> {
+    // Resolve root scripts before touching the feed.
+    let roots: Vec<_> = args
+        .scripts
+        .iter()
+        .filter_map(|s| {
+            let resolved = resolve_script(&args.feed_path, s);
+            if resolved.is_none() {
+                eprintln!("Warning: script not found in feed: {}", s.display());
+            }
+            resolved
+        })
+        .collect();
+
+    if roots.is_empty() {
+        return Err(CliError::from("No valid root scripts found in the feed."));
+    }
+
+    let mut reader = DepReader::new(args.feed_path.clone());
+    // Read only the reachable scripts, not the entire feed.
+    let dep_map = reader.read_from_roots(&roots);
+
+    // The dep_map already contains exactly the reachable set.
+    let collected: std::collections::HashSet<_> = dep_map.keys().cloned().collect();
+
+    if let Some(ref output_path) = args.feed_out {
+        copy_dep_feed(&collected, &args.feed_path, output_path)?;
+    }
+    if args.list {
+        print_dep_scripts(&collected);
+    }
+    if let Some(ref scan_config) = args.scan_config {
+        write_dep_scan_config(&collected, &dep_map, scan_config)?;
+    }
+
+    Ok(())
+}
+
 fn main() -> Result<(), CliError> {
-    let cli = FilterArgs::parse();
-    run(cli)
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Builtin(args) => run_builtin_filter(args),
+        Command::Dep(args) => run_dep_filter(args),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use scannerlib::nasl::syntax::grammar::Ast;
 
-    use super::{RunnableScripts, ScriptPath};
-
-    use super::{Script, Scripts};
+    use crate::script::{RunnableScripts, Script, ScriptPath, Scripts};
 
     fn path(path_str: &str) -> ScriptPath {
         ScriptPath(path_str.to_string())

--- a/rust/src/feed_filter/output.rs
+++ b/rust/src/feed_filter/output.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use scannerlib::models::{Scan, VT};
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Error};
+use std::path::{Path, PathBuf};
+
+use crate::dep_filter::DepMap;
+use crate::script::{RunnableScripts, ScriptPath};
+
+pub fn copy_feed(
+    runnable: &RunnableScripts,
+    feed_path: &Path,
+    output_path: &Path,
+) -> Result<(), io::Error> {
+    fs::create_dir_all(output_path)?;
+    for (path, _) in runnable.iter() {
+        let src = feed_path.join(&path.0);
+        let dst = output_path.join(&path.0);
+        fs::create_dir_all(dst.parent().unwrap())?;
+        std::fs::copy(src, dst)?;
+    }
+    Ok(())
+}
+
+pub fn print_scripts(runnable: &RunnableScripts) {
+    for (path, _) in runnable.iter() {
+        println!("{path:?}");
+    }
+}
+
+pub fn write_scan_config(
+    runnable: &RunnableScripts,
+    feed_path: &Path,
+    scan_config: &PathBuf,
+) -> Result<(), Error> {
+    let scan = get_scan_config(feed_path, runnable);
+    fs::write(scan_config, serde_json::to_string(&scan).unwrap())
+}
+
+fn get_scan_config(_feed_path: &Path, runnable: &RunnableScripts) -> Scan {
+    let vts: Vec<_> = runnable
+        .iter()
+        .filter_map(|(_, script)| {
+            script.oid.as_ref().map(|oid| VT {
+                oid: oid.clone(),
+                parameters: vec![],
+            })
+        })
+        .collect();
+    Scan {
+        vts,
+        ..Default::default()
+    }
+}
+
+/// Copy a set of scripts (given as relative `ScriptPath`s) from `feed_path`
+/// into `output_path`, recreating the directory structure.
+pub fn copy_dep_feed(
+    paths: &HashSet<ScriptPath>,
+    feed_path: &Path,
+    output_path: &Path,
+) -> Result<(), io::Error> {
+    fs::create_dir_all(output_path)?;
+    for path in paths {
+        let src = feed_path.join(&path.0);
+        let dst = output_path.join(&path.0);
+        fs::create_dir_all(dst.parent().unwrap())?;
+        fs::copy(src, dst)?;
+    }
+    Ok(())
+}
+
+/// Print the relative path of every collected script to stdout.
+pub fn print_dep_scripts(paths: &HashSet<ScriptPath>) {
+    let mut sorted: Vec<&str> = paths.iter().map(|p| p.0.as_str()).collect();
+    sorted.sort_unstable();
+    for p in sorted {
+        println!("{p}");
+    }
+}
+
+/// Write a scan-config JSON containing the OIDs of all collected scripts.
+pub fn write_dep_scan_config(
+    paths: &HashSet<ScriptPath>,
+    dep_map: &DepMap,
+    scan_config: &PathBuf,
+) -> Result<(), Error> {
+    let vts: Vec<_> = paths
+        .iter()
+        .filter_map(|p| {
+            dep_map.get(p)?.oid.as_ref().map(|oid| VT {
+                oid: oid.clone(),
+                parameters: vec![],
+            })
+        })
+        .collect();
+    let scan = Scan {
+        vts,
+        ..Default::default()
+    };
+    fs::write(scan_config, serde_json::to_string(&scan).unwrap())
+}

--- a/rust/src/feed_filter/script.rs
+++ b/rust/src/feed_filter/script.rs
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use scannerlib::nasl::Code;
+use scannerlib::nasl::syntax::Loader;
+use scannerlib::nasl::syntax::grammar::{Ast, Statement};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use crate::builtins::BuiltinFunctions;
+use crate::utils::{oid_from_ast, progress};
+
+pub type Scripts = HashMap<ScriptPath, Script>;
+
+#[derive(Clone, Debug)]
+pub enum ScriptKind {
+    Runnable,
+    NotRunnable,
+    Dependencies(Vec<ScriptPath>),
+}
+
+#[derive(Clone, Debug)]
+pub struct Script {
+    pub kind: ScriptKind,
+    pub ast: Ast,
+    pub oid: Option<String>,
+}
+
+impl Script {
+    fn new(kind: ScriptKind, ast: Ast) -> Self {
+        Self {
+            kind,
+            oid: oid_from_ast(&ast),
+            ast,
+        }
+    }
+
+    pub fn runnable(ast: Ast) -> Self {
+        Self::new(ScriptKind::Runnable, ast)
+    }
+
+    pub fn not_runnable(ast: Ast) -> Self {
+        Self::new(ScriptKind::NotRunnable, ast)
+    }
+
+    pub fn dependencies(deps: Vec<ScriptPath>, ast: Ast) -> Self {
+        Self::new(ScriptKind::Dependencies(deps), ast)
+    }
+
+    pub fn iter_dependencies(&self) -> impl Iterator<Item = &ScriptPath> {
+        if let ScriptKind::Dependencies(dependencies) = &self.kind {
+            dependencies.iter()
+        } else {
+            panic!("iter_dependencies() called on non-dependencies variant")
+        }
+    }
+
+    pub fn is_runnable(&self) -> bool {
+        matches!(self.kind, ScriptKind::Runnable)
+    }
+
+    pub fn is_not_runnable(&self) -> bool {
+        matches!(self.kind, ScriptKind::NotRunnable)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ScriptPath(pub String);
+
+impl ScriptPath {
+    pub fn new(feed_path: &Path, path: &Path) -> Self {
+        let relative = pathdiff::diff_paths(path, feed_path).unwrap();
+        Self(relative.as_os_str().to_str().unwrap().to_string())
+    }
+}
+
+pub struct ScriptReader<'a> {
+    feed_path: PathBuf,
+    loader: Loader,
+    builtins: &'a BuiltinFunctions,
+}
+
+impl<'a> ScriptReader<'a> {
+    pub fn new(feed_path: PathBuf, builtins: &'a BuiltinFunctions) -> Self {
+        let loader = Loader::from_feed_path(&feed_path);
+        Self {
+            feed_path,
+            loader,
+            builtins,
+        }
+    }
+
+    pub fn read_scripts(&mut self) -> Scripts {
+        let mut scripts = HashMap::default();
+        let entries: Vec<_> = WalkDir::new(&self.feed_path).into_iter().collect();
+        for entry in progress(entries) {
+            let entry = entry.unwrap();
+            if entry.file_type().is_file() {
+                let path = entry.path();
+                if path
+                    .extension()
+                    .is_none_or(|ext| ext != "nasl" && ext != "inc")
+                {
+                    continue;
+                }
+                let script_path = ScriptPath::new(&self.feed_path, path);
+                if let Some(script) = self.script_from_path(path) {
+                    scripts.insert(script_path, script);
+                }
+            }
+        }
+        scripts
+    }
+
+    fn script_from_path(&mut self, path: &Path) -> Option<Script> {
+        let ast = self.ast_from_path(path)?;
+        let script = self.script_from_ast(ast);
+        Some(script)
+    }
+
+    fn ast_from_path(&mut self, path: &Path) -> Option<Ast> {
+        let code = Code::load(&self.loader, path).unwrap();
+        let ast = code.parse().emit_errors().unwrap();
+        Some(ast)
+    }
+
+    fn script_from_ast(&mut self, ast: Ast) -> Script {
+        let is_runnable = self.builtins.script_is_runnable(&ast);
+        let dependencies = self.get_dependencies(&ast);
+        if !is_runnable {
+            Script::not_runnable(ast)
+        } else if dependencies.is_empty() {
+            Script::runnable(ast)
+        } else {
+            Script::dependencies(dependencies, ast)
+        }
+    }
+
+    fn get_dependencies(&self, ast: &Ast) -> Vec<ScriptPath> {
+        ast.iter_stmts()
+            .filter_map(|stmt| {
+                if let Statement::Include(include) = stmt {
+                    let sp = search_path::SearchPath::from(self.feed_path.clone());
+                    sp.find_file(&PathBuf::from(include.path.as_str()))
+                        .map(|i| ScriptPath::new(&self.feed_path, &i))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+pub struct RunnableScripts(pub Scripts);
+
+impl RunnableScripts {
+    pub fn new(unresolved: Scripts) -> Self {
+        let resolved = Self::resolve(unresolved);
+        Self(
+            resolved
+                .into_iter()
+                .filter(|(_, script)| script.is_runnable())
+                .collect(),
+        )
+    }
+
+    pub fn resolve(mut unresolved: Scripts) -> Scripts {
+        let mut resolved: Scripts = HashMap::default();
+        loop {
+            let (newly_resolved, newly_unresolved) = unresolved
+                .into_iter()
+                .partition::<HashMap<_, _>, _>(|(_, script)| {
+                    script.is_runnable() || script.is_not_runnable()
+                });
+            unresolved = newly_unresolved;
+            let new_length = newly_resolved.len();
+            resolved.extend(newly_resolved);
+            if unresolved.is_empty() {
+                return resolved;
+            }
+            if new_length == 0 {
+                for (k, v) in unresolved.iter() {
+                    for dep in v.iter_dependencies() {
+                        assert!(
+                            resolved.keys().any(|k| k.0 == dep.0)
+                                || unresolved.keys().any(|k| k.0 == dep.0),
+                            "References to non-existent file: {}. dep: {}",
+                            k.0,
+                            dep.0
+                        );
+                    }
+                }
+            }
+            for v in unresolved.values_mut() {
+                let any_not_runnable = v
+                    .iter_dependencies()
+                    .any(|dep| resolved.get(dep).is_some_and(|s| s.is_not_runnable()));
+                if any_not_runnable {
+                    v.kind = ScriptKind::NotRunnable;
+                    continue;
+                }
+                let all_resolved = v.iter_dependencies().all(|dep| resolved.contains_key(dep));
+                if !all_resolved {
+                    continue;
+                }
+                v.kind = ScriptKind::Runnable;
+            }
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ScriptPath, &Script)> {
+        self.0.iter()
+    }
+}

--- a/rust/src/feed_filter/stats.rs
+++ b/rust/src/feed_filter/stats.rs
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use crate::builtins::{BuiltinFunctions, BuiltinStatus};
+use crate::script::Scripts;
+use crate::utils::iter_fn_calls;
+
+pub struct CategoryStats {
+    pub implemented: Vec<(String, usize)>,
+    pub unimplemented: HashMap<BuiltinStatus, Vec<(String, usize)>>,
+}
+
+pub struct BuiltinStats {
+    pub undocumented: Vec<String>,
+    pub categories: HashMap<String, CategoryStats>,
+}
+
+impl BuiltinStats {
+    pub fn new(scripts: &Scripts, builtins: &BuiltinFunctions) -> Self {
+        let mut category_stats = HashMap::new();
+        let mut function_calls = HashMap::new();
+
+        // Initialize all built-in functions with zero calls
+        for (func, _) in builtins.unimplemented().iter() {
+            function_calls.entry(func.clone()).or_insert(0);
+        }
+        for (func, _) in builtins.implemented().iter() {
+            function_calls.entry(func.clone()).or_insert(0);
+        }
+
+        // Count function calls in all scripts
+        for (_, script) in scripts.iter() {
+            for call in iter_fn_calls(&script.ast) {
+                let function = call.fn_name.to_string();
+                *function_calls.entry(function).or_insert(0) += 1;
+            }
+        }
+
+        for (func, calls) in function_calls.iter() {
+            if let Some((category, _)) = builtins.implemented().get(func) {
+                let stats = category_stats
+                    .entry(category.clone())
+                    .or_insert(CategoryStats {
+                        implemented: vec![],
+                        unimplemented: HashMap::new(),
+                    });
+                stats.implemented.push((func.clone(), *calls));
+            } else if let Some((category, deprecated)) = builtins.unimplemented().get(func) {
+                let stats = category_stats
+                    .entry(category.clone())
+                    .or_insert(CategoryStats {
+                        implemented: vec![],
+                        unimplemented: HashMap::new(),
+                    });
+                let status = if *deprecated {
+                    BuiltinStatus::Deprecated
+                } else if *calls > 0 {
+                    BuiltinStatus::Used
+                } else {
+                    BuiltinStatus::Unused
+                };
+                stats
+                    .unimplemented
+                    .entry(status)
+                    .or_insert(vec![])
+                    .push((func.clone(), *calls));
+            }
+        }
+
+        Self {
+            undocumented: builtins.undocumented.iter().cloned().collect(),
+            categories: category_stats,
+        }
+    }
+}
+
+impl Display for BuiltinStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "# Coverage of NASL built-in functions per Category\n")?;
+        let mut num_functions = 0;
+        let mut num_implemented = 0;
+        for (category, stats) in self.categories.iter() {
+            let num_unimplemented: usize = stats.unimplemented.values().map(|v| v.len()).sum();
+            num_functions += stats.implemented.len() + num_unimplemented;
+            num_implemented += stats.implemented.len();
+            writeln!(f, "## {}\n", category)?;
+            writeln!(f, "<b>")?;
+            writeln!(
+                f,
+                "Functions: {}\n",
+                stats.implemented.len() + num_unimplemented
+            )?;
+            writeln!(f, "Implemented: {}\n", stats.implemented.len())?;
+            writeln!(
+                f,
+                "Percentage implemented: {:.2}%",
+                (stats.implemented.len() as f64
+                    / (stats.implemented.len() + num_unimplemented) as f64)
+                    * 100.0
+            )?;
+            writeln!(f, "</b>\n")?;
+            if !stats.implemented.is_empty() {
+                writeln!(f, "### Implemented Functions\n")?;
+                let mut funcs = stats.implemented.clone();
+                funcs.sort_by_key(|(_, a)| *a);
+                funcs.reverse();
+                for (func, count) in funcs {
+                    writeln!(f, "- {} (used {} times)", func, count)?;
+                }
+                writeln!(f)?;
+            }
+            writeln!(f, "### Unimplemented Functions\n")?;
+            let statuses = [
+                BuiltinStatus::Used,
+                BuiltinStatus::Unused,
+                BuiltinStatus::Deprecated,
+            ];
+            for status in statuses {
+                if let Some(funcs) = stats.unimplemented.get(&status)
+                    && !funcs.is_empty()
+                {
+                    match status {
+                        BuiltinStatus::Used => {
+                            writeln!(f, "#### Used\n")?;
+                        }
+                        BuiltinStatus::Unused => {
+                            writeln!(f, "#### Unused\n")?;
+                        }
+                        BuiltinStatus::Deprecated => {
+                            writeln!(f, "#### Deprecated\n")?;
+                        }
+                    }
+                    let mut funcs = funcs.clone();
+                    funcs.sort_by_key(|(_, a)| *a);
+                    funcs.reverse();
+                    for (func, count) in funcs {
+                        writeln!(f, "- {} (used {} times)", func, count)?;
+                    }
+                    writeln!(f)?;
+                }
+            }
+        }
+        writeln!(f, "# Overall Coverage\n")?;
+        writeln!(f, "<b>")?;
+        writeln!(f, "Total Functions: {}\n", num_functions)?;
+        writeln!(f, "Total Implemented: {}\n", num_implemented)?;
+        writeln!(f, "Total Missing: {}\n", num_functions - num_implemented)?;
+        writeln!(
+            f,
+            "Overall Percentage implemented: {:.2}%",
+            (num_implemented as f64 / num_functions as f64) * 100.0
+        )?;
+        writeln!(f, "</b>\n")?;
+        writeln!(f, "## Undocumented Functions (Rust Only)\n")?;
+        for func in self.undocumented.iter() {
+            writeln!(f, "- {}", func)?;
+        }
+        Ok(())
+    }
+}

--- a/rust/src/feed_filter/utils.rs
+++ b/rust/src/feed_filter/utils.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use scannerlib::nasl::syntax::grammar::{Ast, Atom, Expr, FnCall};
+
+pub fn iter_fn_calls(ast: &Ast) -> impl Iterator<Item = &FnCall> {
+    ast.iter_exprs().filter_map(|expr| {
+        if let Expr::Atom(Atom::FnCall(fn_call)) = expr {
+            Some(fn_call)
+        } else {
+            None
+        }
+    })
+}
+
+pub fn oid_from_ast(ast: &Ast) -> Option<String> {
+    iter_fn_calls(ast)
+        .find(|call| call.fn_name.to_string() == "script_oid")
+        .map(|call| {
+            call.args
+                .items
+                .first()
+                .unwrap()
+                .to_string()
+                .replace('\"', "")
+        })
+}
+
+// poor mans TQDM
+pub fn progress<T>(x: Vec<T>) -> impl Iterator<Item = T> {
+    let num = x.len();
+    let mut last_whole = 0;
+    eprintln!("Reading Scripts...");
+    x.into_iter().enumerate().map(move |(i, x)| {
+        let completed_fraction = (i + 1) as f64 / num as f64;
+        let percentage = (completed_fraction * 100.0) as usize;
+        if percentage > last_whole {
+            last_whole = percentage;
+            if i + 1 == num {
+                eprintln!("\rProgress: 100%");
+            } else {
+                eprint!("\rProgress: {}%", percentage);
+            }
+        }
+        x
+    })
+}


### PR DESCRIPTION
This restructures the original feed-filter into separate files. Additionally a dependency filter is added. It does not filter based on builtin functions but on dependencies. A single script is given, and all include and script_dependencies are checked. From here out, the collected scripts can be copied into a specified directory.

Example: `target/release/feed-filter dep-filter --feed-out ~/dev/nasl/gather-package-list/ ~/dev/vulnerability-tests/nasl/common/ ~/dev/vulnerability-tests/nasl/common/gather-package-list.nasl`

SC-1583