### PR TITLE
Fix: OpenAPI spec and scanner framework status codes

### DIFF
--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -1,8 +1,7 @@
 openapi: "3.1.1"
 info:
   title: "Scanner"
-  description: "
-    # Authentication
+  description: " # Authentication
 
     The API supports two kinds of authentication methods:
 
@@ -11,14 +10,15 @@ info:
     - Certificates
 
 
-    The authentication modes are set within a configuration file or via the argument list, when starting the server.
+    The authentication modes are set within a configuration file or via the argument list, when
+    starting the server.
 
     The authentication is required for each request except for a HEAD request.
 
     ## API Key
 
-    An API key is a token that the client provides when doing API requests and are used to authorize access.
-    The `X-API-KEY` must be in the header.
+    An API key is a token that the client provides when doing API requests and are used to authorize
+    access. The `X-API-KEY` must be in the header.
 
 
     <!--More details about this method follows with its implementation.-->
@@ -26,39 +26,39 @@ info:
 
     ## Certificates
 
-    This option uses [X.509](https://en.wikipedia.org/wiki/X.509), based on CA to verify derived certificates to allow access.
+    This option uses [X.509](https://en.wikipedia.org/wiki/X.509), based on CA to verify derived
+    certificates to allow access.
 
 
-    <!--More details about this method follows with its implementation.-->
-    "
+    <!--More details about this method follows with its implementation.--> "
   contact:
     name: "Greenbone AG"
     url: "https://www.greenbone.net/"
   license:
     name: "GPL-2.0-or-later"
-    identifier: "GPL-2.0-or-later"
     url: "https://spdx.org/licenses/GPL-2.0-or-later.html"
   version: "0.1"
 servers:
-  - url: /
+- url: /
 tags:
-  - name: general
-    description: General requests
-  - name: health
-    description: Health checks
-  - name: scan
-    description: Scan resource
-  - name: feed
-    description: Feed related
-  - name: notus
-    description: Notus vulnerability scanner
+- name: general
+  description: General requests
+- name: health
+  description: Health checks
+- name: scan
+  description: Scan resource
+- name: feed
+  description: Feed related
+- name: notus
+  description: Notus vulnerability scanner
 paths:
   /health:
     head:
-      description: "Get the response header. It contains the API version, feed version and available authentication methods."
+      description: "Get the response header. It contains the API version, feed version and available
+        authentication methods."
       operationId: "head_health"
       tags:
-        - "general"
+      - "general"
       responses:
         "200":
           headers:
@@ -74,17 +74,19 @@ paths:
       description: "Get application's health information"
       operationId: "get_health_alive"
       tags:
-        - "health"
+      - "health"
       responses:
         "200":
           description: "Ok"
+        "503":
+          description: "Service Unavailable"
 
   /health/ready:
     get:
       description: "Get application's health information"
       operationId: "get_health_ready"
       tags:
-        - "health"
+      - "health"
       responses:
         "200":
           description: "Ok"
@@ -95,17 +97,20 @@ paths:
       description: "Get application's health information"
       operationId: "get_health_started"
       tags:
-        - "health"
+      - "health"
       responses:
         "200":
           description: "Ok"
+        "503":
+          description: "Service Unavailable"
 
   /notus:
     head:
-      description: "Get the response header. It contains the API version, feed version and available authentication methods."
+      description: "Get the response header. It contains the API version, feed version and available
+        authentication methods."
       operationId: "head_notus"
       tags:
-        - "general"
+      - "general"
       responses:
         "200":
           headers:
@@ -117,11 +122,11 @@ paths:
               $ref: "#/components/headers/Authentication"
           description: "Authenticated and authorized"
     get:
-      description: "Get a list of all available OS products available for the
-        [POST /notus/{os}](#/notus/notus_run) endpoint."
+      description: "Get a list of all available OS products available for the [POST
+        /notus/{os}](#/notus/notus_run) endpoint."
       operationId: "get_notus"
       tags:
-        - "notus"
+      - "notus"
       responses:
         "200":
           description: "Ok"
@@ -137,17 +142,16 @@ paths:
 
   /notus/{os}:
     post:
-      description:
-        "Runs Notus with the given package list for the given OS. The OS is contained
-        within the path. To get a list with all supported OS products, use [GET /notus](#/notus/get_notus). The request
-        body contains the list of packages to check. The response contains the list of vulnerable
-        packages with their fixed versions. The scan is performed synchronously, so the response is
-        only returned when the scan is finished."
+      description: "Runs Notus with the given package list for the given OS. The OS is contained within
+        the path. To get a list with all supported OS products, use [GET /notus](#/notus/get_notus).
+        The request body contains the list of packages to check. The response contains the list of
+        vulnerable packages with their fixed versions. The scan is performed synchronously, so the
+        response is only returned when the scan is finished."
       operationId: "notus_run"
       tags:
-        - "notus"
+      - "notus"
       parameters:
-        - $ref: "#/components/parameters/NotusOS"
+      - $ref: "#/components/parameters/NotusOS"
       requestBody:
         description: "Run Notus."
         content:
@@ -170,22 +174,21 @@ paths:
                 get results:
                   $ref: "./components/examples/notus.yml#/notus_results"
         "400":
-          description: "Bad request body"
+          description: "The provided package list could not be parsed."
         "404":
-          description: "Scan not found"
-        "406":
-          description: "Unable to perform action because of the current scan status"
-        "501":
-          description: "Action not supported"
+          description: "OS not supported"
+        "500":
+          description: "Unable to load Notus product"
 
   /scans:
     head:
-      description: "Get the response header. It contains the API version, feed version and available authentication methods."
+      description: "Get the response header. It contains the API version, feed version and available
+        authentication methods."
       operationId: "get_info_auth"
       tags:
-        - "general"
+      - "general"
       responses:
-        "204":
+        "200":
           headers:
             api-version:
               $ref: "#/components/headers/ApiVersion"
@@ -195,27 +198,21 @@ paths:
               $ref: "#/components/headers/Authentication"
           description: "Authenticated and authorized"
         "401":
-          headers:
-            api-version:
-              $ref: "#/components/headers/ApiVersion"
-            feed-version:
-              $ref: "#/components/headers/FeedVersion"
-            authentication:
-              $ref: "#/components/headers/Authentication"
-          description: "Unauthorized. Required or invalid client certificates"
+          $ref: "#/components/responses/Unauthorized"
     post:
-      description:
-        "This endpoint is the entrypoint to run a scan. The request body contains a scan
+      description: "This endpoint is the entrypoint to run a scan. The request body contains a scan
         configuration. The scan configuration includes all necessary information to run a scan. If a
         scan was successfully created, the response contains the scan ID, which then can be used to
-        start it with [POST /scans/{id}](#/scan/scan_action). For more information about the scan configuration,
-        see the schema of the request body. For additional information about the scan preferences,
-        see [GET /scans/preferences](#/scan/get_preferences). To get information about the scan after it was created, use
-        [GET /scans/{id}](#/scan/get_scan). To get the results of the scan, use [GET /scans/{id}/results](#/scan/get_results). To get the status
-        of the scan, use [GET /scans/{id}/status](#/scan/get_scan_status). To delete the scan, use [DELETE /scans/{id}](#/scan/delete_scan)."
+        start it with [POST /scans/{id}](#/scan/scan_action). For more information about the scan
+        configuration, see the schema of the request body. For additional information about the scan
+        preferences, see [GET /scans/preferences](#/scan/get_preferences). To get information about
+        the scan after it was created, use [GET /scans/{id}](#/scan/get_scan). To get the results of
+        the scan, use [GET /scans/{id}/results](#/scan/get_results). To get the status of the scan,
+        use [GET /scans/{id}/status](#/scan/get_scan_status). To delete the scan, use [DELETE
+        /scans/{id}](#/scan/delete_scan)."
       operationId: "create_scan"
       tags:
-        - "scan"
+      - "scan"
       requestBody:
         description: "Scan to add"
         content:
@@ -267,19 +264,21 @@ paths:
               description: "Delete the scan."
         "400":
           description: "Bad Request body"
-        "403":
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
           description: "ScanID already in use"
 
   /scans/preferences:
     get:
-      description:
-        "This endpoint provides a list of all available scan preferences, which can be
-        set within the scan configuration via the [POST /scans](#/scan/create_scan) endpoint. The response contains the
-        ID, name, type, description and default value of each preference. For more information about
-        the scan configuration, see the schema of the request body of the [POST /scans](#/scan/create_scan) endpoint."
+      description: "This endpoint provides a list of all available scan preferences, which can be set
+        within the scan configuration via the [POST /scans](#/scan/create_scan) endpoint. The
+        response contains the ID, name, type, description and default value of each preference. For
+        more information about the scan configuration, see the schema of the request body of the
+        [POST /scans](#/scan/create_scan) endpoint."
       operationId: "get_preferences"
       tags:
-        - "scan"
+      - "scan"
       responses:
         "200":
           description: "Get Preferences"
@@ -290,17 +289,19 @@ paths:
               examples:
                 preferences:
                   $ref: "./components/examples/scans.yml#/preferences"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
 
   /scans/{id}:
     get:
-      description:
-        "This endpoint provides information about the scan configuration provided with [POST /scans](#/scan/create_scan). It does not
-        contain any information about the status or results of the scan."
+      description: "This endpoint provides information about the scan configuration provided with [POST
+        /scans](#/scan/create_scan). It does not contain any information about the status or results
+        of the scan."
       operationId: "get_scan"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
+      - $ref: "#/components/parameters/ScanID"
       responses:
         "200":
           description: "Get Scan"
@@ -338,19 +339,20 @@ paths:
                 id: "$response.body#/"
               description: "Delete the scan."
 
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Scan not found"
     post:
-      description:
-        "This endpoint is used to perform an action on the scan. The scan can be either
-        started or stopped. Notice, that only a stored scan can be started and only a running scan
-        can be stopped. To create a scan, use [POST /scans](#/scan/create_scan). After it is created,
-        the scan is in the status stored."
+      description: "This endpoint is used to perform an action on the scan. The scan can be either started
+        or stopped. Notice, that only a stored scan can be started and only a running scan can be
+        stopped. To create a scan, use [POST /scans](#/scan/create_scan). After it is created, the
+        scan is in the status stored."
       operationId: "scan_action"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
+      - $ref: "#/components/parameters/ScanID"
       requestBody:
         description: "Action to perform."
         content:
@@ -366,53 +368,56 @@ paths:
         "204":
           description: "Action performed"
         "400":
-          description: "Bad request body"
+          description: "Either no valid JSON body or no valid action was provided."
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Scan not found"
-        "406":
+        "409":
           description: "Unable to perform action because of the current scan status"
-        "501":
-          description: "Action not supported"
+        "500":
+          description: "Internal Server Error"
     delete:
-      description:
-        "Delete a scan, that is not running. Running scans must be either stored, stopped or finished
-        before they can be deleted. To get the status of the scan, use [GET /scans/{id}/status](#/scan/get_scan_status)."
+      description: "Delete a scan, that is not running. Running scans must be either stored, stopped or
+        finished before they can be deleted. To get the status of the scan, use [GET
+        /scans/{id}/status](#/scan/get_scan_status)."
       operationId: "delete_scan"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
+      - $ref: "#/components/parameters/ScanID"
       responses:
         "204":
           description: "Scan deleted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Scan not found"
-        "406":
+        "409":
           description: "A running scan cannot be deleted"
 
   /scans/{id}/results:
     get:
-      description:
-        "While a scan is running it will generate results. This endpoint is used to get
-        a list of all results that were generated by the scan. If you only need specific results,
-        the query `range` can be used. This will then only return the results within the given
-        range. This is helpful to only get new results. The IDs of the results are incremental.
-        Alternative to only receive single results the endpoint [GET /scans/{id}/results/{rid}](#/scan/get_result) can be
-        used."
+      description: "While a scan is running it will generate results. This endpoint is used to get a list
+        of all results that were generated by the scan. If you only need specific results, the query
+        `range` can be used. This will then only return the results within the given range. This is
+        helpful to only get new results. The IDs of the results are incremental. Alternative to only
+        receive single results the endpoint [GET /scans/{id}/results/{rid}](#/scan/get_result) can
+        be used."
       operationId: "get_results"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
-        - name: range
-          in: query
-          description: "Get a range of results (e.g. `0-12`).
-            In case only a single number is given (e.g. `13`), all available results from this index on are returned.
-            If the scan is still running, new results will occur and must be collected with new request starting from the last processed index.
-            If no results are in the given range, an empty array is returned."
-          required: false
-          schema:
-            type: "string"
+      - $ref: "#/components/parameters/ScanID"
+      - name: range
+        in: query
+        description: "Get a range of results (e.g. `0-12`). In case only a single number is given (e.g.
+          `13`), all available results from this index on are returned. If the scan is still
+          running, new results will occur and must be collected with new request starting from the
+          last processed index. If no results are in the given range, an empty array is returned."
+        required: false
+        schema:
+          type: "string"
       responses:
         "200":
           description: "A list of results"
@@ -438,22 +443,22 @@ paths:
               description: "Get the scan that produced these results."
         "400":
           description: "Bad range format"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Scan not found"
-        "406":
-          description: "A scan, that has not started, does not contain results"
 
   /scans/{id}/results/{rid}:
     get:
-      description:
-        "Get a single result by its ID. To retrieve multiple results, use
-        [GET /scans/{id}/results](#/scan/get_results) with the range query parameter or without it to get all results."
+      description: "Get a single result by its ID. To retrieve multiple results, use [GET
+        /scans/{id}/results](#/scan/get_results) with the range query parameter or without it to get
+        all results."
       operationId: "get_result"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
-        - $ref: "#/components/parameters/ResultID"
+      - $ref: "#/components/parameters/ScanID"
+      - $ref: "#/components/parameters/ResultID"
       responses:
         "200":
           description: "The requested result"
@@ -468,22 +473,23 @@ paths:
                   $ref: "./components/examples/results.yml#/scan_result"
                 host detail:
                   $ref: "./components/examples/results.yml#/host_detail"
+        "400":
+          description: "The provided result ID is not a valid, positive number."
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Result or Scan not found"
-        "406":
-          description: "A scan that has not started, cannot contain results"
 
   /scans/{id}/status:
     get:
-      description:
-        "This endpoint provides useful information about a scan. This includes the
-        current scan status (running, finished, etc.), the start and end time of the scan, as
-        well as information about the progress of the scan."
+      description: "This endpoint provides useful information about a scan. This includes the current scan
+        status (running, finished, etc.), the start and end time of the scan, as well as information
+        about the progress of the scan."
       operationId: "get_scan_status"
       tags:
-        - "scan"
+      - "scan"
       parameters:
-        - $ref: "#/components/parameters/ScanID"
+      - $ref: "#/components/parameters/ScanID"
       responses:
         "200":
           description: "The requested status"
@@ -523,15 +529,18 @@ paths:
               parameters:
                 id: "$request.path.id"
               description: "Delete this scan. Available when the scan is not running."
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: "Scan not found"
 
   /vts:
     head:
-      description: "Get the response header. It contains the API version, feed version and available authentication methods."
+      description: "Get the response header. It contains the API version, feed version and available
+        authentication methods."
       operationId: "head_vts"
       tags:
-        - "general"
+      - "general"
       responses:
         "200":
           headers:
@@ -543,12 +552,11 @@ paths:
               $ref: "#/components/headers/Authentication"
           description: "Authenticated and authorized"
     get:
-      description:
-        "Get a list of all available vulnerability tests (VTs) to the scanner. Note, that not the
-        tests itself, but a list of identifiers (OIDs) of the tests is returned."
+      description: "Get a list of all available vulnerability tests (VTs) to the scanner. Note, that not
+        the tests itself, but a list of identifiers (OIDs) of the tests is returned."
       operationId: "get_vts"
       tags:
-        - "feed"
+      - "feed"
       responses:
         "200":
           description: "A list of available VTs."
@@ -572,6 +580,17 @@ components:
       $ref: "./components/headers.yml#/FeedVersion"
     Authentication:
       $ref: "./components/headers.yml#/Authentication"
+
+  responses:
+    Unauthorized:
+      description: "Unauthorized. Required or invalid client certificates"
+      headers:
+        api-version:
+          $ref: "#/components/headers/ApiVersion"
+        feed-version:
+          $ref: "#/components/headers/FeedVersion"
+        authentication:
+          $ref: "#/components/headers/Authentication"
 
   parameters:
     ScanID:

--- a/rust/crates/greenbone-scanner-framework/src/delete_scans_id.rs
+++ b/rust/crates/greenbone-scanner-framework/src/delete_scans_id.rs
@@ -192,7 +192,7 @@ mod tests {
             .body(Empty::<Bytes>::new())
             .unwrap();
         let resp = entry_point.call(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/rust/crates/greenbone-scanner-framework/src/get_scans_id_results.rs
+++ b/rust/crates/greenbone-scanner-framework/src/get_scans_id_results.rs
@@ -59,35 +59,18 @@ where
             .expect("expect ID, this is a toolkit error");
         let query = uri.query().map(|x| x.to_owned());
         Box::pin(async move {
-            let (from, to) = match query {
-                Some(x) => x
-                    .split('&')
-                    .filter_map(|pair| {
-                        let mut kv = pair.splitn(2, '=');
-                        match kv.next() {
-                            Some("range") => kv.next(),
-                            Some(_) | None => None,
-                        }
-                    })
-                    .map(|range| {
-                        let mut rs = range.splitn(2, '-');
-                        (rs.next(), rs.next())
-                    })
-                    .map(|(from, to)| {
-                        let from = match from {
-                            Some(x) => x.parse().ok(),
-                            None => None,
-                        };
-
-                        let to = match to {
-                            Some(x) => x.parse().ok(),
-                            None => None,
-                        };
-                        (from, to)
-                    })
-                    .next()
-                    .unwrap_or_default(),
-                None => (None, None),
+            let (from, to) = match parse_results_range(query.as_deref()) {
+                Ok(range) => range,
+                Err(message) => {
+                    return BodyKind::json_content(
+                        StatusCode::BAD_REQUEST,
+                        &entry::response::BadRequest {
+                            line: 0,
+                            column: 0,
+                            message,
+                        },
+                    );
+                }
             };
             enforce_client_id_and_scan_id(&client_id, id, gsp.as_ref(), async |id| {
                 let input = gsp.get_scans_id_results(id, from, to);
@@ -119,6 +102,45 @@ where
 }
 
 pub type GetScansIDResultsError = GetScansError;
+
+/// Parses the optional `range` query parameter of the results endpoint.
+///
+/// Returns `Ok((None, None))` when no `range` parameter is present. A present
+/// `range` must be either a single number (`N`) or a `from-to` range of
+/// valid, non-negative integers. Any other value is reported as an error.
+fn parse_results_range(query: Option<&str>) -> Result<(Option<usize>, Option<usize>), String> {
+    let range = query.and_then(|q| {
+        q.split('&')
+            .filter_map(|pair| {
+                let mut kv = pair.splitn(2, '=');
+                match kv.next() {
+                    Some("range") => kv.next(),
+                    _ => None,
+                }
+            })
+            .next()
+    });
+
+    let range = match range {
+        Some(range) => range,
+        None => return Ok((None, None)),
+    };
+
+    let invalid =
+        || format!("invalid range '{range}': expected a number or a 'from-to' range of numbers");
+
+    let mut parts = range.splitn(2, '-');
+    let from = parts
+        .next()
+        .and_then(|x| x.parse::<usize>().ok())
+        .ok_or_else(invalid)?;
+    let to = match parts.next() {
+        Some(x) => Some(x.parse::<usize>().map_err(|_| invalid())?),
+        None => None,
+    };
+
+    Ok((Some(from), to))
+}
 
 #[cfg(test)]
 mod tests {
@@ -270,22 +292,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ignores_invalid_query() {
+    async fn invalid_range_returns_bad_request() {
         let entry_point = test_utilities::entry_point(
             Authentication::MTLS,
             create_single_handler!(GetScansIdResultsHandler::from(Test {})),
             Some(ClientHash::from("ok")),
         );
 
-        let req = Request::builder()
-            .uri("/scans/id/results?range=zero-ten&from=1&to=10")
-            .method(Method::GET)
-            .body(Empty::<Bytes>::new())
-            .unwrap();
-        let resp = entry_point.call(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-        let resp: Vec<models::Result> = serde_json::from_slice(bytes.as_ref()).unwrap();
-        assert_eq!(resp.len(), 0);
+        for uri in [
+            "/scans/id/results?range=zero-ten&from=1&to=10",
+            "/scans/id/results?range=1-2-3",
+            "/scans/id/results?range=1-ten",
+            "/scans/id/results?range=",
+        ] {
+            let req = Request::builder()
+                .uri(uri)
+                .method(Method::GET)
+                .body(Empty::<Bytes>::new())
+                .unwrap();
+            let resp = entry_point.call(req).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "expected bad request for {uri}"
+            );
+        }
     }
 }

--- a/rust/crates/greenbone-scanner-framework/src/post_scans.rs
+++ b/rust/crates/greenbone-scanner-framework/src/post_scans.rs
@@ -131,7 +131,7 @@ impl From<PostScansError> for BodyKind {
         match val {
             PostScansError::DuplicateId(id) => {
                 let br = format!("ID ({id}) is already in use.");
-                BodyKind::json_content(StatusCode::NOT_ACCEPTABLE, &br)
+                BodyKind::json_content(StatusCode::CONFLICT, &br)
             }
             PostScansError::External(e) => internal_server_error!(e),
         }
@@ -220,7 +220,7 @@ mod tests {
             .body(json_bytes(&scans))
             .unwrap();
         let resp = entry_point.call(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/rust/crates/greenbone-scanner-framework/src/post_scans_id.rs
+++ b/rust/crates/greenbone-scanner-framework/src/post_scans_id.rs
@@ -126,7 +126,7 @@ impl From<PostScansIDError> for BodyKind {
     fn from(e: PostScansIDError) -> Self {
         match e {
             PostScansIDError::External(e) => internal_server_error!(e),
-            PostScansIDError::Running => BodyKind::no_content(StatusCode::NOT_ACCEPTABLE),
+            PostScansIDError::Running => BodyKind::no_content(StatusCode::CONFLICT),
         }
     }
 }
@@ -240,7 +240,7 @@ mod tests {
             .body(json_bytes(&scans))
             .unwrap();
         let resp = entry_point.call(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/rust/src/openvasd/notus/mod.rs
+++ b/rust/src/openvasd/notus/mod.rs
@@ -113,9 +113,12 @@ impl RequestHandler for PostOSIcnomingRequest {
             {
                 Ok(x) => BodyKind::json_content(StatusCode::OK, &x),
                 Err(NotusError::UnknownProduct(_)) => BodyKind::no_content(StatusCode::NOT_FOUND),
+                Err(NotusError::PackageParseError(e)) => {
+                    BodyKind::json_content(StatusCode::BAD_REQUEST, &e)
+                }
                 Err(error) => {
                     tracing::warn!(%error, "Unable to get available products.");
-                    BodyKind::no_content(StatusCode::INTERNAL_SERVER_ERROR)
+                    BodyKind::json_content(StatusCode::INTERNAL_SERVER_ERROR, &error.to_string())
                 }
             }
         })


### PR DESCRIPTION
Correct wrong status codes and sync the OpenAPI spec with the scanner framework:

- return 409 Conflict (was 406) for duplicate scan IDs, actions on a scan in the wrong state, and deleting a running scan
- reject malformed `range` query on GET /scans/{id}/results with 400
- notus: return 400 on package parse errors and a JSON body on 500
- document 401 (reusable Unauthorized response) on all authenticated /scans endpoints
- document 503 on /health/alive and /health/started
- drop non-idiomatic responses from the spec

Jira: SC-1592