### PR TITLE
Fix: don't store feed `.inc` includes as VTs (full-mode NASL sync aborts on duplicate OID)

### DIFF
--- a/rust/src/openvasd/vts/mod.rs
+++ b/rust/src/openvasd/vts/mod.rs
@@ -314,32 +314,36 @@ where
                 sumsfile.insert(item.file_name.clone(), item);
             }
         }
-        // inc files in the feed, are not listed in the vt-metadata json.
-        // Therefore, we create a list of inc files and perform the integrity
-        // check iterating on this list.
+        // .inc files are feed *includes* (NASL libraries), not VTs: they are
+        // not listed in the vt-metadata json and carry no OID. We still want to
+        // integrity-check them, but they must NOT be sent to the VT storage.
+        // Previously each .inc was stored as a VTData with a shared placeholder
+        // oid ("fake_oid"); with more than one .inc file that collides on the
+        // unique `oid` key and aborts the whole NASL feed synchronization with
+        // `UNIQUE constraint failed: plugins.oid`, leaving openvasd with no
+        // runnable VTs. Verify the integrity of each .inc file in place instead.
+        // The check only applies when signature verification is enabled (there
+        // is nothing in the sums file to verify against otherwise).
         // TODO: improve the signature check for the whole feed.
-        let target_ext = OsStr::new("inc");
-        let inc_files = WalkDir::new(&dir_path)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_type().is_file())
-            .map(|entry| entry.into_path())
-            .filter(|path| path.extension() == Some(target_ext))
-            .collect::<Vec<_>>();
-        for element in inc_files.iter() {
-            let inc_f = VTData {
-                oid: "fake_oid".to_string(),
-                filename: element
+        if signature_check {
+            let target_ext = OsStr::new("inc");
+            let inc_files = WalkDir::new(&dir_path)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_file())
+                .map(|entry| entry.into_path())
+                .filter(|path| path.extension() == Some(target_ext))
+                .collect::<Vec<_>>();
+            for element in inc_files.iter() {
+                let filename = element
                     .strip_prefix(&dir_path)
                     .unwrap()
                     .to_str()
                     .unwrap()
-                    .to_string(),
-                ..Default::default()
-            };
-
-            if let Err(e) = verify_signature_and_send(&sender, &sumsfile, inc_f, signature_check) {
-                tracing::warn!(e);
+                    .to_string();
+                if let Err(e) = verify_signature(&sumsfile, &filename) {
+                    tracing::warn!(e);
+                }
             }
         }
 
@@ -360,6 +364,23 @@ where
 }
 
 // Sends a VTdatamessage struct to be loaded
