### PR TITLE
Keep OpenVAS port ranges compact

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/port.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/port.rs
@@ -95,18 +95,17 @@ impl AsRef<str> for Protocol {
 
 pub fn ports_to_openvas_port_list(ports: Vec<Port>) -> Option<String> {
     fn add_range_to_list(list: &mut String, start: usize, end: Option<usize>) {
-        // Add range
-        if let Some(end) = end {
-            for p in start..=end {
-                list.push_str(p.to_string().as_str());
-                list.push(',');
+        match end {
+            Some(end) if end != start => {
+                list.push_str(start.to_string().as_str());
+                list.push('-');
+                list.push_str(end.to_string().as_str());
             }
-
-        // Add single port
-        } else {
-            list.push_str(start.to_string().as_str());
-            list.push(',');
+            _ => {
+                list.push_str(start.to_string().as_str());
+            }
         }
+        list.push(',');
     }
     if ports.is_empty() {
         return None;
@@ -195,7 +194,23 @@ mod tests {
         ];
         assert_eq!(
             ports_to_openvas_port_list(ports),
-            Some("T:22,23,24,25,80,1000,U:30,31,32,33,34,35,36,37,38,39,40,5060,1000,".to_string())
+            Some("T:22-25,80,1000,U:30-40,5060,1000,".to_string())
+        );
+    }
+
+    #[test]
+    fn test_port_conversion_keeps_large_ranges_compact() {
+        let ports = vec![Port {
+            protocol: Some(Protocol::TCP),
+            range: vec![PortRange {
+                start: 1,
+                end: Some(65535),
+            }],
+        }];
+
+        assert_eq!(
+            ports_to_openvas_port_list(ports),
+            Some("T:1-65535,".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

This fixes port list generation so OpenVAS keeps explicit ranges compact instead of expanding them into every individual port.

For example, a full TCP range now serializes as `T:1-65535,` instead of a very large comma-separated list. This avoids producing oversized scan arguments for broad port ranges.

Fixes #2223

## Testing

```console
$ cargo test -p greenbone-scanner-framework port
running 2 tests
test models::port::tests::test_port_conversion_to_string ... ok
test models::port::tests::test_port_conversion_keeps_large_ranges_compact ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out
```

```console
$ cargo fmt --check -p greenbone-scanner-framework
```

```console
$ git diff --check HEAD~1..HEAD
```