### PR TITLE
Fix: reported issues in the scanner

### DIFF
--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -254,12 +254,19 @@ nasl_get_sign (lex_ctxt *lexic)
                           "buflen:<bl>, seq_number:<s>)\n");
       return NULL;
     }
-  uint8_t calc_md5_mac[16];
-  simple_packet_signature_ntlmssp ((uint8_t *) mac_key, buf, seq_num,
-                                   calc_md5_mac);
   if (buflen != get_var_size_by_name (lexic, "buf") || buflen < 26)
     {
       nasl_perror (lexic, "OOB read/write\n");
+      return NULL;
+    }
+
+  uint8_t calc_md5_mac[16];
+  if (simple_packet_signature_ntlmssp ((uint8_t *) mac_key, buf,
+                                       (size_t) buflen, seq_num,
+                                       calc_md5_mac)
+      != 0)
+    {
+      nasl_perror (lexic, "get_signature: OOB read\n");
       return NULL;
     }
 

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -29,7 +29,6 @@
 #include "smb_signing.h"
 
 #include <assert.h>
-#include <cstdint>
 #include <ctype.h>
 #include <gcrypt.h>
 #include <glib.h>
@@ -263,8 +262,7 @@ nasl_get_sign (lex_ctxt *lexic)
 
   uint8_t calc_md5_mac[16];
   if (simple_packet_signature_ntlmssp ((uint8_t *) mac_key, buf,
-                                       (size_t) buflen, seq_num,
-                                       calc_md5_mac)
+                                       (size_t) buflen, seq_num, calc_md5_mac)
       != 0)
     {
       nasl_perror (lexic, "get_signature: OOB read\n");
@@ -916,17 +914,30 @@ nasl_ntlmv2_hash (lex_ctxt *lexic)
 
   /* NTLMv2 */
 
-  /* We also get to specify some random data */
+  /* We also get to specify some random data.
+     To avoid DoS we set an uper limit for client chal length.
+     At the moment of fixing this, the max lenght used in a nasl script is 64.
+  */
+  if (client_chal_length > 4096)
+    {
+      nasl_perror (lexic, "Length to big. Max is 4096\n");
+      return NULL;
+    }
+
   ntlmv2_client_data = g_malloc0 (client_chal_length);
   for (i = 0; i < client_chal_length; i++)
     ntlmv2_client_data[i] = rand () % 256;
 
   if (hash_len != 16)
-    nasl_perror (lexic, "owf_in must have a length of 16\n");
+    {
+      nasl_perror (lexic, "owf_in must have a length of 16\n");
+      return NULL;
+    }
 
   /* Given that data, and the challenge from the server, generate a response */
-  SMBOWFencrypt_ntv2_ntlmssp (ntlm_v2_hash, server_chal, 8, ntlmv2_client_data,
-                              client_chal_length, ntlmv2_response);
+  SMBOWFencrypt_ntv2_ntlmssp (
+    ntlm_v2_hash, server_chal, get_var_size_by_name (lexic, "cryptkey"),
+    ntlmv2_client_data, client_chal_length, ntlmv2_response);
 
   /* put it into nt_response, for the code below to put into the packet */
   final_response = g_malloc0 (client_chal_length + sizeof (ntlmv2_response));

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -675,6 +675,8 @@ nasl_ntlmv1_hash (lex_ctxt *lexic)
 
   if (pass_len < 16)
     pass_len = 16;
+  if (pass_len > 21)
+    pass_len = 21;
 
   bzero (p21, sizeof (p21));
   memcpy (p21, password, pass_len);

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -35,6 +35,7 @@
 #include <gvm/base/logging.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifndef uchar
 #define uchar unsigned char
@@ -244,19 +245,32 @@ tree_cell *
 nasl_get_sign (lex_ctxt *lexic)
 {
   char *mac_key = (char *) get_str_var_by_name (lexic, "key");
+  long int keylen = get_var_size_by_name (lexic, "key");
   uint8_t *buf = (uint8_t *) get_str_var_by_name (lexic, "buf");
-  long int buflen = get_int_var_by_name (lexic, "buflen", -1);
+  long int buflen = get_var_size_by_name (lexic, "buf");
   int seq_num = get_int_var_by_name (lexic, "seq_number", -1);
-  if (mac_key == NULL || buf == NULL || buf[0] == '\0' || buflen == -1
-      || seq_num <= -1)
+  if (mac_key == NULL || buf == NULL || buf[0] == '\0' || seq_num <= -1)
     {
+      // deprecate the buf_len argument and use the real buf length
       nasl_perror (lexic, "Syntax : get_signature(key:<k>, buf:<b>, "
-                          "buflen:<bl>, seq_number:<s>)\n");
+                          "seq_number:<s>)\n");
       return NULL;
     }
-  if (buflen != get_var_size_by_name (lexic, "buf") || buflen < 26)
+
+  if (buflen < 26)
     {
-      nasl_perror (lexic, "OOB read/write\n");
+      nasl_perror (lexic,
+                   "OOB read/write. Buffer length must be at least 26. Current "
+                   "length: %ld\n",
+                   buflen);
+      return NULL;
+    }
+
+  if (keylen < 16)
+    {
+      nasl_perror (
+        lexic, "OOB read: key must be at least 16 bytes. Current length: %ld\n",
+        keylen);
       return NULL;
     }
 
@@ -531,27 +545,23 @@ nasl_ntlmv2_response (lex_ctxt *lexic)
   unsigned char *ntlmv2_hash =
     (unsigned char *) get_str_var_by_name (lexic, "ntlmv2_hash");
   char *address_list = get_str_var_by_name (lexic, "address_list");
-  int address_list_len = get_int_var_by_name (lexic, "address_list_len", -1);
+  long int address_list_len = get_var_size_by_name (lexic, "address_list");
 
   if (cryptkey == NULL || user == NULL || domain == NULL || ntlmv2_hash == NULL
-      || address_list == NULL || address_list_len < 0)
+      || address_list == NULL || address_list[0] == '\0')
     {
+      // address_list_len argument is deprecated and ignored. Use the real size
+      // of address_list
       nasl_perror (
         lexic, "Syntax : ntlmv2_response(cryptkey:<c>, user:<u>, domain:<d>, "
                "ntlmv2_hash:<n>, address_list:<a>, address_list_len:<len>)\n");
       return NULL;
     }
 