+/// Verify a feed file's hashsum against the (already signature-verified)
+/// sha256sums file, returning its hashsum on success. Used both to integrity-
+/// check feed includes (.inc files, which are not stored as VTs) and as the
+/// verification step before sending a VT to storage.
+fn verify_signature(
+    sumsfile: &HashMap<String, HashSumFileItem<'_>>,
+    filename: &str,
+) -> Result<String, String> {
+    let Some(checker) = sumsfile.get(filename) else {
+        return Err(format!("File not present in sumsfile: {filename:?}"));
+    };
+    checker
+        .verify()
+        .map_err(|e| format!("Wrong hashsum for file: {e:?}"))?;
+    Ok(checker.get_hashsum())
+}
+
 fn verify_signature_and_send(
     sender: &std::sync::mpsc::Sender<VTDataMessage>,
     sumsfile: &HashMap<String, HashSumFileItem<'_>>,
@@ -367,16 +388,7 @@ fn verify_signature_and_send(
     signature_check: bool,
 ) -> Result<(), String> {
     let hashsum = if signature_check {
-        let Some(checker) = sumsfile.get(&item.filename) else {
-            return Err(format!(
-                "File not present in sumsfile: {:?}",
-                &item.filename
-            ));
-        };
-        checker
-            .verify()
-            .map_err(|e| format!("Wrong hashsum for file: {e:?}"))?;
-        checker.get_hashsum()
+        verify_signature(sumsfile, &item.filename)?
     } else {
         "".into()
     };


### PR DESCRIPTION
# Fix: don't store feed `.inc` includes as VTs (full-mode NASL sync aborts on duplicate OID)

## TL;DR

Since #2243, `openvasd` in **full scan mode** can't load the NASL feed: the new
`.inc`-file handling stores every include file under the same placeholder OID
`"fake_oid"`, which collides on the unique `oid` key and **aborts the entire NASL
feed synchronization**. The result is **zero runnable NVTs** and every scan
failing at `progress 0`. This PR integrity-checks `.inc` files without storing
them as VTs, which restores the feed (verified: **0 → 94,402** real NVTs loaded).

---

## The issue / symptoms

On `openvasd` ≥ v23.46.4 running its own NASL feed sync (full scan mode):

**1. NASL feed sync aborts on startup**
```
WARN  openvasd::vts::orchestrator: Unable to update feed.
      error=error returned from database: (code: 1555) UNIQUE constraint failed: plugins.oid
      feed_type=nasl
INFO  openvasd::scans::scheduling: Synchronized allowing_new_scans=false feed=NASL
```

**2. `GET /vts` returns no real NVTs — only advisories + a bogus `fake_oid`.**
The real NASL NVTs (`1.3.6.1.4.1.25623.1.0.*`) are never stored, because they are
sent *after* the `.inc` loop in the same sync, which already errored out.

**3. Every scan fails immediately.** A consumer that builds a scan from `GET /vts`
submits `fake_oid` (and no real VTs); `ospd-openvas` reports:
```
WARNING (ospd_openvas.preferencehandler) The VT fake_oid was not found and it will
        not be added to the plugin scheduler.
INFO    <scan-id>: Host scan got interrupted. Progress: 0, Status: RUNNING
INFO    <scan-id>: Scan process is dead and its progress is 0
INFO    openvasd::scans::scheduling: Scan is finished. … status=failed
```

**Impact:** full-mode `openvasd` is effectively unusable for scanning on affected
builds — it authenticates and accepts scans, but every scan returns nothing
because there are no NVTs loaded. (The default **notus-only** deployment, where
`ospd-openvas` owns the NASL feed, is unaffected.)

## Root cause

`.inc` files are NASL *includes* (libraries) — they are not VTs, have no OID, and
are not listed in `vt-metadata.json`. #2243 added a block that pushes each `.inc`
file through the same `verify_signature_and_send` path used for real VTs, all
sharing a hardcoded `oid: "fake_oid"`:

```rust
// rust/src/openvasd/vts/mod.rs  (added in #2243)
for element in inc_files.iter() {
    let inc_f = VTData {
        oid: "fake_oid".to_string(),
        filename: element.strip_prefix(&dir_path)…,
        ..Default::default()
    };
    if let Err(e) = verify_signature_and_send(&sender, &sumsfile, inc_f, signature_check) {
        tracing::warn!(e);
    }
}
```

The VT store enforces a **unique `oid`**. A real feed has many `.inc` files, so the
**second** insert (`oid = "fake_oid"` again) fails with `UNIQUE constraint failed:
plugins.oid`, the `synchronize_json` closure returns `Err`, and the whole NASL sync
aborts before the real VTs are loaded.

- **Introduced by:** `4c2ea461` — *"store the mtime in the redis nvticache for
  backward compatibility"* (#2243). `git show 4c2ea461 -- rust/src/openvasd/vts/mod.rs`
  shows the `.inc` block is entirely new.
- **Affected:** v23.46.4 / v23.46.5 and the `:stable`/`:edge` images built from
  them. v23.46.2 / v23.46.3 are clean.
- **Scope:** `openvasd` full scan mode (NASL feed sync) only.

## The fix

`rust/src/openvasd/vts/mod.rs`:

1. Extract the hashsum verification into `verify_signature` and have
   `verify_signature_and_send` reuse it:

```rust
fn verify_signature(
    sumsfile: &HashMap<String, HashSumFileItem<'_>>,
    filename: &str,
) -> Result<String, String> {
    let Some(checker) = sumsfile.get(filename) else {
        return Err(format!("File not present in sumsfile: {filename:?}"));
    };
    checker.verify().map_err(|e| format!("Wrong hashsum for file: {e:?}"))?;
    Ok(checker.get_hashsum())
}

fn verify_signature_and_send(/* … */) -> Result<(), String> {
    let hashsum = if signature_check {
        verify_signature(sumsfile, &item.filename)?
    } else {
        "".into()
    };
    sender.send(VTDataMessage { item, hashsum }).map_err(|e| e.to_string())
}
```

2. In the NASL sync, **only integrity-check** `.inc` files — never build a
   `VTData` or send them to the VT store:

```rust
if signature_check {
    let target_ext = OsStr::new("inc");
    let inc_files = WalkDir::new(&dir_path) … .collect::<Vec<_>>();
    for element in inc_files.iter() {
        let filename = element.strip_prefix(&dir_path).unwrap().to_str().unwrap().to_string();
        if let Err(e) = verify_signature(&sumsfile, &filename) {
            tracing::warn!(e);
        }
    }
}
```

`.inc` files are still integrity-checked, but they no longer enter the VT `oid`
table, so the duplicate-OID collision is gone and the NASL feed synchronizes
completely. `verify_signature_and_send`'s public signature is unchanged.

> **Note on #2243's intent:** that PR also aimed to persist `.inc` hashsums/mtime
> in the redis nvticache for backward compatibility. This fix verifies `.inc`
> integrity but does not persist their hashsums. If that persistence is required,
> the collision should instead be fixed by keying `.inc` entries **by filename**
> (or a dedicated namespace) so they never enter the VT `oid` table or `GET /vts`.
> Happy to take whichever direction maintainers prefer.

## Testing

Built the workspace from source with this fix (`.docker/prod.Dockerfile`) and ran
the resulting `openvasd` in a full-scan-mode stack (`OPENVASD_MODE` unset,
`ospd-openvas` + redis + the 24.10 feed), then compared against the affected
`:stable` build.

**Patched binary no longer contains the placeholder:**
```
$ strings /usr/local/bin/openvasd | grep -c fake_oid
0          # (affected build: > 0)
```

**Feed sync — no error, NASL loads:**
```
# affected:  WARN … UNIQUE constraint failed: plugins.oid  feed_type=nasl
# patched:   (no UNIQUE constraint errors; feed synchronization completes)
```

**`GET /vts` before vs after (FEED_RELEASE 24.10):**

| | before (`:stable`, v23.46.5) | after (this fix) |
|---|---|---|
| total entries | 85,756 | 180,844 |
| `fake_oid` | 1 | **0** |
| real NASL NVTs (`…1.0.x`) | **0** | **94,402** |
| advisories (`…2002.x`) | 85,755 | 86,442 |
| `UNIQUE constraint` errors | feed aborted | 0 |

**End-to-end scan:** a scan that previously went
`fake_oid was not found → Progress 0 → status=failed` in seconds now reports
`status=running` and scans the target with the real VT set — no `fake_oid`
warnings in `ospd-openvas`.

**Suggested unit coverage** for `verify_signature`: present file → `Ok(hashsum)`;
missing file → `Err("File not present…")`; tampered hashsum → `Err("Wrong hashsum…")`.

## Reproduce

1. Run `openvasd` full scan mode (`OPENVASD_MODE` unset) against the NASL feed,
   image ≥ v23.46.4.
2. Startup logs `UNIQUE constraint failed: plugins.oid` + `allowing_new_scans=false
   feed=NASL`; `GET /vts` contains `fake_oid` and no `…1.0.x` NVTs.
3. Submit any scan → `The VT fake_oid was not found` → `progress 0`, `status failed`.

After this fix: the NASL feed finishes synchronizing, `GET /vts` returns the real
NVTs (no `fake_oid`), and scans run.

## Notes

- No behavior change for the notus-only path or for real VT loading.
- `// TODO: improve the signature check for the whole feed` is retained.
