### PR TITLE
Render mainpage includes as Doxygen docs

### DIFF
--- a/src/openvas.c
+++ b/src/openvas.c
@@ -9,10 +9,10 @@
  * @mainpage
  *
  * @section Introduction
- * @verbinclude README.md
+ * @includedoc README.md
  *
  * @section license License Information
- * @verbinclude COPYING
+ * @includedoc COPYING
  */
 
 /**


### PR DESCRIPTION
## Summary

This updates the Doxygen main page includes for `README.md` and `COPYING` from verbatim includes to documentation includes.

That lets Doxygen render the referenced Markdown/document content instead of showing it as raw verbatim text.

Fixes #2130

## Testing

```console
$ rg -n '@verbinclude' src/openvas.c
```

No matches.

```console
$ rg -n '@includedoc (README.md|COPYING)' src/openvas.c
12: * @includedoc README.md
15: * @includedoc COPYING
```

```console
$ git diff --check HEAD~1..HEAD
```