-  if (address_list_len <= get_var_size_by_name (lexic, "address_list"))
-    {
-      nasl_perror (lexic, "ntlmv2_response: address_list and address_list_len "
-                          "have different sized\n");
-      return NULL;
-    }
   if (address_list_len > UINT16_MAX)
     {
       nasl_perror (lexic,
-                   "ntlmv2_response: address_list_len exceed Max lenght\n");
+                   "ntlmv2_response: address_list_len exceed Max length\n");
       return NULL;
     }
   uint8_t lm_response[24];
@@ -698,11 +708,7 @@ nasl_ntlmv1_hash (lex_ctxt *lexic)
       return NULL;
     }
 
-  if (pass_len < 16)
-    pass_len = 16;
-  if (pass_len > 21)
-    pass_len = 21;
-
+  pass_len = pass_len < 16 ? pass_len : 16;
   bzero (p21, sizeof (p21));
   memcpy (p21, password, pass_len);
 
@@ -920,7 +926,18 @@ nasl_ntlmv2_hash (lex_ctxt *lexic)
   */
   if (client_chal_length > 4096)
     {
-      nasl_perror (lexic, "Length to big. Max is 4096\n");
+      nasl_perror (lexic, "Length too big. Max is 4096\n");
+      return NULL;
+    }
+
+  if (hash_len != 16)
+    {
+      nasl_perror (lexic, "owf_in must have a length of 16\n");
+      return NULL;
+    }
+  if (get_var_size_by_name (lexic, "cryptkey") != 8)
+    {
+      nasl_perror (lexic, "cryptkey/server_chal must have a length of 8\n");
       return NULL;
     }
 
