### PR TITLE
Fix: Filter Advisory OIDs for openvas

### DIFF
--- a/rust/src/openvas/openvas_redis.rs
+++ b/rust/src/openvas/openvas_redis.rs
@@ -104,11 +104,18 @@ impl KbAccess for RedisHelper<RedisCtx> {
 
 pub trait VtHelper {
     fn get_vt(&self, oid: &str) -> RedisStorageResult<Option<VTData>>;
+    fn get_nasl_vt(&self, oid: &str) -> RedisStorageResult<Option<VTData>> {
+        self.get_vt(oid)
+    }
 }
 
 impl VtHelper for RedisHelper<RedisCtx> {
     fn get_vt(&self, oid: &str) -> RedisStorageResult<Option<VTData>> {
         self.lock_cache()?.redis_get_vt(oid)
+    }
+
+    fn get_nasl_vt(&self, oid: &str) -> RedisStorageResult<Option<VTData>> {
+        self.lock_cache()?.redis_get_nasl_vt(oid)
     }
 }
 

--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -99,7 +99,7 @@ where
         let mut pref_list: HashMap<String, String> = HashMap::new();
 
         for vt in vts {
-            let nvt_opt = match self.redis_connector.get_vt(&vt.oid) {
+            let nvt_opt = match self.redis_connector.get_nasl_vt(&vt.oid) {
                 Ok(nvt) => nvt,
                 Err(e) => {
                     tracing::warn!(

--- a/rust/src/storage/redis/connector.rs
+++ b/rust/src/storage/redis/connector.rs
@@ -767,4 +767,16 @@ mod tests {
         assert_eq!(vt.filename, "test.notus");
         assert_eq!(vt.family, "Notus");
     }
+
+    #[test]
+    fn redis_get_nasl_vt_excludes_advisory() {
+        let mut redis = FakeRedis::default();
+        redis.add_advisory("1.3.6.1.4.3", "Notus Advisory");
+
+        assert!(redis.redis_get_nasl_vt("1.3.6.1.4.3").unwrap().is_none());
+
+        let vt = redis.redis_get_vt("1.3.6.1.4.3").unwrap().unwrap();
+        assert_eq!(vt.name, "Notus Advisory");
+        assert_eq!(vt.family, "Notus");
+    }
 }


### PR DESCRIPTION
OIDs given via the HTTP API, that belong to notus were previously filtered out, but were included with https://github.com/greenbone/openvas-scanner/pull/2236. This is now fixed.

Jira: SC-1618

Scan JSON for testing (Remember to adjust credentials):
```json
{
    "target": {
        "hosts": [
            "127.0.0.1"
        ],
        "ports": [
            {
                "range": [
                    {
                        "start": 22
                    }
                ]
            }
        ],
        "credentials": [
            {
                "service": "ssh",
                "port": 22,
                "up": {
                    "username": "user",
                    "password": "password"
                }
            }
        ]
    },
    "vts": [
        {
            "oid": "1.3.6.1.4.1.25623.1.0.50282"
        },
      	{
          	"oid": "1.3.6.1.4.1.25623.1.1.1.1.2005.696"
        }
    ]
}
```