### PR TITLE
Fix: reported issues in openvas scanner

### DIFF
--- a/doc/manual/nasl/built-in-functions/string-functions/insstr.md
+++ b/doc/manual/nasl/built-in-functions/string-functions/insstr.md
@@ -57,5 +57,5 @@ a = insstr('aaaa', 'b', 2, 1);
 # Prints insstr: warning! 1st index 2 greater than 2nd index 1
 
 display(a);
-# Displays a
+# Displays aabaa
 ```

--- a/nasl/capture_packet.c
+++ b/nasl/capture_packet.c
@@ -198,6 +198,9 @@ capture_next_packet (int bpf, int timeout, int *sz)
       struct ip *ip;
 
       ip = (struct ip *) (packet + dl_len);
+      if (len <= dl_len)
+        return NULL;
+
 #ifdef BSD_BYTE_ORDERING
       ip->ip_len = ntohs (ip->ip_len);
       ip->ip_off = ntohs (ip->ip_off);
@@ -313,6 +316,8 @@ capture_next_v6_packet (int bpf, int timeout, int *sz)
     {
       struct ip6_hdr *ip6;
       ip6 = (struct ip6_hdr *) (packet + dl_len);
+      if (len <= dl_len)
+        return NULL;
 #ifdef BSD_BYTE_ORDERING
       ip6->ip6_plen = ntohs (ip6->ip6_plen);
 #endif

--- a/nasl/nasl_misc_funcs.c
+++ b/nasl/nasl_misc_funcs.c
@@ -660,8 +660,7 @@ nasl_gettimeofday (lex_ctxt *lexic)
   sprintf (str, "%u.%06u", (unsigned int) t.tv_sec, (unsigned int) t.tv_usec);
   retc = alloc_typed_cell (CONST_DATA);
   retc->size = strlen (str);
-  retc->x.str_val = g_malloc0 (retc->size);
-  strcpy (retc->x.str_val, str);
+  retc->x.str_val = g_strdup (str);
   return retc;
 }
 

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -1623,6 +1623,7 @@ get_udp_element (lex_ctxt *lexic)
   unsigned int ipsz;
   struct udphdr *udphdr;
   int ret;
+  size_t ip_hdr_offset;
 
   udp = get_str_var_by_name (lexic, "udp");
   ipsz = get_var_size_by_name (lexic, "udp");
@@ -1635,11 +1636,12 @@ get_udp_element (lex_ctxt *lexic)
       return NULL;
     }
   ip = (struct ip *) udp;
+  ip_hdr_offset = ip->ip_hl * 4;
 
-  if (ip->ip_hl * 4 + sizeof (struct udphdr) > ipsz)
+  if (ip_hdr_offset + sizeof (struct udphdr) > ipsz)
     return NULL;
 
-  udphdr = (struct udphdr *) (udp + ip->ip_hl * 4);
+  udphdr = (struct udphdr *) (udp + ip_hdr_offset);
   if (!strcmp (element, "uh_sport"))
     ret = ntohs (udphdr->uh_sport);
   else if (!strcmp (element, "uh_dport"))
@@ -1650,17 +1652,25 @@ get_udp_element (lex_ctxt *lexic)
     ret = ntohs (udphdr->uh_sum);
   else if (!strcmp (element, "data"))
     {
-      int sz;
+      size_t sz;
+      size_t udp_len = (size_t) ntohs (udphdr->uh_ulen);
+      if (udp_len < sizeof (struct udphdr))
+        {
+          nasl_perror (lexic,
+                       "get_udp_element: uh_ulen < 8. Buffer underflow\n");
+          return NULL;
+        }
+
+      sz = udp_len - sizeof (struct udphdr);
+      if (sz > ipsz - ip_hdr_offset - sizeof (struct udphdr))
+        {
+          nasl_perror (lexic, "get_udp_element: over read of data field\n");
+          return NULL;
+        }
       retc = alloc_typed_cell (CONST_DATA);
-      sz = ntohs (udphdr->uh_ulen) - sizeof (struct udphdr);
-
-      if (ntohs (udphdr->uh_ulen) - ip->ip_hl * 4 - sizeof (struct udphdr)
-          > ipsz)
-        sz = ipsz - ip->ip_hl * 4 - sizeof (struct udphdr);
-
       retc->x.str_val = g_malloc0 (sz);
       retc->size = sz;
-      bcopy (udp + ip->ip_hl * 4 + sizeof (struct udphdr), retc->x.str_val, sz);
+      bcopy (udp + ip_hdr_offset + sizeof (struct udphdr), retc->x.str_val, sz);
       return retc;
     }
   else

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -1973,7 +1973,7 @@ get_icmp_element (lex_ctxt *lexic)
           if (retc->size > 0)
             {
               retc->x.str_val = g_malloc0 (retc->size + 1);
-              memcpy (retc->x.str_val, &(p[ip->ip_hl * 4 + 8]), retc->size + 1);
+              memcpy (retc->x.str_val, &(p[ip->ip_hl * 4 + 8]), retc->size);
             }
           else
             {

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -1872,54 +1872,60 @@ forge_icmp_packet (lex_ctxt *lexic)
 
   ip = (struct ip *) get_str_var_by_name (lexic, "ip");
   ip_sz = get_var_size_by_name (lexic, "ip");
-  if (ip != NULL)
+
+  if (ip == NULL)
     {
-      data = get_str_var_by_name (lexic, "data");
-      len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
-
-      t = get_int_var_by_name (lexic, "icmp_type", 0);
-      if (t == 13 || t == 14)
-        len += 3 * sizeof (time_t);
-
-      if (ip->ip_hl * 4 > ip_sz)
-        return NULL;
-
-      pkt = g_malloc0 (sizeof (struct icmp) + ip_sz + len);
-      ip_icmp = (struct ip *) pkt;
-
-      bcopy (ip, ip_icmp, ip_sz);
-      if (UNFIX (ip_icmp->ip_len) <= (ip_icmp->ip_hl * 4))
-        {
-          if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
-            {
-              ip_icmp->ip_len = FIX (ip->ip_hl * 4 + 8 + len);
-              ip_icmp->ip_sum = 0;
-              ip_icmp->ip_sum =
-                np_in_cksum ((u_short *) ip_icmp, ip->ip_hl * 4);
-            }
-        }
-      p = (char *) (pkt + (ip->ip_hl * 4));
-      icmp = (struct icmp *) p;
-
-      icmp->icmp_code = get_int_var_by_name (lexic, "icmp_code", 0);
-      icmp->icmp_type = t;
-      icmp->icmp_seq = htons (get_int_var_by_name (lexic, "icmp_seq", 0));
-      icmp->icmp_id = htons (get_int_var_by_name (lexic, "icmp_id", 0));
-
-      if (data != NULL)
-        bcopy (data, &(p[8]), len);
-
-      if (get_int_var_by_name (lexic, "icmp_cksum", -1) == -1)
-        icmp->icmp_cksum = np_in_cksum ((u_short *) icmp, len + 8);
-      else
-        icmp->icmp_cksum = htons (get_int_var_by_name (lexic, "icmp_cksum", 0));
-
-      retc = alloc_typed_cell (CONST_DATA);
-      retc->x.str_val = (char *) pkt;
-      retc->size = ip_sz + len + 8;
+      nasl_perror (lexic, "forge_icmp_packet: missing 'ip' parameter\n");
+      return NULL;
     }
+
+  data = get_str_var_by_name (lexic, "data");
+  len = data == NULL ? 0 : get_var_size_by_name (lexic, "data");
+
+  t = get_int_var_by_name (lexic, "icmp_type", 0);
+
+  // timestamp icmp types have a fixed lenght payload of 12 bytes
+  if ((t == 13 || t == 14) && (12 != len))
+    {
+      nasl_perror (lexic, "forge_icmp_packet: malformed packet. type 13/14 "
+                          "have a fixed length of 12 bytes\n");
+      return NULL;
+    }
+  if (ip->ip_hl * 4 > ip_sz)
+    return NULL;
+
+  pkt = g_malloc0 (sizeof (struct icmp) + ip_sz + len);
+  ip_icmp = (struct ip *) pkt;
+
+  bcopy (ip, ip_icmp, ip_sz);
+  if (UNFIX (ip_icmp->ip_len) <= (ip_icmp->ip_hl * 4))
+    {
+      if (get_int_var_by_name (lexic, "update_ip_len", 1) != 0)
+        {
+          ip_icmp->ip_len = FIX (ip->ip_hl * 4 + 8 + len);
+          ip_icmp->ip_sum = 0;
+          ip_icmp->ip_sum = np_in_cksum ((u_short *) ip_icmp, ip->ip_hl * 4);
+        }
+    }
+  p = (char *) (pkt + (ip->ip_hl * 4));
+  icmp = (struct icmp *) p;
+
+  icmp->icmp_code = get_int_var_by_name (lexic, "icmp_code", 0);
+  icmp->icmp_type = t;
+  icmp->icmp_seq = htons (get_int_var_by_name (lexic, "icmp_seq", 0));
+  icmp->icmp_id = htons (get_int_var_by_name (lexic, "icmp_id", 0));
+
+  if (data != NULL)
+    bcopy (data, &(p[8]), len);
+
+  if (get_int_var_by_name (lexic, "icmp_cksum", -1) == -1)
+    icmp->icmp_cksum = np_in_cksum ((u_short *) icmp, len + 8);
   else
-    nasl_perror (lexic, "forge_icmp_packet: missing 'ip' parameter\n");
+    icmp->icmp_cksum = htons (get_int_var_by_name (lexic, "icmp_cksum", 0));
+
+  retc = alloc_typed_cell (CONST_DATA);
+  retc->x.str_val = (char *) pkt;
+  retc->size = ip_sz + len + 8;
 
   return retc;
 }

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -1546,6 +1546,7 @@ get_udp_v6_element (lex_ctxt *lexic)
   size_t ipsz;
   struct udphdr *udphdr;
   int ret;
+  size_t ip_hdr_offset = 40; // fixed value for ipv6
 
   udp = get_str_var_by_name (lexic, "udp");
   ipsz = get_var_size_by_name (lexic, "udp");
@@ -1559,10 +1560,10 @@ get_udp_v6_element (lex_ctxt *lexic)
       return NULL;
     }
 
-  if (40 + sizeof (struct udphdr) > ipsz)
+  if (ipsz < ip_hdr_offset + sizeof (struct udphdr))
     return NULL;
 
-  udphdr = (struct udphdr *) (udp + 40);
+  udphdr = (struct udphdr *) (udp + ip_hdr_offset);
   if (!strcmp (element, "uh_sport"))
     ret = ntohs (udphdr->uh_sport);
   else if (!strcmp (element, "uh_dport"))
@@ -1573,16 +1574,25 @@ get_udp_v6_element (lex_ctxt *lexic)
     ret = ntohs (udphdr->uh_sum);
   else if (!strcmp (element, "data"))
     {
-      int sz;
+      size_t sz;
+      size_t udp_len = (size_t) ntohs (udphdr->uh_ulen);
+      if (udp_len < sizeof (struct udphdr))
+        {
+          nasl_perror (lexic,
+                       "get_udp_element: uh_ulen < 8. Buffer underflow\n");
+          return NULL;
+        }
+
+      sz = udp_len - sizeof (struct udphdr);
+      if (sz > ipsz - ip_hdr_offset - sizeof (struct udphdr))
+        {
+          nasl_perror (lexic, "get_udp_element: over read of data field\n");
+          return NULL;
+        }
       retc = alloc_typed_cell (CONST_DATA);
-      sz = ntohs (udphdr->uh_ulen) - sizeof (struct udphdr);
-
-      if (ntohs (udphdr->uh_ulen) - 40 - sizeof (struct udphdr) > ipsz)
-        sz = ipsz - 40 - sizeof (struct udphdr);
-
       retc->x.str_val = g_malloc0 (sz);
       retc->size = sz;
-      bcopy (udp + 40 + sizeof (struct udphdr), retc->x.str_val, sz);
+      bcopy (udp + ip_hdr_offset + sizeof (struct udphdr), retc->x.str_val, sz);
       return retc;
     }
   else

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -2089,7 +2089,7 @@ get_icmp_v6_element (lex_ctxt *lexic)
           if (retc->size > 0)
             {
               retc->x.str_val = g_malloc0 (retc->size + 1);
-              memcpy (retc->x.str_val, &(p[40 + 8]), retc->size + 1);
+              memcpy (retc->x.str_val, &(p[40 + 8]), retc->size);
             }
           else
             {

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -912,26 +912,29 @@ nasl_eregmatch (lex_ctxt *lexic)
       int index = 0;
       char *current_pos;
       current_pos = string;
-      while (1)
+      while (*current_pos)
         {
+          unsigned int offset = 0, i = 0;
+          size_t cur_len;
+          char *current_pos_cp;
+
           if (regexec (&re, current_pos, (size_t) NS, subs, 0) != 0)
             {
-              regfree (&re);
               break;
             }
 
-          unsigned int offset = 0, i = 0;
+          cur_len = strlen (current_pos);
+          current_pos_cp = g_malloc (cur_len + 1);
+
           for (i = 0; i < NS; i++)
             {
-              char current_pos_cp[strlen (current_pos) + 1];
-
               if (subs[i].rm_so == -1)
                 break;
 
               if (i == 0)
                 offset = subs[i].rm_eo;
 
-              strcpy (current_pos_cp, current_pos);
+              memcpy (current_pos_cp, current_pos, cur_len + 1);
               current_pos_cp[subs[i].rm_eo] = 0;
               v.var_type = VAR2_DATA;
               v.v.v_str.s_siz = subs[i].rm_eo - subs[i].rm_so;
@@ -940,6 +943,11 @@ nasl_eregmatch (lex_ctxt *lexic)
               (void) add_var_to_list (a, index, &v);
               index++;
             }
+
+          g_free (current_pos_cp);
+
+          if (offset == 0)
+            offset = 1;
           current_pos += offset;
         }
     }

--- a/nasl/nasl_text_utils.c
+++ b/nasl/nasl_text_utils.c
@@ -1024,7 +1024,7 @@ nasl_insstr (lex_ctxt *lexic)
 
   i1 = get_int_var_by_num (lexic, 2, -1);
   i2 = get_int_var_by_num (lexic, 3, -1);
-  if (i2 > sz1 || i2 == -1)
+  if (i2 >= sz1 || i2 == -1)
     i2 = sz1 - 1;
 
   if (s1 == NULL || s2 == NULL || i1 < 0 || i2 < 0)
@@ -1045,9 +1045,10 @@ nasl_insstr (lex_ctxt *lexic)
   if (i1 > i2)
     {
       nasl_perror (lexic,
-                   " insstr: warning! 1st index %d greater than 2nd index %d\n",
+                   " insstr: warning! 1st index %ld greater than 2nd index "
+                   "%ld\n",
                    i1, i2);
-      sz3 = sz2;
+      sz3 = i1 + sz2 + (i2 < sz1 - 1 ? sz1 - 1 - i2 : 0);
     }
   else
     sz3 = sz1 + i1 - i2 - 1 + sz2;


### PR DESCRIPTION
FIX: 
- Fix: nasl_gettimeofday() one-byte heap overflow
- Fix: Heap overflow in insstr. Allocated size doesn't match with the copied bytes when i1>i2
- Fix: prevent buffer underflow and buffer over read in get_udp_element() and get_udp_v6_element()
- Fix: get_icmp_element() and get_icmp_v6_element(). memcpy(..., size +1) reads one byte past the ICMP payload.
- Fix: capture_next_packet(). Add guard before dereferencing/byte-swapping the IP header;  can underflow.
- Fix: forge_icmp_packet(). over-reads the source  buffer (info leak into the forged packet) when the icmp type is 13 or 14. In this cases the payload length is fixed to 12.
- Fix: eregmatch(). loop never advances, infinite loop, unbounded allocation when find_all is set to TRUE

SC-1649
 

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.