@@ -928,16 +945,9 @@ nasl_ntlmv2_hash (lex_ctxt *lexic)
   for (i = 0; i < client_chal_length; i++)
     ntlmv2_client_data[i] = rand () % 256;
 
-  if (hash_len != 16)
-    {
-      nasl_perror (lexic, "owf_in must have a length of 16\n");
-      return NULL;
-    }
-
   /* Given that data, and the challenge from the server, generate a response */
-  SMBOWFencrypt_ntv2_ntlmssp (
-    ntlm_v2_hash, server_chal, get_var_size_by_name (lexic, "cryptkey"),
-    ntlmv2_client_data, client_chal_length, ntlmv2_response);
+  SMBOWFencrypt_ntv2_ntlmssp (ntlm_v2_hash, server_chal, 8, ntlmv2_client_data,
+                              client_chal_length, ntlmv2_response);
 
   /* put it into nt_response, for the code below to put into the packet */
   final_response = g_malloc0 (client_chal_length + sizeof (ntlmv2_response));

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -29,6 +29,7 @@
 #include "smb_signing.h"
 
 #include <assert.h>
+#include <cstdint>
 #include <ctype.h>
 #include <gcrypt.h>
 #include <glib.h>
@@ -540,6 +541,19 @@ nasl_ntlmv2_response (lex_ctxt *lexic)
       nasl_perror (
         lexic, "Syntax : ntlmv2_response(cryptkey:<c>, user:<u>, domain:<d>, "
                "ntlmv2_hash:<n>, address_list:<a>, address_list_len:<len>)\n");
+      return NULL;
+    }
+
+  if (address_list_len <= get_var_size_by_name (lexic, "address_list"))
+    {
+      nasl_perror (lexic, "ntlmv2_response: address_list and address_list_len "
+                          "have different sized\n");
+      return NULL;
+    }
+  if (address_list_len > UINT16_MAX)
+    {
+      nasl_perror (lexic,
+                   "ntlmv2_response: address_list_len exceed Max lenght\n");
       return NULL;
     }
   uint8_t lm_response[24];

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -257,6 +257,12 @@ nasl_get_sign (lex_ctxt *lexic)
   uint8_t calc_md5_mac[16];
   simple_packet_signature_ntlmssp ((uint8_t *) mac_key, buf, seq_num,
                                    calc_md5_mac);
+  if (buflen != get_var_size_by_name (lexic, "buf") || buflen < 26)
+    {
+      nasl_perror (lexic, "OOB read/write\n");
+      return NULL;
+    }
+
   memcpy (buf + 18, calc_md5_mac, 8);
   char *ret = g_malloc0 (buflen);
   memcpy (ret, buf, buflen);

--- a/nasl/nasl_http2.c
+++ b/nasl/nasl_http2.c
@@ -355,7 +355,7 @@ _http2_req (lex_ctxt *lexic, KEYWORD keyword)
     }
   if (ua)
     {
-      curl_easy_setopt (handle, CURLOPT_USERAGENT, g_strdup (url->str));
+      curl_easy_setopt (handle, CURLOPT_USERAGENT, g_strdup (ua));
       g_free (ua);
     }
 

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -370,9 +370,9 @@ insert_ip_options (lex_ctxt *lexic)
   int pad_len;
   char zero = '0';
   int i;
-  int hl;
+  size_t hl;
 
