### PR TITLE
Fix openvas `Command` handling being blocking instead of async.

### DIFF
--- a/rust/src/openvas/cmd.rs
+++ b/rust/src/openvas/cmd.rs
@@ -5,8 +5,9 @@
 use configparser::ini::Ini;
 use std::{
     io::Result,
-    process::{Child, Command},
+    path::{Path, PathBuf},
 };
+use tokio::process::{Child, Command};
 
 /// Check if it is possible to start openvas with the sudo command. In most
 /// environments it is necessary to start openvas as sudo, as it is not possible
@@ -18,8 +19,8 @@ pub fn check_sudo() -> bool {
 }
 
 /// Read the openvas configuration.
-pub fn read_openvas_config() -> Result<Ini> {
-    let oconfig = Command::new("openvas").arg("-s").output()?;
+pub async fn read_openvas_config() -> Result<Ini> {
+    let oconfig = Command::new("openvas").arg("-s").output().await?;
 
     let mut config = Ini::new();
     let oconfig = oconfig.stdout.iter().map(|x| *x as char).collect();
@@ -30,8 +31,8 @@ pub fn read_openvas_config() -> Result<Ini> {
 }
 
 /// Get the path to the redis unix socket from openvas configuration
-pub fn get_redis_socket() -> String {
-    if let Ok(config) = read_openvas_config() {
+pub async fn get_redis_socket() -> String {
+    if let Ok(config) = read_openvas_config().await {
         return match config.get("default", "db_address") {
             Some(setting) => format!("unix://{setting}"),
             None => String::new(),
@@ -41,11 +42,12 @@ pub fn get_redis_socket() -> String {
 }
 
 /// Get the plugin folder from openvas configuration
-pub fn get_plugins_folder() -> String {
-    if let Ok(config) = read_openvas_config() {
-        return config.get("default", "plugins_folder").unwrap_or_default();
+pub async fn get_plugins_folder() -> PathBuf {
+    if let Ok(config) = read_openvas_config().await {
+        return Path::new(&config.get("default", "plugins_folder").unwrap_or_default()).into();
     }
-    String::new()
+    // TODO: Really? Is this path ever reached? Does this actually do something useful?
+    Path::new("").into()
 }
 
 /// Start a new scan with the openvas executable with the given string. Before a scan can be

--- a/rust/src/openvas/openvas.rs
+++ b/rust/src/openvas/openvas.rs
@@ -11,6 +11,7 @@ use super::{
     result_collector::ResultHelper,
 };
 use greenbone_scanner_framework::models::{self, HostInfo, Phase, Scan, Status};
+use tokio::process::Child;
 
 use crate::storage::redis::{NameSpaceSelector, RedisCtx};
 use crate::utils::scanner_types::ScannerType;
@@ -18,7 +19,6 @@ use async_trait::async_trait;
 use std::{
     collections::HashMap,
     fmt::Display,
-    process::Child,
     str::FromStr,
     sync::{Arc, Mutex},
     time::SystemTime,
@@ -106,7 +106,7 @@ impl OpenvasScanner {
     }
 
     /// Removes a scan from init and add it to the list of running scans
-    fn add_running(&self, id: String, dbid: u32) -> Result<bool, OpenvasError> {
+    async fn add_running(&self, id: String, dbid: u32) -> Result<bool, OpenvasError> {
         let openvas = cmd::start(&id, self.sudo, None).map_err(OpenvasError::CmdError)?;
         self.running.lock().unwrap().insert(id, (openvas, dbid));
         Ok(true)
@@ -143,18 +143,6 @@ impl OpenvasScanner {
     }
 }
 
-impl Default for OpenvasScanner {
-    fn default() -> Self {
-        Self {
-            running: Default::default(),
-            sudo: cmd::check_sudo(),
-            redis_socket: cmd::get_redis_socket(),
-            resource_checker: None,
-            default_scanner_preferences: Vec::new(),
-        }
-    }
-}
-
 #[async_trait]
 impl Scanner for OpenvasScanner {
     fn scanner_type(&self) -> ScannerType {
@@ -181,7 +169,8 @@ impl Scanner for OpenvasScanner {
         self.add_running(
             scan.scan_id,
             redis_help.kb_id().expect("Valid Redis context"),
-        )?;
+        )
+        .await?;
 
         return Ok(());
     }
@@ -208,9 +197,10 @@ impl Scanner for OpenvasScanner {
         cmd::stop(scan_id, self.sudo)
             .map_err(OpenvasError::CmdError)?
             .wait()
+            .await
             .map_err(OpenvasError::CmdError)?;
 
-        scan.wait().map_err(OpenvasError::CmdError)?;
+        scan.wait().await.map_err(OpenvasError::CmdError)?;
 
         // Release the task kb
         let mut redis_help = self.create_redis_connector(Some(dbid))?;
@@ -361,7 +351,7 @@ impl Scanner for OpenvasScanner {
             };
 
             // Read openvas scanner exit code and if failed, reset the status to Failed.
-            let exit_status = scan.wait().map_err(OpenvasError::CmdError)?;
+            let exit_status = scan.wait().await.map_err(OpenvasError::CmdError)?;
             if let Some(code) = exit_status.code()
                 && code != 0
             {

--- a/rust/src/openvas/pref_handler.rs
+++ b/rust/src/openvas/pref_handler.rs
@@ -266,7 +266,7 @@ where
     async fn prepare_boreas_alive_test(&mut self) -> RedisStorageResult<()> {
         // Check "test_alive_hosts_only" configuration from openvas.conf
         // If set no, boreas is disabled and alive_host.nasl is used instead.
-        if let Ok(config) = cmd::read_openvas_config()
+        if let Ok(config) = cmd::read_openvas_config().await
             && let Some(setting) = config.get("default", "test_alive_hosts_only")
             && setting == "no"
         {

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -600,7 +600,7 @@ where
             init_with_scanner(pool, crypter, config, scanner, feed_status).await
         }
         scanner_types::ScannerType::Openvas => {
-            let redis_url = cmd::get_redis_socket();
+            let redis_url = cmd::get_redis_socket().await;
 
             let scanner = openvas::OpenvasScanner::new(
                 config.scheduler.min_free_mem,

--- a/rust/src/openvasd/vts/mod.rs
+++ b/rust/src/openvasd/vts/mod.rs
@@ -12,6 +12,7 @@ use scannerlib::Promise;
 use scannerlib::feed::{HashSumFileItem, HashSumNameLoader, check_signature};
 use scannerlib::nasl::syntax::Loader;
 use scannerlib::notus::advisory_loader;
+use scannerlib::openvas::cmd::{get_plugins_folder, get_redis_socket};
 use scannerlib::{
     models::{FeedState, FeedType, VTData},
     notus::advisories::VulnerabilityData,
@@ -131,12 +132,16 @@ pub async fn init(
 ) -> (orchestrator::Communicator, Endpoints) {
     match config.scanner.scanner_type {
         ScannerType::Openvas => {
-            let fetcher = redis::RedisPluginHandler::from(config);
-            let worker = redis::FeedSynchronizer::from(config);
+            let socket = get_redis_socket().await;
+            let plugin_folder = get_plugins_folder().await;
+            let fetcher = redis::RedisPluginHandler::new(socket.clone(), plugin_folder);
+            let worker = redis::FeedSynchronizer::new(config, socket);
             _init(config, fetcher, worker, snapshot).await
         }
         ScannerType::Ospd => {
-            let fetcher = redis::RedisPluginHandler::from(config);
+            let socket = get_redis_socket().await;
+            let plugins_folder = get_plugins_folder().await;
+            let fetcher = redis::RedisPluginHandler::new(socket, plugins_folder);
             let worker = crate::database::sqlite::vts::FeedSynchronizer::new(pool, config);
             _init(config, fetcher, worker, snapshot).await
         }

--- a/rust/src/openvasd/vts/redis.rs
+++ b/rust/src/openvasd/vts/redis.rs
@@ -1,10 +1,9 @@
-use std::{fs, path::PathBuf, str::FromStr, task::Poll, time::UNIX_EPOCH};
+use std::{fs, path::PathBuf, task::Poll, time::UNIX_EPOCH};
 
 use futures::Stream;
 use greenbone_scanner_framework::GetVTsError;
 use scannerlib::{
     models::{FeedType, VTData},
-    openvas::cmd,
     storage::redis::{
         CACHE_KEY, DbError, NOTUS_KEY, RedisAddAdvisory, RedisAddNvt, RedisCtx, RedisGetNvt,
         RedisWrapper,
@@ -28,8 +27,7 @@ pub struct FeedSynchronizer {
 }
 
 impl FeedSynchronizer {
-    pub fn new(config: &Config) -> Self {
-        let address = cmd::get_redis_socket();
+    pub fn new(config: &Config, address: String) -> Self {
         let plugin_feed = config.feed.path.clone();
         let advisory_feed = config.notus.advisories_path.clone();
         let signature_check = config.feed.signature_check;
@@ -44,12 +42,6 @@ impl FeedSynchronizer {
             address,
             plugin_storer,
         }
-    }
-}
-
-impl From<&Config> for FeedSynchronizer {
-    fn from(value: &Config) -> Self {
-        Self::new(value)
     }
 }
 
@@ -70,12 +62,9 @@ pub struct RedisPluginHandler {
     feed_path: PathBuf,
 }
 
-impl From<&Config> for RedisPluginHandler {
-    fn from(_: &Config) -> Self {
-        Self {
-            address: cmd::get_redis_socket(),
-            feed_path: PathBuf::from_str(cmd::get_plugins_folder().as_str()).unwrap(),
-        }
+impl RedisPluginHandler {
+    pub fn new(address: String, feed_path: PathBuf) -> Self {
+        Self { address, feed_path }
     }
 }
 


### PR DESCRIPTION
While trying to track down while some tests were taking such a long time, I noticed that the scheduling task had a very large busy time (meaning it was either extremely busy doing CPU work or just never yielding). Turns out it never yielded. I traced down why and this is the result, the `openvas` commands were run as sync commands. This changes them to be async
