### PR TITLE
Fix default lock file path

### DIFF
--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -6,7 +6,7 @@ use std::{
     collections::HashMap,
     fmt::{self, Display, Formatter},
     net::SocketAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
 };
@@ -101,8 +101,23 @@ impl Default for Feed {
             path: PathBuf::from("/var/lib/openvas/plugins"),
             check_interval: Duration::from_secs(3600),
             signature_check: true,
-            lock_file_dir: Some(PathBuf::from("/var/lib/openvas")),
+            lock_file_dir: None,
         }
+    }
+}
+
+impl Feed {
+    fn default_lock_file_dir(feed_path: &Path) -> PathBuf {
+        feed_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
+    pub(crate) fn lock_file_dir(&self) -> PathBuf {
+        self.lock_file_dir
+            .clone()
+            .unwrap_or_else(|| Self::default_lock_file_dir(&self.path))
     }
 }
 
@@ -657,10 +672,14 @@ impl Config {
             config.scanner.ospd.read_timeout = Some(Duration::from_secs(*interval));
         }
 
+        let lock_file_dir_arg = cmds.get_one::<PathBuf>("lock-file-dir");
         if let Some(path) = cmds.get_one::<PathBuf>("feed-path") {
             config.feed.path.clone_from(path);
+            if lock_file_dir_arg.is_none() {
+                config.feed.lock_file_dir = None;
+            }
         }
-        if let Some(path) = cmds.get_one::<PathBuf>("lock-file-dir") {
+        if let Some(path) = lock_file_dir_arg {
             config
                 .feed
                 .lock_file_dir

--- a/rust/src/openvasd/config/snapshots/openvasd__config__tests__defaults.snap
+++ b/rust/src/openvasd/config/snapshots/openvasd__config__tests__defaults.snap
@@ -8,7 +8,6 @@ mode = 'service'
 path = '/var/lib/openvas/plugins'
 check_interval = '3600s'
 signature_check = true
-lock_file_dir = '/var/lib/openvas'
 
 [notus]
 products_path = '/var/lib/notus/products'

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -129,6 +129,25 @@ pub enum Message {
 // maybe we should just use AnyHow
 type R<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+#[derive(Debug, thiserror::Error)]
+enum LockFileError {
+    #[error("Unable to open feed update lock file {path}: {source}")]
+    Open {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("Unable to check feed update lock file {path}: {source}")]
+    TryLock {
+        path: String,
+        source: std::io::Error,
+    },
+    #[error("Unable to unlock feed update lock file {path}: {source}")]
+    Unlock {
+        path: String,
+        source: std::io::Error,
+    },
+}
+
 impl<T, C> ScanScheduler<T, C> {
     /// Should be called on restart if the application crashed while there were running scans.
     ///
@@ -181,15 +200,22 @@ impl<T, C> ScanScheduler<T, C> {
     }
 }
 
-fn is_file_locked(path: String) -> bool {
-    let mut file = LockFile::open(&path).expect("Invalid path to lock file");
+fn is_file_locked(path: String) -> R<bool> {
+    let mut file = LockFile::open(&path).map_err(|source| LockFileError::Open {
+        path: path.clone(),
+        source,
+    })?;
 
-    if file.try_lock().expect("already locked by this process") {
-        file.unlock().expect("unlocking not locked file");
-        false
+    if file.try_lock().map_err(|source| LockFileError::TryLock {
+        path: path.clone(),
+        source,
+    })? {
+        file.unlock()
+            .map_err(|source| LockFileError::Unlock { path, source })?;
+        Ok(false)
     } else {
-        //locked by another process
-        true
+        // locked by another process
+        Ok(true)
     }
 }
 
@@ -386,7 +412,7 @@ where
                 let is_file_locked = {
                     let mut lockfile = PathBuf::from(self.lock_file_dir.clone());
                     lockfile.push(LOCK_FILE);
-                    is_file_locked(lockfile.to_string_lossy().to_string())
+                    is_file_locked(lockfile.to_string_lossy().to_string())?
                 };
                 if self.scan_type() == ScannerType::Openvas && !is_file_locked {
                     Some(self.feed_sync_in_progress.write().await.approve())
@@ -438,7 +464,7 @@ where
             let filelocked = {
                 let mut lockfile = PathBuf::from(self.lock_file_dir.clone());
                 lockfile.push(LOCK_FILE);
-                is_file_locked(lockfile.to_string_lossy().to_string())
+                is_file_locked(lockfile.to_string_lossy().to_string())?
             };
             if count_running == 0 || (self.scan_type() == ScannerType::Openvas && !filelocked) {
                 return Ok(self.need_to_allow().await);

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -486,17 +486,19 @@ where
         let send_allow = async |msgs: Vec<orchestrator::Allow>| {
             for msg in msgs {
                 tracing::debug!(feed_type=?msg, "Sending feed sync allow.");
-                if let Err(error) = feed.approve(msg).await {
-                    tracing::warn!(%error, "Unable to send allow message to orchestrator");
-                }
+                feed.approve(msg).await?;
             }
+            Ok::<(), orchestrator::CommunicationIssues>(())
         };
         loop {
             tokio::select! {
                 Some(msg) = feed.receive_state_changes() => {
                     match scheduler.on_feed_action(&msg).await {
                         Ok(Some(msg)) => {
-                            send_allow(msg).await;
+                            if let Err(error) = send_allow(msg).await {
+                                tracing::warn!(%error, "Unable to send allow message to orchestrator");
+                                break;
+                            }
                         }
                         Ok(None) => {},
                         Err(error) =>  tracing::warn!(?msg, %error, "Unable to react on feed message"),
@@ -516,7 +518,10 @@ where
                     match scheduler.on_schedule().await {
                         Err(error) => tracing::warn!(%error, "Unable to schedule"),
                         Ok(msgs) => {
-                                send_allow(msgs).await;
+                            if let Err(error) = send_allow(msgs).await {
+                                tracing::warn!(%error, "Unable to send allow message to orchestrator");
+                                break;
+                            }
                         }
 
                     }

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -591,13 +591,7 @@ where
         scanner: Arc::new(scanner),
         feed_sync_in_progress: Arc::new(RwLock::new(IsInProgress::default())),
         scan_state: change_scan_status,
-        lock_file_dir: config
-            .feed
-            .lock_file_dir
-            .clone()
-            .unwrap_or(PathBuf::from("/var/lib/openvas"))
-            .to_string_lossy()
-            .to_string(),
+        lock_file_dir: config.feed.lock_file_dir().to_string_lossy().to_string(),
     };
 
     run_scheduler(config.scheduler.check_interval, scheduler, feed).await

--- a/rust/src/openvasd/vts/orchestrator.rs
+++ b/rust/src/openvasd/vts/orchestrator.rs
@@ -140,6 +140,8 @@ pub enum WorkerError {
     Serialization(#[from] serde_json::Error),
     #[error("Unable to send message. Receiver dropped.")]
     Send,
+    #[error("Unable to receive message. Sender dropped.")]
+    Receive,
 }
 
 pub trait Worker {
@@ -320,7 +322,7 @@ where
                         )
                     }
                 },
-                None => tracing::warn!("Sender dropped."),
+                None => return Err(WorkerError::Receive),
             }
 
             match (


### PR DESCRIPTION
This fixes a regression in which we assume that the feed update lock file is available at `/var/lib/openvas/plugins/feed-update.lock`, but this is a very unlikely default when the feed path is set to something other than `/var/lib/openvas/plugins`.

This 
1. Fixes the above default to default to `$FEED_PATH/feed-update.lock`
2. Fixes millions of sends on a closed channel polluting the logfile, obscuring the real issue
3. Gracefully handles a missing lockfile by returning an error instead of panicking


Jira:
SC-1608
SC-1642