### PR TITLE
Fix: Convert non UTF-8 lossily

### DIFF
--- a/rust/src/nasl/syntax/loader.rs
+++ b/rust/src/nasl/syntax/loader.rs
@@ -64,7 +64,17 @@ where
 {
     match fs::read_to_string(path) {
         Ok(x) => Ok(x),
-        Err(_) => read_non_utf8_path(path),
+        Err(err) => {
+            // `InvalidData` means the file could be read but is not valid UTF-8
+            // (some VTs are still stored as latin-1).
+            if err.kind() == io::ErrorKind::InvalidData {
+                tracing::warn!(
+                    file = %path.as_ref().display(),
+                    "File is not valid UTF-8; falling back to latin-1 decoding."
+                );
+            }
+            read_non_utf8_path(path)
+        }
     }
 }
 
@@ -248,5 +258,54 @@ where
 impl Clone for Box<dyn NaslLoader> {
     fn clone(&self) -> Box<dyn NaslLoader> {
         (*self).clone_box()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn reads_utf8_file_as_is() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all("script_name(\"Hütte\");".as_bytes())
+            .unwrap();
+
+        let content = read_utf8_or_non_utf8_path(file.path()).unwrap();
+
+        assert_eq!(content, "script_name(\"Hütte\");");
+    }
+
+    #[test]
+    fn reads_latin1_file_by_falling_back() {
+        // 0xE9 is 'é' in latin-1 (ISO-8859-1) but not a valid UTF-8 byte on its
+        // own, so `fs::read_to_string` fails and the latin-1 fallback is used.
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&[b'c', b'a', b'f', 0xE9]).unwrap();
+
+        let content = read_utf8_or_non_utf8_path(file.path()).unwrap();
+
+        // Every byte is mapped to its code point, so 0xE9 becomes 'é' and the
+        // resulting string is valid UTF-8.
+        assert_eq!(content, "café");
+    }
+
+    #[test]
+    fn read_non_utf8_path_maps_every_byte_to_a_char() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&[0x41, 0xE9, 0xFF]).unwrap();
+
+        let content = read_non_utf8_path(file.path()).unwrap();
+
+        assert_eq!(content, "A\u{00E9}\u{00FF}");
+    }
+
+    #[test]
+    fn read_utf8_or_non_utf8_path_reports_missing_file() {
+        let result = read_utf8_or_non_utf8_path("does/not/exist.nasl");
+
+        assert!(result.is_err());
     }
 }

--- a/rust/src/storage/redis/connector.rs
+++ b/rust/src/storage/redis/connector.rs
@@ -79,20 +79,25 @@ impl Debug for RedisCtx {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-struct RedisValueHandler {
-    v: String,
-}
-
-impl FromRedisValue for RedisValueHandler {
-    fn from_redis_value(v: Value) -> Result<RedisValueHandler, ParsingError> {
-        match &v {
-            Value::Nil => Ok(RedisValueHandler { v: String::new() }),
-            _ => {
-                let new_var: String = from_redis_value(v).unwrap_or_default();
-                Ok(RedisValueHandler { v: new_var })
+/// Converts a redis [`Value`] into a `String`.
+///
+/// Some VTs are still stored using latin-1 (ISO-8859-1) instead of UTF-8. To
+/// avoid aborting a whole read when a single value contains invalid UTF-8, such
+/// values are converted lossily.
+fn redis_value_to_string(key: &str, value: Value) -> String {
+    match value {
+        Value::Nil => String::new(),
+        Value::BulkString(bytes) => match String::from_utf8(bytes) {
+            Ok(string) => string,
+            Err(err) => {
+                tracing::warn!(
+                    redis_key = key,
+                    "Non UTF-8 value stored in redis; converting lossily."
+                );
+                String::from_utf8_lossy(&err.into_bytes()).into_owned()
             }
-        }
+        },
+        other => from_redis_value(other).unwrap_or_default(),
     }
 }
 
@@ -207,26 +212,29 @@ impl RedisWrapper for RedisCtx {
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
     fn lindex(&mut self, key: &str, index: isize) -> RedisStorageResult<String> {
-        let ret: RedisValueHandler = redis::Commands::lindex(
+        let value: Value = redis::Commands::lindex(
             self.kb.as_mut().expect("Valid redis connection"),
             key,
             index,
         )
         .map_err(DbError::from)?;
-        Ok(ret.v)
+        Ok(redis_value_to_string(key, value))
     }
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
     fn lrange(&mut self, key: &str, start: isize, end: isize) -> RedisStorageResult<Vec<String>> {
-        let ret = redis::Commands::lrange(
+        let values: Vec<Value> = redis::Commands::lrange(
             self.kb.as_mut().expect("Valid redis connection"),
             key,
             start,
             end,
         )
         .map_err(DbError::from)?;
-        Ok(ret)
+        Ok(values
+            .into_iter()
+            .map(|value| redis_value_to_string(key, value))
+            .collect())
     }
 
     ///Wrapper function to avoid accessing kb member directly.
@@ -812,5 +820,26 @@ mod tests {
         let vt = redis.redis_get_vt("1.3.6.1.4.3").unwrap().unwrap();
         assert_eq!(vt.name, "Notus Advisory");
         assert_eq!(vt.family, "Notus");
+    }
+
+    #[test]
+    fn redis_value_to_string_reads_valid_utf8() {
+        let value = Value::BulkString("Hütte".as_bytes().to_vec());
+
+        assert_eq!(redis_value_to_string("nvt:1.2.3", value), "Hütte");
+    }
+
+    #[test]
+    fn redis_value_to_string_nil_is_empty() {
+        assert_eq!(redis_value_to_string("nvt:1.2.3", Value::Nil), "");
+    }
+
+    #[test]
+    fn redis_value_to_string_converts_invalid_utf8_lossily() {
+        // 0xE9 is 'é' in latin-1 but an invalid UTF-8 byte on its own. Instead
+        // of aborting the whole read, the value is converted lossily.
+        let value = Value::BulkString(vec![b'a', b'b', 0xE9]);
+
+        assert_eq!(redis_value_to_string("nvt:1.2.3", value), "ab\u{FFFD}");
     }
 }


### PR DESCRIPTION
Instead of failing, the non UTF-8 character within redis is now converted lossily. Additionally a value written into redis, that is non UTF-8, as well as reading a non UTF-8 character a log message is hinting to the file (or OID) that might contain non UTF-8 characters.

SC-1606