### PR TITLE
Fix: Use dynamic list for vulnerable packages in notus results

### DIFF
--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -438,7 +438,7 @@ advisories_new_notus ()
   advisories_t *advisories_list = g_malloc0 (sizeof (advisories_t));
   advisories_list->max_size = 100;
   advisories_list->advisories =
-    g_malloc0_n (advisories_list->max_size, sizeof (advisory_t));
+    g_malloc0_n (advisories_list->max_size, sizeof (advisory_t *));
   advisories_list->type = NOTUS;
 
   return advisories_list;
@@ -499,6 +499,8 @@ advisory_new (char *oid)
   adv = g_malloc0 (sizeof (advisory_t));
   adv->oid = g_strdup (oid);
   adv->count = 0;
+  adv->max_size = 100;
+  adv->pkgs = g_malloc0_n (adv->max_size, sizeof (vuln_pkg_t *));
   return adv;
 }
 
@@ -523,13 +525,12 @@ skiron_advisory_new (char *oid, char *message)
 static void
 advisory_add_vuln_pkg (advisory_t *adv, vuln_pkg_t *vuln)
 {
-  if (adv->count == 100)
+  if (adv->count == adv->max_size)
     {
-      g_warning (
-        "%s: Failed adding new vulnerable package to the notus_advisory %s. "
-        "No more free slots",
-        __func__, adv->oid);
-      return;
+      adv->max_size *= 2;
+      adv->pkgs = g_realloc_n (adv->pkgs, adv->max_size, sizeof (vuln_pkg_t *));
+      memset (adv->pkgs + adv->count, '\0',
+              (adv->max_size - adv->count) * sizeof (vuln_pkg_t *));
     }
 
   adv->pkgs[adv->count] = vuln;
@@ -558,15 +559,19 @@ advisory_free (advisory_t *notus_advisory)
             {
               g_free (notus_advisory->pkgs[i]->range->start);
               g_free (notus_advisory->pkgs[i]->range->stop);
+              g_free (notus_advisory->pkgs[i]->range);
             }
           else if (notus_advisory->pkgs[i]->type == SINGLE)
             {
               g_free (notus_advisory->pkgs[i]->version->version);
               g_free (notus_advisory->pkgs[i]->version->specifier);
+              g_free (notus_advisory->pkgs[i]->version);
             }
+          g_free (notus_advisory->pkgs[i]);
         }
     }
-  notus_advisory = NULL;
+  g_free (notus_advisory->pkgs);
+  g_free (notus_advisory);
 }
 
 static void
@@ -577,7 +582,7 @@ skiron_advisory_free (skiron_advisory_t *skiron_advisory)
 
   g_free (skiron_advisory->oid);
   g_free (skiron_advisory->message);
-  skiron_advisory = NULL;
+  g_free (skiron_advisory);
 }
 
 /** @brief Free()'s an advisories
@@ -597,7 +602,8 @@ advisories_free (advisories_t *advisories)
       else
         skiron_advisory_free (advisories->skiron_advisories[i]);
     }
-  advisories = NULL;
+  g_free (advisories->advisories);
+  g_free (advisories);
 }
 
 /** @brief Creates a new Vulnerable packages which belongs to an notus_advisory

--- a/misc/table_driven_lsc.h
+++ b/misc/table_driven_lsc.h
@@ -69,10 +69,11 @@ typedef struct vulnerable_pkg vuln_pkg_t;
  */
 struct notus_advisory
 {
-  char *oid;             // Advisory OID
-  vuln_pkg_t *pkgs[100]; // list of vulnerable packages, installed version and
-                         // fixed versions
-  size_t count;          // Count of vulnerable packages this advisory has
+  char *oid;         // Advisory OID
+  vuln_pkg_t **pkgs; // list of vulnerable packages, installed version and
+                     // fixed versions
+  size_t count;      // Count of vulnerable packages this advisory has
+  size_t max_size;   // Max size of the vulnerable packages list
 };
 typedef struct notus_advisory advisory_t;
 

--- a/misc/table_driven_lsc_tests.c
+++ b/misc/table_driven_lsc_tests.c
@@ -89,6 +89,45 @@ Ensure (lsc, process_resp)
   advisories_free (advisories);
 }
 
+Ensure (lsc, process_resp_more_than_100_pkgs)
+{
+  const int num_pkgs = 150;
+  GString *resp =
+    g_string_new ("{\"1.3.6.1.4.1.25623.1.1.7.2.2023.0000000000001\": [");
+
+  for (int i = 0; i < num_pkgs; i++)
+    {
+      if (i > 0)
+        g_string_append (resp, ",");
+      g_string_append_printf (
+        resp,
+        "{\"name\": \"pkg%d\", \"installed_version\": \"1.0\","
+        " \"fixed_version\": {\"version\": \"1.1\", \"specifier\": \">=\"}}",
+        i);
+    }
+  g_string_append (resp, "]}");
+
+  advisories_t *advisories = lsc_process_response (resp->str, resp->len);
+  g_string_free (resp, TRUE);
+
+  assert_that (advisories, is_not_null);
+  assert_that (advisories->count, is_equal_to (1));
+  assert_that (advisories->advisories[0]->count, is_equal_to (num_pkgs));
+
+  for (int i = 0; i < num_pkgs; i++)
+    {
+      char expected_name[32];
+      snprintf (expected_name, sizeof (expected_name), "pkg%d", i);
+      assert_that (
+        strcmp (advisories->advisories[0]->pkgs[i]->pkg_name, expected_name),
+        is_equal_to (0));
+      assert_that (advisories->advisories[0]->pkgs[i]->type,
+                   is_equal_to (SINGLE));
+    }
+
+  advisories_free (advisories);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -99,6 +138,7 @@ main (int argc, char **argv)
 
   add_test_with_context (suite, lsc, process_resp);
   add_test_with_context (suite, lsc, make_pkg_in_json);
+  add_test_with_context (suite, lsc, process_resp_more_than_100_pkgs);
   if (argc > 1)
     ret = run_single_test (suite, argv[1], create_text_reporter ());
   else


### PR DESCRIPTION
Previous we assumed to have a maximum of 100 vulnerable packages within a single notus result. This is now eliminated by having a dynamic list. Additionally fixes a free memory leaks and also adds a test for a result with 150 vulnerable packages.

SC-1613