### PR TITLE
Fix: KRB5 credential type.

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/credential.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/credential.rs
@@ -52,7 +52,7 @@ pub enum Service {
     /// SNMP, supports [SNMP](CredentialType::SNMP)
     SNMP,
     #[serde(rename = "krb5")]
-    /// SNMP, supports [SNMP](CredentialType::SNMP)
+    /// KRB5, supports [KRB5](CredentialType::KRB5)
     KRB5,
     #[serde(rename = "generic")]
     Generic,
@@ -139,6 +139,8 @@ pub enum CredentialType {
         /// The SNMP privacy algorithm.
         privacy_algorithm: String,
     },
+    #[serde(rename = "krb5")]
+    /// KRB5 credentials.
     KRB5 {
         username: String,
         password: String,


### PR DESCRIPTION
Fix: KRB5 credential type.
the missing rename produced an error when reading the scan config with krb5 credential type.
SC-1648

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.
