### PR TITLE
Fix: Prefer CVSSv3 over CVSSv2 in Notus advisories

### DIFF
--- a/rust/src/notus/advisories.rs
+++ b/rust/src/notus/advisories.rs
@@ -124,9 +124,9 @@ pub struct VulnerabilityData {
 
 impl From<VulnerabilityData> for Vulnerability {
     fn from(data: VulnerabilityData) -> Self {
-        let sv = match data.adv.severity.cvss_v2 {
+        let sv = match data.adv.severity.cvss_v3 {
             Some(cvss) => cvss,
-            None => match data.adv.severity.cvss_v3 {
+            None => match data.adv.severity.cvss_v2 {
                 Some(cvss) => cvss,
                 None => "".to_string(),
             },


### PR DESCRIPTION
When picking the value for the "severity_vector" VT tag of Notus advisories, the CVSSv3 one is now prefrerred over the CVSSv2 one.

This is more consistent with the common behavior of preferring the newest CVSS version where available.

This addresses GEA-1844, GEA-1853