-  if (ip == NULL)
+  if (ip == NULL || value == NULL)
     {
       nasl_perror (lexic, "Usage : insert_ip_options(ip:<ip>, code:<code>, "
                           "length:<len>, value:<value>\n");
@@ -384,7 +384,11 @@ insert_ip_options (lex_ctxt *lexic)
     pad_len = 0;
 
   hl = ip->ip_hl * 4 < UNFIX (ip->ip_len) ? ip->ip_hl * 4 : UNFIX (ip->ip_len);
+  if (hl > size)
+    return NULL; // malformed.
+
   new_packet = g_malloc0 (size + 4 + value_size + pad_len);
+
   bcopy (ip, new_packet, hl);
 
   uc_code = (u_char) code;
@@ -898,6 +902,13 @@ get_tcp_option (lex_ctxt *lexic)
   ip = (struct ip *) packet;
 
   ipsz = get_var_size_by_name (lexic, "tcp");
+  if (ipsz < (int) sizeof (struct ip))
+    return NULL;
+
+  // check that ip + tcp is bigger that the original packet
+  if (ip->ip_hl * 4 + 20 > ipsz)
+    return NULL;
+
   // ip header length is given in 32 bits words = 4 bytes.
   if (ip->ip_hl * 4 > ipsz)
     return NULL; /* Invalid packet */

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -906,11 +906,8 @@ get_tcp_option (lex_ctxt *lexic)
     return NULL;
 
   // check that ip + tcp is bigger that the original packet
-  if (ip->ip_hl * 4 + 20 > ipsz)
-    return NULL;
-
   // ip header length is given in 32 bits words = 4 bytes.
-  if (ip->ip_hl * 4 > ipsz)
+  if (ip->ip_hl * 4 + 20 > ipsz)
     return NULL; /* Invalid packet */
 
   if (UNFIX (ip->ip_len) > ipsz)

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -409,7 +409,7 @@ insert_ip_v6_options (lex_ctxt *lexic)
   int i;
   size_t pl;
 
-  if (ip6 == NULL && value == NULL)
+  if (ip6 == NULL || value == NULL)
     {
       nasl_perror (lexic,
                    "Usage : %s(ip6:<ip6>, code:<code>, "
@@ -865,19 +865,18 @@ get_tcp_v6_option (lex_ctxt *lexic)
 
   ip6 = (struct ip6_hdr *) packet;
 
-  /* valid ipv6 header check */
+  /* valid ipv6 header check
+     ipv6 header has a fixed length of 40 bytes and tcp a minimum header size of
+     20 bytes.
+  */
   ipsz = get_var_size_by_name (lexic, "tcp");
-  if (ipsz < (int) sizeof (struct ip6_hdr))
-    return NULL; // mal formed.
-
-  if (40 + 20 > ipsz)
-    return NULL;
+  if (ipsz < sizeof (struct ip6_hdr) + 20)
+    return NULL; /* Invalid packet */
 
   if (UNFIX (ip6->ip6_plen) > ipsz)
     return NULL; /* Invalid packet */
 
   tcp = (struct tcphdr *) (packet + 40);
-
   if (tcp->th_off <= 5)
     return NULL;
 

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -407,9 +407,9 @@ insert_ip_v6_options (lex_ctxt *lexic)
   int pad_len;
   char zero = '0';
   int i;
-  int pl;
+  size_t pl;
 
-  if (ip6 == NULL)
+  if (ip6 == NULL && value == NULL)
     {
       nasl_perror (lexic,
                    "Usage : %s(ip6:<ip6>, code:<code>, "
@@ -423,6 +423,10 @@ insert_ip_v6_options (lex_ctxt *lexic)
     pad_len = 0;
 
   pl = 40 < UNFIX (ip6->ip6_plen) ? 40 : UNFIX (ip6->ip6_plen);
+
+  if (pl > size)
+    return NULL; // malformed packet.
+
   new_packet = g_malloc0 (size + 4 + value_size + pad_len);
   bcopy (ip6, new_packet, pl);
 
@@ -863,6 +867,12 @@ get_tcp_v6_option (lex_ctxt *lexic)
 
   /* valid ipv6 header check */
   ipsz = get_var_size_by_name (lexic, "tcp");
+  if (ipsz < (int) sizeof (struct ip6_hdr))
+    return NULL; // mal formed.
+
+  if (40 + 20 > ipsz)
+    return NULL;
+
   if (UNFIX (ip6->ip6_plen) > ipsz)
     return NULL; /* Invalid packet */
 

--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -423,9 +423,16 @@ nasl_win_cmd_exec (lex_ctxt *lexic)
   else
     {
       delimiter = strchr (kdc, ',');
+      int kdc_len = delimiter - kdc;
+      if (delimiter && (kdc_len > INET6_ADDRSTRLEN - 1))
+        {
+          g_warning ("kdc hostname value too long (max 45 chars)");
+          return NULL;
+        }
+
       if (delimiter != NULL)
         {
-          strncpy (first_kdc, kdc, delimiter - kdc);
+          strncpy (first_kdc, kdc, kdc_len);
         }
       else
         {

--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -423,8 +423,7 @@ nasl_win_cmd_exec (lex_ctxt *lexic)
   else
     {
       delimiter = strchr (kdc, ',');
-      int kdc_len = delimiter - kdc;
-      if (delimiter && (kdc_len > INET6_ADDRSTRLEN - 1))
+      if (delimiter && (delimiter - kdc > INET6_ADDRSTRLEN - 1))
         {
           g_warning ("kdc hostname value too long (max 45 chars)");
           return NULL;
@@ -432,7 +431,7 @@ nasl_win_cmd_exec (lex_ctxt *lexic)
 
       if (delimiter != NULL)
         {
-          strncpy (first_kdc, kdc, kdc_len);
+          strncpy (first_kdc, kdc, delimiter - kdc);
         }
       else
         {

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -11,6 +11,7 @@
 #include "nasl_snmp.h"
 
 #include "../misc/plugutils.h"
+#include "glib.h"
 #include "nasl_lex_ctxt.h"
 
 #include <assert.h>
@@ -683,13 +684,19 @@ nasl_snmpv1v2c_get (lex_ctxt *lexic, int version, u_char action)
   // is stored.
   if (result->oid_str != NULL && g_strstr_len (result->oid_str, 3, "iso"))
     {
-      next_oid_str = result->oid_str + 2;
-      next_oid_str[0] = '1';
-      result->oid_str = g_strdup (next_oid_str);
+      char *orig = result->oid_str;
+      char *tmp = result->oid_str + 2;
+      tmp[0] = '1';
+      result->oid_str = g_strdup (tmp);
+      g_free (orig);
+      g_free (next_oid_str);
+      next_oid_str = g_strdup (result->oid_str);
     }
   else if (result->oid_str != NULL)
-    next_oid_str = result->oid_str;
-
+    {
+      g_free (next_oid_str);
+      next_oid_str = g_strdup (result->oid_str);
+    }
   /* Free request only, since members are pointers to the nasl lexic context
      which will be free()'d later */
   g_free (request);

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -419,19 +419,19 @@ check_spwan_output (int fd, snmp_result_t result, int fd_flag)
   while (1)
     {
       char buf[4096];
-      size_t bytes;
+      ssize_t bytes;
 
       bytes = read (fd, buf, sizeof (buf));
-      if (!bytes)
-        break;
-      else if (bytes > 0)
-        g_string_append_len (string, buf, bytes);
-      else
+      if (bytes < 0)
         {
           g_warning ("snmpget: %s", strerror (errno));
           g_string_free (string, TRUE);
           return -1;
         }
+      if (!bytes)
+        break;
+      else if (bytes > 0)
+        g_string_append_len (string, buf, bytes);
     }
 
   // Split the result and store the oid and name

--- a/nasl/nasl_snmp.c
+++ b/nasl/nasl_snmp.c
@@ -819,12 +819,19 @@ nasl_snmpv3_get_action (lex_ctxt *lexic, u_char action)
   // is stored.
   if (result->oid_str != NULL && g_strstr_len (result->oid_str, 3, "iso"))
     {
-      next_oid_str = result->oid_str + 2;
-      next_oid_str[0] = '1';
-      result->oid_str = g_strdup (next_oid_str);
+      char *orig = result->oid_str;
+      char *tmp = result->oid_str + 2;
+      tmp[0] = '1';
+      result->oid_str = g_strdup (tmp);
+      g_free (orig);
+      g_free (next_oid_str);
+      next_oid_str = g_strdup (result->oid_str);
     }
   else if (result->oid_str != NULL)
-    next_oid_str = result->oid_str;
+    {
+      g_free (next_oid_str);
+      next_oid_str = g_strdup (result->oid_str);
+    }
 
   /* Free request only, since members are pointers to the nasl lexic context
      which will be free()'d later */

--- a/nasl/smb_signing.c
+++ b/nasl/smb_signing.c
@@ -18,11 +18,13 @@
 */
 
 #include "smb_signing.h"
+
 #include <stdint.h>
 
 int
-simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf, size_t buf_len,
-                                 uint32 seq_number, unsigned char *calc_md5_mac)
+simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf,
+                                 size_t buf_len, uint32 seq_number,
+                                 unsigned char *calc_md5_mac)
 {
   const size_t offset_end_of_sig = (smb_ss_field + 8);
   unsigned char sequence_buf[8];

--- a/nasl/smb_signing.c
+++ b/nasl/smb_signing.c
@@ -18,14 +18,28 @@
 */
 
 #include "smb_signing.h"
+#include <stdint.h>
 
-void
-simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf,
+int
+simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf, size_t buf_len,
                                  uint32 seq_number, unsigned char *calc_md5_mac)
 {
   const size_t offset_end_of_sig = (smb_ss_field + 8);
   unsigned char sequence_buf[8];
   struct MD5Context md5_ctx;
+  const uint32 claimed_len = smb_len (buf);
+  size_t tail_len;
+
+  if (buf == NULL || buf_len < offset_end_of_sig)
+    return -1;
+
+  if (claimed_len < offset_end_of_sig - 4)
+    return -1;
+
+  tail_len = claimed_len - (offset_end_of_sig - 4);
+
+  if (tail_len > buf_len - offset_end_of_sig)
+    return -1;
 
   /*
    * Firstly put the sequence number into the first 4 bytes.
@@ -33,7 +47,6 @@ simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf,
    *
    * We do this here, to avoid modifying the packet.
    */
-
   SIVAL (sequence_buf, 0, seq_number);
   SIVAL (sequence_buf, 4, 0);
 
@@ -54,9 +67,9 @@ simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf,
   MD5Update (&md5_ctx, sequence_buf, sizeof (sequence_buf));
 
   /* copy in the rest of the packet in, skipping the signature */
-  MD5Update (&md5_ctx, buf + offset_end_of_sig,
-             smb_len (buf) - (offset_end_of_sig - 4));
+  MD5Update (&md5_ctx, buf + offset_end_of_sig, tail_len);
 
   /* calculate the MD5 sig */
   MD5Final (calc_md5_mac, &md5_ctx);
+  return 0;
 }

--- a/nasl/smb_signing.h
+++ b/nasl/smb_signing.h
@@ -32,9 +32,9 @@
 #define uint8 uint8_t
 #endif
 
-void
+int
 simple_packet_signature_ntlmssp (uint8_t *mac_key, const uchar *buf,
-                                 uint32 seq_number,
+                                 size_t buf_len, uint32 seq_number,
                                  unsigned char *calc_md5_mac);
 
 #endif


### PR DESCRIPTION
SC-1649

SC-1665
- Fix: useragent in nasl_http2.c. Reported as an use-after-free issue, but the problem was that I was using the wrong variable. Now uses the right one ua
SC-1666
- Fix: avoid stack overflow when password length is greater than 21
SC-1667
- Fix: check buffer lenght before memcpy
SC-1668
- Fix: OOB read in nasl_crypt.c
SC-1669
- Fix: nasl_ntlmv2_hash(). Do length validation.
SC-1670
- Fix: Unbounded VLA / stack overflow / integer overflow
SC-1671
- Fix:nasl_snmp.c: read() return stored in size_t
SC-1672
- Fix: use-after-free in nasl_snmpv1v2c_get()
SC-1673
- Fix: Stack overflow in nasl_win_cmd_exec()
SC-1674
- Fix: OOB read / potential heap overflow nasl_packet_forgery*

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.
