### PR TITLE
Change pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,6 @@
-**What**:
+**IMPORTANT**
+Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).
 
-<!--
-  Describe what changes are being made, e.g. which feature/bug is being
-  developed/fixed in this PR?
--->
-
-**Why**:
-
-<!-- Why are these changes necessary? -->
-
-**How**:
-
-<!--
-  How did you verify the changes in this PR?
-  If this PR contains tests this section can be considered done.
-  Otherwise please write down the steps on how you did test your changes and
-  verified that the changes are working as expected.
-
-  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
-  for some background.
- -->
-
-**Checklist**:
-
-<!-- add "N/A" to the end of each line not applicable to your changes -->
-
-<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->
-
-- [ ] Tests
-- [ ] PR merge commit message adjusted
+1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
+2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
+3. Disclose any use of generative AI in your pull request.


### PR DESCRIPTION
This changes the pull request template to hopefully be irrelevant. Few people stuck to the original format anyways and I am not sure it was particularly helpful to begin with. This template just reminds people of the most important steps that will hopefully save us some time managing community contributions