### PR TITLE
Fix: use API Key when given

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/lib.rs
+++ b/rust/crates/greenbone-scanner-framework/src/lib.rs
@@ -175,6 +175,15 @@ impl<T> RuntimeBuilder<T> {
         self
     }
 
+    pub fn api_keys(mut self, api_keys: Vec<String>) -> RuntimeBuilder<T> {
+        self.api_keys = if api_keys.is_empty() {
+            None
+        } else {
+            Some(api_keys)
+        };
+        self
+    }
+
     pub fn server_tls_cer(mut self, server_tls_cer: ServerCertificate) -> RuntimeBuilder<T> {
         self.tls = Some(match self.tls {
             Some(TLSConfig {

--- a/rust/src/openvasd/main.rs
+++ b/rust/src/openvasd/main.rs
@@ -79,6 +79,9 @@ async fn _main() -> Result<i32> {
 
     let mut rb = RuntimeBuilder::<greenbone_scanner_framework::End>::new(config.listener.address)
         .feed_version(feed_snapshot.clone());
+    if let Some(api_key) = config.endpoints.key.clone() {
+        rb = rb.api_keys(vec![api_key]);
+    }
     match (config.tls.certs.clone(), config.tls.key.clone()) {
         (Some(certificate), Some(key)) => {
             rb = rb.server_tls_cer(ServerCertificate::new(key, certificate))


### PR DESCRIPTION
Previously the API key was completely ignored within the openvasd settings. It was never passed to the Server.

SC-1605