### PR TITLE
Add: Opt-in endpoint hardening (auth, health IP allow-list, declined-response headers)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2017,6 +2017,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "greenbone-scanner-framework"
 version = "0.1.0"
 dependencies = [
+ "cidr",
  "futures",
  "futures-util",
  "http-body",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing-appender = "0.2.4"
 uuid = { version = "1", features = ["v4", "fast-rng", "serde"] }
 once_cell = "1"
+cidr = "0.3.2"
 
 [dependencies]
 aes = "0.8.2"
@@ -137,7 +138,7 @@ tar = "0"
 bzip2 = "0"
 zstd = "0"
 rustls-pki-types = { version = "1.14.0", features = ["std"] }
-cidr = "0.3.2"
+cidr = { workspace = true }
 
 [workspace]
 members = ["crates/nasl-function-proc-macro"]

--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -71,6 +71,8 @@ paths:
           description: "Ok"
         "403":
           description: "Forbidden by configured health IP allow-list"
+        "503":
+          description: "Service Unavailable"
     get:
       description: "Get application's liveness information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_alive"
@@ -102,6 +104,8 @@ paths:
           description: "Ok"
         "403":
           description: "Forbidden by configured health IP allow-list"
+        "503":
+          description: "Service Unavailable"
     get:
       description: "Get application's readiness information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_ready"
@@ -132,6 +136,8 @@ paths:
           description: "Ok"
         "403":
           description: "Forbidden by configured health IP allow-list"
+        "503":
+          description: "Service Unavailable"
     get:
       description: "Get application's startup information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_started"

--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -53,12 +53,12 @@ tags:
   - name: notus
     description: Notus vulnerability scanner
 paths:
-  /health:
+  /health/alive:
     head:
-      description: "Get the response header. It contains the API version, feed version and available authentication methods."
-      operationId: "head_health"
+      description: "Get response headers for the liveness probe. Access can be restricted by the configured health IP allow-list."
+      operationId: "head_health_alive"
       tags:
-        - "general"
+        - "health"
       responses:
         "200":
           headers:
@@ -68,37 +68,82 @@ paths:
               $ref: "#/components/headers/FeedVersion"
             authentication:
               $ref: "#/components/headers/Authentication"
-          description: "Authenticated and authorized"
-  /health/alive:
+          description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
     get:
-      description: "Get application's health information"
+      description: "Get application's liveness information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_alive"
       tags:
         - "health"
       responses:
         "200":
           description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
+        "503":
+          description: "Service Unavailable"
 
   /health/ready:
+    head:
+      description: "Get response headers for the readiness probe. Access can be restricted by the configured health IP allow-list."
+      operationId: "head_health_ready"
+      tags:
+        - "health"
+      responses:
+        "200":
+          headers:
+            api-version:
+              $ref: "#/components/headers/ApiVersion"
+            feed-version:
+              $ref: "#/components/headers/FeedVersion"
+            authentication:
+              $ref: "#/components/headers/Authentication"
+          description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
     get:
-      description: "Get application's health information"
+      description: "Get application's readiness information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_ready"
       tags:
         - "health"
       responses:
         "200":
           description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
         "503":
           description: "Service Unavailable"
   /health/started:
+    head:
+      description: "Get response headers for the startup probe. Access can be restricted by the configured health IP allow-list."
+      operationId: "head_health_started"
+      tags:
+        - "health"
+      responses:
+        "200":
+          headers:
+            api-version:
+              $ref: "#/components/headers/ApiVersion"
+            feed-version:
+              $ref: "#/components/headers/FeedVersion"
+            authentication:
+              $ref: "#/components/headers/Authentication"
+          description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
     get:
-      description: "Get application's health information"
+      description: "Get application's startup information. Access can be restricted by the configured health IP allow-list."
       operationId: "get_health_started"
       tags:
         - "health"
       responses:
         "200":
           description: "Ok"
+        "403":
+          description: "Forbidden by configured health IP allow-list"
+        "503":
+          description: "Service Unavailable"
 
   /notus:
     head:
@@ -116,6 +161,8 @@ paths:
             authentication:
               $ref: "#/components/headers/Authentication"
           description: "Authenticated and authorized"
+        "401":
+          description: "Unauthorized when endpoint authentication is required and credentials are missing or invalid"
     get:
       description: "Get a list of all available OS products available for the
         [POST /notus/{os}](#/notus/notus_run) endpoint."
@@ -134,6 +181,8 @@ paths:
               examples:
                 get notus products:
                   $ref: "./components/examples/notus.yml#/notus_products"
+        "401":
+          description: "Unauthorized when endpoint authentication is required and credentials are missing or invalid"
 
   /notus/{os}:
     post:
@@ -171,6 +220,8 @@ paths:
                   $ref: "./components/examples/notus.yml#/notus_results"
         "400":
           description: "Bad request body"
+        "401":
+          description: "Unauthorized when endpoint authentication is required and credentials are missing or invalid"
         "404":
           description: "Scan not found"
         "406":
@@ -542,6 +593,8 @@ paths:
             authentication:
               $ref: "#/components/headers/Authentication"
           description: "Authenticated and authorized"
+        "401":
+          description: "Unauthorized when endpoint authentication is required and credentials are missing or invalid"
     get:
       description:
         "Get a list of all available vulnerability tests (VTs) to the scanner. Note, that not the
@@ -561,6 +614,8 @@ paths:
               examples:
                 list of OIDs:
                   $ref: "./components/examples/vts.yml#/list_of_oids"
+        "401":
+          description: "Unauthorized when endpoint authentication is required and credentials are missing or invalid"
         "503":
           description: "The list of OIDs is currently updated. Please try again later."
 

--- a/rust/crates/greenbone-scanner-framework/Cargo.toml
+++ b/rust/crates/greenbone-scanner-framework/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }
 once_cell = { workspace = true }
+cidr = { workspace = true }
 signal-hook-tokio = { version = "0.4.0", features = ["futures-v0_3"] }
 signal-hook = "0.4.3"
 

--- a/rust/crates/greenbone-scanner-framework/src/entry/mod.rs
+++ b/rust/crates/greenbone-scanner-framework/src/entry/mod.rs
@@ -211,7 +211,7 @@ fn segments_match(prefix: &str, handler_parts: &[&str], request_parts: &[&str]) 
 }
 
 fn is_health_probe_route(prefix: &str, handler_parts: &[&str], method: &Method) -> bool {
-    (method == &Method::GET || method == &Method::HEAD)
+    (*method == Method::GET || *method == Method::HEAD)
         && prefix.is_empty()
         && handler_parts.len() == 2
         && handler_parts[0] == "health"

--- a/rust/crates/greenbone-scanner-framework/src/entry/mod.rs
+++ b/rust/crates/greenbone-scanner-framework/src/entry/mod.rs
@@ -7,6 +7,7 @@
 use std::{
     convert::Infallible,
     fmt::Display,
+    net::SocketAddr,
     pin::Pin,
     sync::{
         Arc,
@@ -15,6 +16,7 @@ use std::{
 };
 pub mod response;
 
+use cidr::IpInet;
 use hyper::{StatusCode, header::HeaderValue};
 use response::{BodyKind, BodyKindContent};
 
@@ -126,6 +128,39 @@ pub trait RequestHandler: Prefixed {
         'b: 'a;
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct EndpointPolicy {
+    health_ip_allowlist: Vec<IpInet>,
+    hide_declined_response_headers: bool,
+}
+
+impl EndpointPolicy {
+    pub fn new(health_ip_allowlist: Vec<IpInet>) -> Self {
+        Self {
+            health_ip_allowlist,
+            hide_declined_response_headers: false,
+        }
+    }
+
+    pub fn hide_declined_response_headers(mut self, hide_declined_response_headers: bool) -> Self {
+        self.hide_declined_response_headers = hide_declined_response_headers;
+        self
+    }
+
+    fn allows_health_peer(&self, peer_addr: Option<SocketAddr>) -> bool {
+        if self.health_ip_allowlist.is_empty() {
+            return true;
+        }
+
+        peer_addr.is_some_and(|peer_addr| {
+            let peer_ip = peer_addr.ip();
+            self.health_ip_allowlist
+                .iter()
+                .any(|allowed| allowed.contains(&peer_ip))
+        })
+    }
+}
+
 /// Will be called after the authorization and sanity checks are done.
 ///
 /// It contains all the RequestHandler implementations and finds handler
@@ -175,6 +210,14 @@ fn segments_match(prefix: &str, handler_parts: &[&str], request_parts: &[&str]) 
     true
 }
 
+fn is_health_probe_route(prefix: &str, handler_parts: &[&str], method: &Method) -> bool {
+    (method == &Method::GET || method == &Method::HEAD)
+        && prefix.is_empty()
+        && handler_parts.len() == 2
+        && handler_parts[0] == "health"
+        && matches!(handler_parts[1], "alive" | "ready" | "started")
+}
+
 type BodyKindFuture = Pin<Box<dyn futures_util::Future<Output = BodyKind> + Send>>;
 
 impl RequestHandlers {
@@ -190,6 +233,8 @@ impl RequestHandlers {
     fn call<R>(
         &self,
         client_identifier: Arc<ClientIdentifier>,
+        endpoint_policy: Arc<EndpointPolicy>,
+        peer_addr: Option<SocketAddr>,
         req: hyper::Request<R>,
     ) -> BodyKindFuture
     where
@@ -210,6 +255,12 @@ impl RequestHandlers {
 
             for rh in callbacks {
                 if segments_match(rh.prefix(), rh.path_segments(), &segments) {
+                    if is_health_probe_route(rh.prefix(), rh.path_segments(), req.method())
+                        && !endpoint_policy.allows_health_peer(peer_addr)
+                    {
+                        return BodyKind::no_content(StatusCode::FORBIDDEN);
+                    }
+
                     let needs_authentication = rh.needs_authentication();
                     let is_authenticated =
                         matches!(&*client_identifier, &ClientIdentifier::Known(_));
@@ -255,6 +306,8 @@ pub struct EntryPoint {
     scanner: Arc<super::Scanner>,
     handlers: Arc<RequestHandlers>,
     client_identifier: Arc<ClientIdentifier>,
+    endpoint_policy: Arc<EndpointPolicy>,
+    peer_addr: Option<SocketAddr>,
     max_connections: usize,
     counter: Arc<AtomicUsize>,
 }
@@ -264,6 +317,8 @@ impl EntryPoint {
         scanner: Arc<super::Scanner>,
         client_identifier: Arc<ClientIdentifier>,
         handlers: Arc<RequestHandlers>,
+        endpoint_policy: Arc<EndpointPolicy>,
+        peer_addr: Option<SocketAddr>,
         max_connections: usize,
         counter: Arc<AtomicUsize>,
     ) -> EntryPoint {
@@ -272,6 +327,8 @@ impl EntryPoint {
             scanner,
             client_identifier,
             handlers,
+            endpoint_policy,
+            peer_addr,
             counter,
         }
     }
@@ -307,6 +364,25 @@ fn api_key_to_client_identifier(
     result
 }
 
+fn should_hide_metadata_headers(
+    hide_declined_response_headers: bool,
+    status_code: StatusCode,
+) -> bool {
+    hide_declined_response_headers
+        && matches!(
+            status_code,
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        )
+}
+
+fn feed_version_header(feed_version: &Arc<std::sync::RwLock<crate::models::FeedState>>) -> String {
+    match &*feed_version.read().unwrap() {
+        crate::models::FeedState::Unknown => "unavailable".to_string(),
+        crate::models::FeedState::Syncing => "unavailable".to_string(),
+        crate::models::FeedState::Synced(vt, adv) => format!("{vt}{adv}"),
+    }
+}
+
 use crate::{Authentication, MapScanID, internal_server_error};
 
 impl<R> hyper::service::Service<hyper::Request<R>> for EntryPoint
@@ -332,23 +408,23 @@ where
                 req.headers().get("x-api-key"),
             )),
         };
-        let feed_version = match &*cbs.feed_version.read().unwrap() {
-            crate::models::FeedState::Unknown => "unavailable".to_string(),
-            crate::models::FeedState::Syncing => "unavailable".to_string(),
-            crate::models::FeedState::Synced(vt, adv) => format!("{vt}{adv}"),
-        };
-        let rb = hyper::Response::builder()
-            .header("authentication", cbs.authentication.static_str())
-            .header("api-version", &cbs.api_version)
-            .header("feed-version", &feed_version);
         let incoming = self.handlers.clone();
+        let endpoint_policy = self.endpoint_policy.clone();
+        let peer_addr = self.peer_addr;
+        let hide_declined_response_headers = endpoint_policy.hide_declined_response_headers;
+        let authentication = cbs.authentication.static_str();
+        let api_version = cbs.api_version.clone();
+        let feed_version = cbs.feed_version.clone();
 
         let acc = self.counter.clone();
         let max_connections = self.max_connections;
         Box::pin(async move {
             if acc.load(Ordering::Relaxed) > max_connections {
                 tracing::trace!("Too many open connections, returning 503");
-                return Ok(rb
+                return Ok(hyper::Response::builder()
+                    .header("authentication", authentication)
+                    .header("api-version", &api_version)
+                    .header("feed-version", feed_version_header(&feed_version))
                     .header("Retry-After", 10)
                     .status(StatusCode::SERVICE_UNAVAILABLE)
                     .body(BodyKindContent::Empty)
@@ -357,7 +433,16 @@ where
 
             let current = acc.fetch_add(1, Ordering::Relaxed);
             tracing::trace!(current, max_connections, "handling request");
-            let resp = incoming.call(cid, req).await;
+            let resp = incoming.call(cid, endpoint_policy, peer_addr, req).await;
+            let rb = hyper::Response::builder();
+            let rb =
+                if should_hide_metadata_headers(hide_declined_response_headers, resp.status_code) {
+                    rb
+                } else {
+                    rb.header("authentication", authentication)
+                        .header("api-version", &api_version)
+                        .header("feed-version", feed_version_header(&feed_version))
+                };
             let rb = match &resp.content {
                 BodyKindContent::Empty => rb,
                 BodyKindContent::Binary(x) => rb
@@ -403,6 +488,7 @@ where
 
 pub mod test_utilities {
     use std::{
+        net::SocketAddr,
         pin::Pin,
         sync::{Arc, RwLock},
     };
@@ -410,13 +496,31 @@ pub mod test_utilities {
     use http_body_util::{Empty, Full};
     use hyper::{Request, body::Bytes};
 
-    use super::{ClientHash, ClientIdentifier, EntryPoint, Method, RequestHandlers};
+    use super::{
+        ClientHash, ClientIdentifier, EndpointPolicy, EntryPoint, Method, RequestHandlers,
+    };
     use crate::{Authentication, Scanner, models::FeedState};
 
     pub fn entry_point(
         authentication: Authentication,
         handlers: RequestHandlers,
         client_hash: Option<ClientHash>,
+    ) -> EntryPoint {
+        entry_point_with_policy(
+            authentication,
+            handlers,
+            client_hash,
+            Default::default(),
+            None,
+        )
+    }
+
+    pub fn entry_point_with_policy(
+        authentication: Authentication,
+        handlers: RequestHandlers,
+        client_hash: Option<ClientHash>,
+        endpoint_policy: EndpointPolicy,
+        peer_addr: Option<SocketAddr>,
     ) -> EntryPoint {
         let configuration = Arc::new(Scanner {
             api_version: "test".to_owned(),
@@ -432,7 +536,15 @@ pub mod test_utilities {
             None => ClientIdentifier::Unknown,
         });
         let ir = Arc::new(handlers);
-        EntryPoint::new(configuration, client_identifier, ir, 10, Default::default())
+        EntryPoint::new(
+            configuration,
+            client_identifier,
+            ir,
+            Arc::new(endpoint_policy),
+            peer_addr,
+            10,
+            Default::default(),
+        )
     }
 
     pub fn empty_request(method: Method, uri: &str) -> Request<Empty<Bytes>> {
@@ -494,6 +606,26 @@ mod tests {
     use super::*;
     use crate::Authentication;
 
+    fn assert_no_metadata_headers<T>(resp: &hyper::Response<T>) {
+        let headers = resp.headers();
+        assert!(headers.get("authentication").is_none());
+        assert!(headers.get("api-version").is_none());
+        assert!(headers.get("feed-version").is_none());
+    }
+
+    fn assert_metadata_headers<T>(resp: &hyper::Response<T>, authentication: HeaderValue) {
+        let headers = resp.headers();
+        assert_eq!(headers.get("authentication").unwrap(), authentication);
+        assert_eq!(
+            headers.get("api-version").unwrap(),
+            HeaderValue::from_static("test")
+        );
+        assert_eq!(
+            headers.get("feed-version").unwrap(),
+            HeaderValue::from_static("vtadvisories")
+        );
+    }
+
     struct IdPart {}
 
     impl Prefixed for IdPart {
@@ -553,6 +685,30 @@ mod tests {
 
     impl RequestHandler for NotAuthenticated {
         auth_method_segments!(authenticated: false, Method::GET, "test", "not_authn");
+        fn call<'a, 'b>(
+            &'b self,
+            _: Arc<ClientIdentifier>,
+            _: &'a Uri,
+            _: Bytes,
+        ) -> Pin<Box<dyn Future<Output = BodyKind> + Send>>
+        where
+            'b: 'a,
+        {
+            Box::pin(async move { BodyKind::no_content(StatusCode::OK) })
+        }
+    }
+
+    struct HealthReady {}
+
+    impl Prefixed for HealthReady {
+        fn prefix(&self) -> &'static str {
+            ""
+        }
+    }
+
+    impl RequestHandler for HealthReady {
+        auth_method_segments!(authenticated: false, Method::GET, "health", "ready");
+
         fn call<'a, 'b>(
             &'b self,
             _: Arc<ClientIdentifier>,
@@ -665,6 +821,7 @@ mod tests {
         let req = test_utilities::empty_request(Method::HEAD, "/test/authn");
         let resp = entry_point.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_metadata_headers(&resp, HeaderValue::from_static("mTLS"));
     }
 
     #[tokio::test]
@@ -678,6 +835,23 @@ mod tests {
         let req = test_utilities::empty_request(Method::HEAD, "/test/authn");
         let resp = entry_point.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_metadata_headers(&resp, HeaderValue::from_static("api-key"));
+    }
+
+    #[tokio::test]
+    async fn declined_auth_hides_metadata_headers_when_configured() {
+        let entry_point = test_utilities::entry_point_with_policy(
+            Authentication::MTLS,
+            create_single_handler!(Authenticated {}),
+            None,
+            EndpointPolicy::new(vec![]).hide_declined_response_headers(true),
+            None,
+        );
+
+        let req = test_utilities::empty_request(Method::HEAD, "/test/authn");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_no_metadata_headers(&resp);
     }
 
     #[tokio::test]
@@ -697,6 +871,91 @@ mod tests {
         let resp = entry_point.call(req).await.unwrap();
 
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn health_allowlist_allows_matching_peer() {
+        let entry_point = test_utilities::entry_point_with_policy(
+            Authentication::MTLS,
+            create_single_handler!(HealthReady {}),
+            None,
+            EndpointPolicy::new(vec!["127.0.0.0/8".parse().unwrap()]),
+            Some(([127, 0, 0, 1], 1234).into()),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = test_utilities::empty_request(Method::HEAD, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn health_allowlist_denies_non_matching_peer() {
+        let entry_point = test_utilities::entry_point_with_policy(
+            Authentication::MTLS,
+            create_single_handler!(HealthReady {}),
+            None,
+            EndpointPolicy::new(vec!["127.0.0.1".parse().unwrap()]),
+            Some(([192, 0, 2, 1], 1234).into()),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_metadata_headers(&resp, HeaderValue::from_static("mTLS"));
+
+        let req = test_utilities::empty_request(Method::HEAD, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_metadata_headers(&resp, HeaderValue::from_static("mTLS"));
+    }
+
+    #[tokio::test]
+    async fn health_allowlist_hides_declined_metadata_headers_when_configured() {
+        let entry_point = test_utilities::entry_point_with_policy(
+            Authentication::MTLS,
+            create_single_handler!(HealthReady {}),
+            None,
+            EndpointPolicy::new(vec!["127.0.0.1".parse().unwrap()])
+                .hide_declined_response_headers(true),
+            Some(([192, 0, 2, 1], 1234).into()),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_no_metadata_headers(&resp);
+
+        let req = test_utilities::empty_request(Method::HEAD, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_no_metadata_headers(&resp);
+    }
+
+    #[tokio::test]
+    async fn health_allowlist_keeps_unimplemented_health_routes_not_found() {
+        let entry_point = test_utilities::entry_point_with_policy(
+            Authentication::MTLS,
+            create_single_handler!(HealthReady {}),
+            None,
+            EndpointPolicy::new(vec!["127.0.0.1".parse().unwrap()]),
+            Some(([192, 0, 2, 1], 1234).into()),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/health");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let req = test_utilities::empty_request(Method::POST, "/health/ready");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let req = test_utilities::empty_request(Method::GET, "/health/unknown");
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     struct PrefixedAuth {}

--- a/rust/crates/greenbone-scanner-framework/src/get_vts.rs
+++ b/rust/crates/greenbone-scanner-framework/src/get_vts.rs
@@ -3,7 +3,7 @@ use std::{pin::Pin, sync::Arc};
 use hyper::StatusCode;
 
 use crate::{
-    ExternalError, StreamResult, auth_method_segments,
+    ExternalError, StreamResult,
     entry::{self, Bytes, Method, Prefixed, RequestHandler, response::BodyKind},
     internal_server_error,
     models::VTData,
@@ -17,6 +17,14 @@ pub trait GetVts: Send + Sync {
 
 pub struct GetVTsHandler<T> {
     get_scans: Arc<T>,
+    require_authentication: bool,
+}
+
+impl<T> GetVTsHandler<T> {
+    pub fn require_authentication(mut self, require_authentication: bool) -> Self {
+        self.require_authentication = require_authentication;
+        self
+    }
 }
 
 impl<T> Prefixed for GetVTsHandler<T>
@@ -32,11 +40,17 @@ impl<S> RequestHandler for GetVTsHandler<S>
 where
     S: GetVts + Prefixed + 'static,
 {
-    auth_method_segments!(
-        authenticated: false,
-        Method::GET,
-        "vts"
-    );
+    fn needs_authentication(&self) -> bool {
+        self.require_authentication
+    }
+
+    fn path_segments(&self) -> &'static [&'static str] {
+        &["vts"]
+    }
+
+    fn http_method(&self) -> Method {
+        Method::GET
+    }
 
     fn call<'a, 'b>(
         &'b self,
@@ -76,6 +90,7 @@ where
     fn from(value: T) -> Self {
         GetVTsHandler {
             get_scans: Arc::new(value),
+            require_authentication: false,
         }
     }
 }
@@ -85,7 +100,10 @@ where
     T: GetVts + 'static,
 {
     fn from(value: Arc<T>) -> Self {
-        GetVTsHandler { get_scans: value }
+        GetVTsHandler {
+            get_scans: value,
+            require_authentication: false,
+        }
     }
 }
 
@@ -250,5 +268,55 @@ mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let resp = String::from_utf8_lossy(bytes.as_ref());
         insta::assert_snapshot!(resp);
+    }
+
+    #[tokio::test]
+    async fn get_vts_requires_authentication_when_enabled() {
+        let entry_point = test_utilities::entry_point(
+            Authentication::MTLS,
+            create_single_handler!(GetVTsHandler::from(Test {}).require_authentication(true)),
+            None,
+        );
+
+        let req = Request::builder()
+            .uri("/vts")
+            .method(Method::GET)
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let req = Request::builder()
+            .uri("/vts")
+            .method(Method::HEAD)
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn get_vts_with_required_authentication_allows_known_client() {
+        let entry_point = test_utilities::entry_point(
+            Authentication::MTLS,
+            create_single_handler!(GetVTsHandler::from(Test {}).require_authentication(true)),
+            Some(ClientHash::from("ok")),
+        );
+
+        let req = Request::builder()
+            .uri("/vts")
+            .method(Method::GET)
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = Request::builder()
+            .uri("/vts")
+            .method(Method::HEAD)
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let resp = entry_point.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }

--- a/rust/crates/greenbone-scanner-framework/src/lib.rs
+++ b/rust/crates/greenbone-scanner-framework/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 
 use delete_scans_id::{DeleteScansId, DeleteScansIdHandler};
 use entry::Prefixed;
-pub use entry::{ClientHash, ClientIdentifier, RequestHandler, RequestHandlers};
+pub use entry::{ClientHash, ClientIdentifier, EndpointPolicy, RequestHandler, RequestHandlers};
 use get_scans::GetScansHandler;
 use get_scans_id::GetScansIdHandler;
 use get_scans_id_results::GetScansIdResultsHandler;
@@ -129,6 +129,8 @@ pub struct RuntimeBuilder<T> {
     listener_address: SocketAddr,
     tls: Option<TLSConfig>,
     api_keys: Option<Vec<String>>,
+    endpoint_policy: EndpointPolicy,
+    require_authentication: bool,
     handlers: RequestHandlers,
     max_concurrent_connections: usize,
     _phantom: PhantomData<T>,
@@ -163,6 +165,8 @@ impl<T> RuntimeBuilder<T> {
             feed_state: None,
             tls: None,
             api_keys: None,
+            endpoint_policy: Default::default(),
+            require_authentication: false,
             handlers,
             listener_address,
             max_concurrent_connections: 10,
@@ -207,6 +211,21 @@ impl<T> RuntimeBuilder<T> {
                 path_client_certs: Some(path_client_certs),
             },
         });
+        self
+    }
+
+    pub fn api_key(mut self, api_key: String) -> RuntimeBuilder<T> {
+        self.api_keys = Some(vec![api_key]);
+        self
+    }
+
+    pub fn endpoint_policy(mut self, endpoint_policy: EndpointPolicy) -> RuntimeBuilder<T> {
+        self.endpoint_policy = endpoint_policy;
+        self
+    }
+
+    pub fn require_authentication(mut self, require_authentication: bool) -> RuntimeBuilder<T> {
+        self.require_authentication = require_authentication;
         self
     }
 
@@ -261,6 +280,7 @@ impl<T> RuntimeBuilder<T> {
             + 'static,
         V: GetVts + Prefixed + 'static,
     {
+        let require_authentication = self.require_authentication;
         let ior = self
             .add_request_handler(PostScansHandler::from(scans.clone()))
             .add_request_handler(GetScansHandler::from(scans.clone()))
@@ -271,13 +291,17 @@ impl<T> RuntimeBuilder<T> {
             .add_request_handler(GetScansIdStatusHandler::from(scans.clone()))
             .add_request_handler(PostScansIdHandler::from(scans.clone()))
             .add_request_handler(DeleteScansIdHandler::from(scans))
-            .add_request_handler(GetVTsHandler::from(vts));
+            .add_request_handler(
+                GetVTsHandler::from(vts).require_authentication(require_authentication),
+            );
         RuntimeBuilder {
             api_version: ior.api_version,
             feed_state: ior.feed_state,
             listener_address: ior.listener_address,
             tls: ior.tls,
             api_keys: ior.api_keys,
+            endpoint_policy: ior.endpoint_policy,
+            require_authentication: ior.require_authentication,
             handlers: ior.handlers,
             _phantom: PhantomData,
             max_concurrent_connections: ior.max_concurrent_connections,
@@ -351,6 +375,8 @@ impl RuntimeBuilder<runtime_builder_states::Start> {
             listener_address: ior.listener_address,
             tls: ior.tls,
             api_keys: ior.api_keys,
+            endpoint_policy: ior.endpoint_policy,
+            require_authentication: ior.require_authentication,
             handlers: ior.handlers,
             _phantom: PhantomData,
             max_concurrent_connections: ior.max_concurrent_connections,
@@ -363,13 +389,18 @@ impl RuntimeBuilder<runtime_builder_states::DeleteScanIDSet> {
     where
         T: GetVts + Prefixed + 'static,
     {
-        let ior = self.add_request_handler(GetVTsHandler::from(value));
+        let require_authentication = self.require_authentication;
+        let ior = self.add_request_handler(
+            GetVTsHandler::from(value).require_authentication(require_authentication),
+        );
         RuntimeBuilder {
             api_version: ior.api_version,
             feed_state: ior.feed_state,
             listener_address: ior.listener_address,
             tls: ior.tls,
             api_keys: ior.api_keys,
+            endpoint_policy: ior.endpoint_policy,
+            require_authentication: ior.require_authentication,
             handlers: ior.handlers,
             max_concurrent_connections: ior.max_concurrent_connections,
             _phantom: PhantomData,
@@ -401,12 +432,16 @@ fn make_service(
     scanner: Arc<Scanner>,
     handlers: Arc<RequestHandlers>,
     client_id: ClientIdentifier,
+    endpoint_policy: Arc<EndpointPolicy>,
+    peer_addr: SocketAddr,
     max_connections: usize,
 ) -> entry::EntryPoint {
     entry::EntryPoint::new(
         scanner,
         Arc::new(client_id),
         handlers,
+        endpoint_policy,
+        Some(peer_addr),
         max_connections,
         REQUEST_COUNTER.clone(),
     )
@@ -418,7 +453,7 @@ async fn run_accept_loop<F, Fut>(
     on_accept: F,
 ) -> Result<i32, Box<dyn std::error::Error + Send + Sync>>
 where
-    F: Fn(tokio::net::TcpStream) -> Fut + Send + Sync + Clone + 'static,
+    F: Fn(tokio::net::TcpStream, SocketAddr) -> Fut + Send + Sync + Clone + 'static,
     Fut: Future<Output = ()> + Send + 'static,
 {
     loop {
@@ -430,10 +465,10 @@ where
             }
 
             accept_result = incoming.accept() => {
-                let (tcp_stream, _remote_addr) = accept_result?;
+                let (tcp_stream, remote_addr) = accept_result?;
                 let f = on_accept.clone();
                 tokio::spawn(async move {
-                    f(tcp_stream).await;
+                    f(tcp_stream, remote_addr).await;
                 });
             }
         }
@@ -452,6 +487,7 @@ impl RuntimeBuilder<runtime_builder_states::End> {
 
         let incoming = TcpListener::bind(&self.listener_address).await?;
         let handlers = Arc::new(self.handlers);
+        let endpoint_policy = Arc::new(self.endpoint_policy);
 
         let max_connections = self.max_concurrent_connections;
 
@@ -467,12 +503,14 @@ impl RuntimeBuilder<runtime_builder_states::End> {
             run_accept_loop(incoming, signals, {
                 let scanner = scanner.clone();
                 let handlers = handlers.clone();
+                let endpoint_policy = endpoint_policy.clone();
 
-                move |tcp_stream| {
+                move |tcp_stream, remote_addr| {
                     let tls_acceptor = tls_acceptor.clone();
                     let identifier = identifier.clone();
                     let scanner = scanner.clone();
                     let handlers = handlers.clone();
+                    let endpoint_policy = endpoint_policy.clone();
 
                     async move {
                         let tls_stream = match tls_acceptor.accept(tcp_stream).await {
@@ -484,7 +522,14 @@ impl RuntimeBuilder<runtime_builder_states::End> {
                         };
 
                         let cci = retrieve_and_reset_client_identifier(identifier);
-                        let service = make_service(scanner, handlers, cci, max_connections);
+                        let service = make_service(
+                            scanner,
+                            handlers,
+                            cci,
+                            endpoint_policy,
+                            remote_addr,
+                            max_connections,
+                        );
 
                         if let Err(err) = Builder::new(TokioExecutor::new())
                             .max_concurrent_streams(20)
@@ -505,16 +550,20 @@ impl RuntimeBuilder<runtime_builder_states::End> {
             run_accept_loop(incoming, signals, {
                 let scanner = scanner.clone();
                 let handlers = handlers.clone();
+                let endpoint_policy = endpoint_policy.clone();
 
-                move |tcp_stream| {
+                move |tcp_stream, remote_addr| {
                     let scanner = scanner.clone();
                     let handlers = handlers.clone();
+                    let endpoint_policy = endpoint_policy.clone();
 
                     async move {
                         let service = make_service(
                             scanner,
                             handlers,
                             ClientIdentifier::Unknown,
+                            endpoint_policy,
+                            remote_addr,
                             max_connections,
                         );
 

--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -24,6 +24,12 @@ advisories_path = "/var/lib/notus/advisories/"
 [endpoints]
 # Enables GET /scans endpoint
 enable_get_scans = true
+# Require configured authentication for /notus, /notus/{os}, and /vts.
+# require_authentication = false
+# Restrict implemented health probe routes to direct TCP peer IPs or CIDR networks.
+# health_ip_allowlist = ["127.0.0.1", "::1"]
+# Hide authentication, api-version, and feed-version headers on 401 and 403 responses.
+# hide_declined_response_headers = false
 # If set it requires `x-api-key` header to use the endpoint
 key = "mtls_is_preferred"
 

--- a/rust/examples/openvasd/config.example_v1.toml
+++ b/rust/examples/openvasd/config.example_v1.toml
@@ -24,6 +24,12 @@ advisories_path = "/var/lib/notus/advisories/"
 [endpoints]
 # Enables GET /scans endpoint
 enable_get_scans = true
+# Require configured authentication for /notus, /notus/{os}, and /vts.
+# require_authentication = false
+# Restrict implemented health probe routes to direct TCP peer IPs or CIDR networks.
+# health_ip_allowlist = ["127.0.0.1", "::1"]
+# Hide authentication, api-version, and feed-version headers on 401 and 403 responses.
+# hide_declined_response_headers = false
 # If set it requires `x-api-key` header to use the endpoint
 key = "mtls_is_preferred"
 

--- a/rust/src/openvasd/README.md
+++ b/rust/src/openvasd/README.md
@@ -52,7 +52,20 @@ The API supports two kinds of authentication methods:
 
 The authentication modes are set within a configuration file or via the argument list, when starting the server.
 
-The authentication is required for each request except for a HEAD request.
+By default, existing endpoint behavior is preserved. Scan endpoints require authentication when authentication is configured. Notus and VT endpoints can additionally require authentication by setting `require_authentication = true` under `[endpoints]`.
+
+Declined requests keep the existing response metadata headers by default. Set `hide_declined_response_headers = true` under `[endpoints]` to omit the `authentication`, `api-version`, and `feed-version` headers from `401 Unauthorized` and `403 Forbidden` responses.
+
+Implemented health probe routes are:
+
+- `GET /health/alive`
+- `HEAD /health/alive`
+- `GET /health/ready`
+- `HEAD /health/ready`
+- `GET /health/started`
+- `HEAD /health/started`
+
+`HEAD /health` is not implemented. Health probe access can be restricted to direct TCP peers by setting `health_ip_allowlist` under `[endpoints]`. The allow-list accepts bare IPv4/IPv6 addresses and CIDR networks, for example `127.0.0.1`, `::1`, or `10.0.0.0/8`. Forwarding headers such as `X-Forwarded-For` are not used for this check.
 
 ### API Key
 
@@ -170,6 +183,12 @@ Options:
           path to client tls certs. Enables mtls. [env: TLS_CLIENT_CERTS=]
       --enable-get-scans
           enable get scans endpoint [env: ENABLE_GET_SCANS=]
+      --require-authentication [<require-authentication>]
+          require authentication for Notus and VT endpoints [env: REQUIRE_AUTHENTICATION=]
+      --health-ip-allowlist <health-ip-allowlist>...
+          IP addresses or CIDR networks allowed to use health endpoints [env: HEALTH_IP_ALLOWLIST=]
+      --hide-declined-response-headers [<hide-declined-response-headers>]
+          hide metadata headers on declined requests [env: HIDE_DECLINED_RESPONSE_HEADERS=]
       --api-key <api-key>
           API key that must be set as X-API-KEY header to gain access [env: API_KEY=]
       --scanner-type <ospd,openvas>
@@ -223,6 +242,9 @@ If the signature check is enabled, it is also required to set the the `GNUPGHOME
 | TLS Key                  | --tls-key               |               | tls                                | key               | TLS_KEY                  | Path to server TLS key                                                                                                                                                    |                               |
 | TLS Client Certificates  | --tls-client-certs      |               | tls                                | client_certs      | TLS_CLIENT_CERTS         | Path to client TLS certs enables mTLS                                                                                                                                     |                               |
 | Enable get scans         | --enable-get-scans      |               | endpoints                          | enable_get_scans  | ENABLE_GET_SCANS         | Enables GET /scans endpoint                                                                                                                                               | false                         |
+| Require authentication   | --require-authentication |               | endpoints                          | require_authentication | REQUIRE_AUTHENTICATION | Requires configured authentication for Notus and VT endpoints                                                                                                               | false                         |
+| Health IP allow-list     | --health-ip-allowlist   |               | endpoints                          | health_ip_allowlist | HEALTH_IP_ALLOWLIST    | Allows only listed direct TCP peer IP addresses or CIDR networks to use implemented health probe routes                                                                     | []                            |
+| Hide declined response headers | --hide-declined-response-headers |               | endpoints                          | hide_declined_response_headers | HIDE_DECLINED_RESPONSE_HEADERS | Omits metadata headers from 401 and 403 responses                                                                                                                         | false                         |
 | API key                  | --api-key               |               | endpoints                          | key               | API_KEY                  | API key that must be set as X-API-KEY header to gain access. If none is given, api-key authorization is disabled                                                          |                               |
 | Scanner Type             | --scanner-type          |               | scanner                            | type              | SCANNER_TYPE             | Type of wrapper used to manage scans, currently only `OSPD` is available                                                                                                  | OSPD                          |
 | Max queued scans         | --max-queued-scans      |               | scheduler                          | max_queued_scans  | MAX_QUEUED_SCANS         | Maximum number of queued scans, omit for no limits                                                                                                                        |                               |

--- a/rust/src/openvasd/README.md
+++ b/rust/src/openvasd/README.md
@@ -52,9 +52,9 @@ The API supports two kinds of authentication methods:
 
 The authentication modes are set within a configuration file or via the argument list, when starting the server.
 
-By default, existing endpoint behavior is preserved. Scan endpoints require authentication when authentication is configured. Notus and VT endpoints can additionally require authentication by setting `require_authentication = true` under `[endpoints]`.
+Scan endpoints require authentication when authentication is configured. Notus and VT endpoints require authentication only when `require_authentication = true` is set under `[endpoints]`. With `require_authentication` enabled, `openvasd` refuses to start unless an API key (`key` under `[endpoints]`) or a complete mTLS configuration (`certs`, `key`, and `client_certs` under `[tls]`) is provided.
 
-Declined requests keep the existing response metadata headers by default. Set `hide_declined_response_headers = true` under `[endpoints]` to omit the `authentication`, `api-version`, and `feed-version` headers from `401 Unauthorized` and `403 Forbidden` responses.
+On `401 Unauthorized` and `403 Forbidden` responses, declined requests include the `authentication`, `api-version`, and `feed-version` response metadata headers. Set `hide_declined_response_headers = true` under `[endpoints]` to omit them.
 
 Implemented health probe routes are:
 

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -46,7 +46,7 @@ where
     parse_health_ip_allowlist(values).map_err(serde::de::Error::custom)
 }
 
-fn serialize_health_ip_allowlist<S>(value: &Vec<IpInet>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_health_ip_allowlist<S>(value: &[IpInet], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -235,6 +235,7 @@ impl TypedValueParser for Mode {
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Endpoints {
+    #[serde(default)]
     pub enable_get_scans: bool,
     #[serde(default)]
     pub require_authentication: bool,
@@ -567,6 +568,7 @@ impl Config {
                 clap::Arg::new("health-ip-allowlist")
                     .env("HEALTH_IP_ALLOWLIST")
                     .long("health-ip-allowlist")
+                    .value_parser(clap::value_parser!(IpInet))
                     .action(ArgAction::Append)
                     .value_delimiter(',')
                     .num_args(1..)
@@ -786,9 +788,8 @@ impl Config {
         if let Some(require_authentication) = cmds.get_one::<bool>("require-authentication") {
             config.endpoints.require_authentication = *require_authentication;
         }
-        if let Some(allowlist) = cmds.get_many::<String>("health-ip-allowlist") {
-            config.endpoints.health_ip_allowlist =
-                parse_health_ip_allowlist(allowlist).unwrap_or_else(|error| panic!("{error}"));
+        if let Some(allowlist) = cmds.get_many::<IpInet>("health-ip-allowlist") {
+            config.endpoints.health_ip_allowlist = allowlist.cloned().collect();
         }
         if let Some(hide_declined_response_headers) =
             cmds.get_one::<bool>("hide-declined-response-headers")

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -12,14 +12,47 @@ use std::{
 };
 
 use crate::container_image_scanner::config::{DBLocation, SqliteConfiguration};
+use cidr::IpInet;
 use clap::{ArgAction, builder::TypedValueParser};
 use logging::SerLevel;
 use scannerlib::{
     models::PreferenceValue,
     scanner::preferences::preference::{PREFERENCES, ScanPrefValue},
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 mod logging;
+
+fn parse_health_ip_allowlist<I, S>(entries: I) -> Result<Vec<IpInet>, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    entries
+        .into_iter()
+        .map(|entry| {
+            let entry = entry.as_ref();
+            entry
+                .parse::<IpInet>()
+                .map_err(|error| format!("invalid health IP allow-list entry `{entry}`: {error}"))
+        })
+        .collect()
+}
+
+fn deserialize_health_ip_allowlist<'de, D>(deserializer: D) -> Result<Vec<IpInet>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let values = Vec::<String>::deserialize(deserializer)?;
+    parse_health_ip_allowlist(values).map_err(serde::de::Error::custom)
+}
+
+fn serialize_health_ip_allowlist<S>(value: &Vec<IpInet>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let values = value.iter().map(ToString::to_string).collect::<Vec<_>>();
+    values.serialize(serializer)
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Feed {
@@ -203,6 +236,16 @@ impl TypedValueParser for Mode {
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Endpoints {
     pub enable_get_scans: bool,
+    #[serde(default)]
+    pub require_authentication: bool,
+    #[serde(default)]
+    pub hide_declined_response_headers: bool,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_health_ip_allowlist",
+        serialize_with = "serialize_health_ip_allowlist"
+    )]
+    pub health_ip_allowlist: Vec<IpInet>,
     #[serde(default)]
     pub enable_get_performance: Option<bool>,
     #[serde(default)]
@@ -512,6 +555,33 @@ impl Config {
                     .help("enable get performance endpoint. Default 'false'."),
             )
             .arg(
+                clap::Arg::new("require-authentication")
+                    .env("REQUIRE_AUTHENTICATION")
+                    .long("require-authentication")
+                    .num_args(0..=1)
+                    .value_parser(clap::builder::BoolValueParser::new())
+                    .default_missing_value("true")
+                    .help("require authentication for Notus and VT endpoints. Default 'false'."),
+            )
+            .arg(
+                clap::Arg::new("health-ip-allowlist")
+                    .env("HEALTH_IP_ALLOWLIST")
+                    .long("health-ip-allowlist")
+                    .action(ArgAction::Append)
+                    .value_delimiter(',')
+                    .num_args(1..)
+                    .help("IP addresses or CIDR networks allowed to use health endpoints."),
+            )
+            .arg(
+                clap::Arg::new("hide-declined-response-headers")
+                    .env("HIDE_DECLINED_RESPONSE_HEADERS")
+                    .long("hide-declined-response-headers")
+                    .num_args(0..=1)
+                    .value_parser(clap::builder::BoolValueParser::new())
+                    .default_missing_value("true")
+                    .help("hide metadata headers on declined requests. Default 'false'."),
+            )
+            .arg(
                 clap::Arg::new("api-key")
                     .env("API_KEY")
                     .long("api-key")
@@ -713,6 +783,18 @@ impl Config {
         if let Some(enable) = cmds.get_one::<bool>("enable-get-performance") {
             config.endpoints.enable_get_performance = Some(*enable);
         }
+        if let Some(require_authentication) = cmds.get_one::<bool>("require-authentication") {
+            config.endpoints.require_authentication = *require_authentication;
+        }
+        if let Some(allowlist) = cmds.get_many::<String>("health-ip-allowlist") {
+            config.endpoints.health_ip_allowlist =
+                parse_health_ip_allowlist(allowlist).unwrap_or_else(|error| panic!("{error}"));
+        }
+        if let Some(hide_declined_response_headers) =
+            cmds.get_one::<bool>("hide-declined-response-headers")
+        {
+            config.endpoints.hide_declined_response_headers = *hide_declined_response_headers;
+        }
         if let Some(api_key) = cmds.get_one::<String>("api-key") {
             config.endpoints.key = Some(api_key.clone());
         }
@@ -825,6 +907,35 @@ mod tests {
 
         let storage_test = toml::from_str::<super::Config>(&content).unwrap();
         assert!(matches!(storage_test.storage, StorageTypes::V1(_)));
+    }
+
+    #[test]
+    fn endpoint_security_settings_parse() {
+        let config: super::Config = toml::from_str(
+            r#"
+            [endpoints]
+            require_authentication = true
+            hide_declined_response_headers = true
+            health_ip_allowlist = ["127.0.0.1", "::1", "10.0.0.0/8"]
+            "#,
+        )
+        .unwrap();
+
+        assert!(config.endpoints.require_authentication);
+        assert!(config.endpoints.hide_declined_response_headers);
+        assert_eq!(config.endpoints.health_ip_allowlist.len(), 3);
+    }
+
+    #[test]
+    fn endpoint_health_ip_allowlist_rejects_invalid_entries() {
+        let result = toml::from_str::<super::Config>(
+            r#"
+            [endpoints]
+            health_ip_allowlist = ["not-an-ip"]
+            "#,
+        );
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/rust/src/openvasd/config/snapshots/openvasd__config__tests__defaults.snap
+++ b/rust/src/openvasd/config/snapshots/openvasd__config__tests__defaults.snap
@@ -15,6 +15,9 @@ advisories_path = '/var/lib/notus/advisories'
 
 [endpoints]
 enable_get_scans = false
+require_authentication = false
+hide_declined_response_headers = false
+health_ip_allowlist = []
 
 [tls]
 

--- a/rust/src/openvasd/main.rs
+++ b/rust/src/openvasd/main.rs
@@ -23,7 +23,7 @@ use std::{
 
 use config::{Config, StorageType};
 use container_image_scanner::config::{DBLocation, SqliteConfiguration};
-use greenbone_scanner_framework::{RuntimeBuilder, ServerCertificate};
+use greenbone_scanner_framework::{EndpointPolicy, RuntimeBuilder, ServerCertificate};
 use notus::config_to_products;
 use scannerlib::models::FeedState;
 use scannerlib::utils::version::show_version;
@@ -69,16 +69,45 @@ async fn _main() -> Result<i32> {
         return Ok(0);
     }
 
+    let require_endpoint_authentication = config.endpoints.require_authentication;
+    let has_api_key = config
+        .endpoints
+        .key
+        .as_ref()
+        .is_some_and(|key| !key.is_empty());
+    let has_mtls =
+        config.tls.certs.is_some() && config.tls.key.is_some() && config.tls.client_certs.is_some();
+    if require_endpoint_authentication && !has_api_key && !has_mtls {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "require_authentication needs endpoints.key or complete mTLS configuration",
+        )
+        .into());
+    }
+
     let products = config_to_products(&config);
     let pool = setup_sqlite(&config).await?;
     let feed_snapshot = Arc::new(std::sync::RwLock::new(FeedState::Unknown));
     let (sender, vts) = vts::init(pool.clone(), &config, feed_snapshot.clone()).await;
     let vts = Arc::new(vts);
     let scan = scans::init(pool.clone(), &config, sender).await?;
-    let (get_notus, post_notus) = notus::init(products.clone());
+    let (get_notus, post_notus) = notus::init(products.clone(), require_endpoint_authentication);
 
     let mut rb = RuntimeBuilder::<greenbone_scanner_framework::End>::new(config.listener.address)
-        .feed_version(feed_snapshot.clone());
+        .feed_version(feed_snapshot.clone())
+        .endpoint_policy(
+            EndpointPolicy::new(config.endpoints.health_ip_allowlist.clone())
+                .hide_declined_response_headers(config.endpoints.hide_declined_response_headers),
+        )
+        .require_authentication(require_endpoint_authentication);
+    if let Some(api_key) = config
+        .endpoints
+        .key
+        .clone()
+        .filter(|api_key| !api_key.is_empty())
+    {
+        rb = rb.api_key(api_key);
+    }
     match (config.tls.certs.clone(), config.tls.key.clone()) {
         (Some(certificate), Some(key)) => {
             rb = rb.server_tls_cer(ServerCertificate::new(key, certificate))

--- a/rust/src/openvasd/notus/mod.rs
+++ b/rust/src/openvasd/notus/mod.rs
@@ -16,17 +16,17 @@ use crate::config::Config;
 
 type Oz = Notus;
 
-pub struct GetOSIcnomingRequest {
+pub struct GetOSIncomingRequest {
     notus: Arc<RwLock<Oz>>,
     require_authentication: bool,
 }
 
-impl Prefixed for GetOSIcnomingRequest {
+impl Prefixed for GetOSIncomingRequest {
     fn prefix(&self) -> &'static str {
         ""
     }
 }
-impl RequestHandler for GetOSIcnomingRequest {
+impl RequestHandler for GetOSIncomingRequest {
     fn needs_authentication(&self) -> bool {
         self.require_authentication
     }
@@ -66,18 +66,18 @@ impl RequestHandler for GetOSIcnomingRequest {
     }
 }
 
-pub struct PostOSIcnomingRequest {
+pub struct PostOSIncomingRequest {
     notus: Arc<RwLock<Oz>>,
     require_authentication: bool,
 }
 
-impl Prefixed for PostOSIcnomingRequest {
+impl Prefixed for PostOSIncomingRequest {
     fn prefix(&self) -> &'static str {
         ""
     }
 }
 
-impl RequestHandler for PostOSIcnomingRequest {
+impl RequestHandler for PostOSIncomingRequest {
     fn needs_authentication(&self) -> bool {
         self.require_authentication
     }
@@ -135,13 +135,13 @@ pub fn config_to_products(config: &Config) -> Arc<RwLock<Notus>> {
 pub fn init(
     notus: Arc<RwLock<Notus>>,
     require_authentication: bool,
-) -> (GetOSIcnomingRequest, PostOSIcnomingRequest) {
+) -> (GetOSIncomingRequest, PostOSIncomingRequest) {
     (
-        GetOSIcnomingRequest {
+        GetOSIncomingRequest {
             notus: notus.clone(),
             require_authentication,
         },
-        PostOSIcnomingRequest {
+        PostOSIncomingRequest {
             notus,
             require_authentication,
         },

--- a/rust/src/openvasd/notus/mod.rs
+++ b/rust/src/openvasd/notus/mod.rs
@@ -16,7 +16,10 @@ use crate::config::Config;
 
 type Oz = Notus;
 
-pub struct GetOSIcnomingRequest(Arc<RwLock<Oz>>);
+pub struct GetOSIcnomingRequest {
+    notus: Arc<RwLock<Oz>>,
+    require_authentication: bool,
+}
 
 impl Prefixed for GetOSIcnomingRequest {
     fn prefix(&self) -> &'static str {
@@ -25,7 +28,7 @@ impl Prefixed for GetOSIcnomingRequest {
 }
 impl RequestHandler for GetOSIcnomingRequest {
     fn needs_authentication(&self) -> bool {
-        false
+        self.require_authentication
     }
 
     fn path_segments(&self) -> &'static [&'static str] {
@@ -46,7 +49,7 @@ impl RequestHandler for GetOSIcnomingRequest {
     where
         'b: 'a,
     {
-        let products = self.0.clone();
+        let products = self.notus.clone();
         Box::pin(async move {
             let p = products.read_owned().await;
             match tokio::task::spawn_blocking(move || p.get_available_os())
@@ -63,7 +66,10 @@ impl RequestHandler for GetOSIcnomingRequest {
     }
 }
 
-pub struct PostOSIcnomingRequest(Arc<RwLock<Oz>>);
+pub struct PostOSIcnomingRequest {
+    notus: Arc<RwLock<Oz>>,
+    require_authentication: bool,
+}
 
 impl Prefixed for PostOSIcnomingRequest {
     fn prefix(&self) -> &'static str {
@@ -73,7 +79,7 @@ impl Prefixed for PostOSIcnomingRequest {
 
 impl RequestHandler for PostOSIcnomingRequest {
     fn needs_authentication(&self) -> bool {
-        false
+        self.require_authentication
     }
 
     fn path_segments(&self) -> &'static [&'static str] {
@@ -93,7 +99,7 @@ impl RequestHandler for PostOSIcnomingRequest {
     where
         'b: 'a,
     {
-        let products = self.0.clone();
+        let products = self.notus.clone();
 
         let os = self
             .ids(uri)
@@ -126,10 +132,19 @@ pub fn config_to_products(config: &Config) -> Arc<RwLock<Notus>> {
     products_loader(&config.notus.products_path, config.feed.signature_check)
 }
 
-pub fn init(notus: Arc<RwLock<Notus>>) -> (GetOSIcnomingRequest, PostOSIcnomingRequest) {
+pub fn init(
+    notus: Arc<RwLock<Notus>>,
+    require_authentication: bool,
+) -> (GetOSIcnomingRequest, PostOSIcnomingRequest) {
     (
-        GetOSIcnomingRequest(notus.clone()),
-        PostOSIcnomingRequest(notus),
+        GetOSIcnomingRequest {
+            notus: notus.clone(),
+            require_authentication,
+        },
+        PostOSIcnomingRequest {
+            notus,
+            require_authentication,
+        },
     )
 }
 
@@ -174,7 +189,7 @@ mod tests {
     #[tokio::test]
     async fn get_notus() -> crate::Result<()> {
         let config = config();
-        let (undertest, _) = super::init(super::config_to_products(&config));
+        let (undertest, _) = super::init(super::config_to_products(&config), false);
         let entry_point = test_utilities::entry_point(
             Authentication::MTLS,
             create_single_handler!(undertest),
@@ -189,7 +204,7 @@ mod tests {
     #[tokio::test]
     async fn post_notus_os() -> crate::Result<()> {
         let config = config();
-        let (_, undertest) = super::init(super::config_to_products(&config));
+        let (_, undertest) = super::init(super::config_to_products(&config), false);
         let entry_point = test_utilities::entry_point(
             Authentication::MTLS,
             create_single_handler!(undertest),
@@ -202,6 +217,64 @@ mod tests {
         );
         let resp = entry_point.call(req).await?;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let req = test_utilities::json_request(
+            Method::POST,
+            "/notus/test",
+            &vec!["man-db-1.1.1".to_string()],
+        );
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn notus_requires_authentication_when_enabled() -> crate::Result<()> {
+        let config = config();
+        let (get_notus, post_notus) = super::init(super::config_to_products(&config), true);
+        let entry_point = test_utilities::entry_point(
+            Authentication::MTLS,
+            create_single_handler!(get_notus, post_notus),
+            None,
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/notus");
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let req = test_utilities::empty_request(Method::HEAD, "/notus");
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let req = test_utilities::json_request(
+            Method::POST,
+            "/notus/test",
+            &vec!["man-db-1.1.1".to_string()],
+        );
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn notus_required_authentication_allows_known_client() -> crate::Result<()> {
+        let config = config();
+        let (get_notus, post_notus) = super::init(super::config_to_products(&config), true);
+        let entry_point = test_utilities::entry_point(
+            Authentication::MTLS,
+            create_single_handler!(get_notus, post_notus),
+            Some(ClientHash::default()),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/notus");
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let req = test_utilities::empty_request(Method::HEAD, "/notus");
+        let resp = entry_point.call(req).await?;
+        assert_eq!(resp.status(), StatusCode::OK);
 
         let req = test_utilities::json_request(
             Method::POST,


### PR DESCRIPTION
## What

Adds three opt-in `[endpoints]` settings to `openvasd`, all defaulting to off so
existing deployments are unaffected:

- `require_authentication` — require the configured auth (mTLS or API key) for
  `/notus`, `/notus/{os}`, and `/vts` (previously always unauthenticated).
- `health_ip_allowlist` — restrict the implemented health probe routes
  (`GET`/`HEAD` on `/health/alive`, `/health/ready`, `/health/started`) to direct
  TCP peer IPs or CIDR networks. `X-Forwarded-For` is intentionally ignored.
- `hide_declined_response_headers` — omit the `authentication`, `api-version`, and
  `feed-version` metadata headers on `401` and `403` responses.

Each is configurable via TOML, CLI flag, and environment variable. Startup fails
fast if `require_authentication` is set without an API key or complete mTLS config.
OpenAPI, README, example configs, the default config snapshot, and tests are updated.

## Why

Today `openvasd` serves the Notus and VT endpoints without authentication and
answers health probes for any caller. That is acceptable behind a trusted gateway,
but risky for any instance that is — intentionally or accidentally — reachable from
an untrusted network. This change lets operators harden such deployments without
breaking the default behavior.

Concrete risks on a publicly reachable instance:

- **Unauthenticated Notus/VT endpoints** disclose which OS advisories and
  vulnerability tests the scanner knows about. An attacker can fingerprint the
  feed and OS coverage to infer what the operator can (and cannot) detect, and use
  that to plan evasion. These endpoints are also comparatively expensive, so open
  access invites resource abuse and denial-of-service amplification.
- **Open health endpoints** (`/health/alive`, `/health/ready`, `/health/started`)
  leak liveness and readiness state. That confirms a live service to scanners and
  helps an attacker time activity (e.g., probe while the service is starting or
  not ready) and map infrastructure during reconnaissance.
- **Metadata headers on declined requests.** Returning `authentication`,
  `api-version`, and `feed-version` on `401`/`403` responses hands version and
  capability details to callers who have *not* authenticated. This is information
  disclosure / version fingerprinting — OWASP A02:2025 Security Misconfiguration —
  and contradicts the least-information and defense-in-depth principles. Precise
  `api-version`/`feed-version` values let an attacker correlate the instance with
  known issues in specific versions (cf. OWASP WSTG information-gathering / version
  disclosure). Suppressing them on declined responses reduces the pre-auth
  attack surface while keeping the headers available to authenticated clients.

Because every option defaults to off, current setups are unchanged; operators opt
in only where the threat model requires it.

## How

- New `EndpointPolicy` in `greenbone-scanner-framework` holds the allow-list and the
  hide-headers flag. `allows_health_peer` matches the peer IP against the CIDR set;
  `is_health_probe_route` gates only the implemented health routes; metadata-header
  suppression is centralized in `should_hide_metadata_headers`.
- The accept loop now forwards the peer `SocketAddr` through `make_service` into the
  entry point so the allow-list can be enforced per connection.
- Request handlers (`GetVTsHandler`, Notus handlers) gain a `require_authentication`
  flag threaded through `RuntimeBuilder` (new `api_key`, `endpoint_policy`, and
  `require_authentication` builder methods).
- Config parsing validates allow-list entries (`IpInet`) and rejects invalid values
  for both TOML and CLI input.

## Contribution checklist

- [x] Conventional commit tag (`Add:` → minor release)
- [x] AI use disclosed (`Co-authored-by: AI (codex/partial)` and
      `Co-authored-by: AI (copilot/partial)`)
- [x] RELICENSE: not required — contributor is a Greenbone member; if a RELICENSE
      file is nonetheless required, it is covered by greenbone/openvas-scanner#2248.

## Misc

Jira: SC-1635