### PR TITLE
Fix security issues

### DIFF
--- a/doc/manual/nasl/built-in-functions/cryptographic/NTLMv1_HASH.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/NTLMv1_HASH.md
@@ -3,16 +3,17 @@
 ## NAME
 
 **NTLMv1_HASH** - takes two named arguments cryptkey, passhash
+
 ## SYNOPSIS
 
-*str* **NTLMv1_HASH**(cryptkey: str, passhash: str);
+_str_ **NTLMv1_HASH**(cryptkey: str, passhash: str);
 
 **NTLMv1_HASH** It takes two named arguments cryptkey, passhash.
 
 ## DESCRIPTION
 
-NTLMv1_HASH generates the NTLMv1_HASH based on the given arguments.
-
+NTLMv1_HASH generates the NTLMv1_HASH based on the given arguments. To generate the passhash,
+**[nt_owf_gen(3)](nt_owf_gen.md)** and **[lm_owf_gen(3)](lm_owf_gen.md)** should be used.
 
 ## RETURN VALUE
 
@@ -20,8 +21,8 @@ NTLMv1_HASH
 
 ## ERRORS
 
-Returns NULL when a given parameter is null.
+Returns NULL when a given parameter is null or the passhash does not have a length of 16.
 
 ## SEE ALSO
 
-**[NTLMv2_HASH(3)](NTLMv2_HASH.md)**,
+**[nt_owf_gen(3)](nt_owf_gen.md)**, **[lm_owf_gen(3)](lm_owf_gen.md)**, **[NTLMv2_HASH(3)](NTLMv2_HASH.md)**

--- a/doc/manual/nasl/built-in-functions/cryptographic/lm_owf_gen.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/lm_owf_gen.md
@@ -2,21 +2,27 @@
 
 ## NAME
 
-**lm_owf_gen** - takes a unnamed parameter and returns LanMan one way hash.
+**lm_owf_gen** - takes an unnamed parameter and returns LM one way hash.
+
 ## SYNOPSIS
 
-*str* **lm_owf_gen**(str);
+_str_ **lm_owf_gen**(str);
 
 **lm_owf_gen** It takes one unnamed argument.
 
 ## DESCRIPTION
 
-lm_owf_gen is a type of hash function.
+lm_owf_gen is a type of hash function. It produces the LM Hash (part of NTLM) for the
+**[NTLMv1_HASH(3)](NTLMv1_HASH.md)** function. This is the counterpart to the
+**[nt_owf_gen(3)](nt_owf_gen.md)** function.
 
+LM - Lan Manager
+OWF - one way function
+gen - generate
 
 ## RETURN VALUE
 
-lm_owf_gen hash
+LM Hash
 
 ## ERRORS
 
@@ -30,5 +36,6 @@ hash = lm_owf_gen("test");
 
 ## SEE ALSO
 
+**[NTLMv1_HASH(3)](NTLMv1_HASH.md)**,
 **[nt_owf_gen(3)](nt_owf_gen.md)**,
 **[ntv2_owf_gen(3)](ntv2_owf_gen.md)**,

--- a/doc/manual/nasl/built-in-functions/cryptographic/nt_owf_gen.md
+++ b/doc/manual/nasl/built-in-functions/cryptographic/nt_owf_gen.md
@@ -2,21 +2,27 @@
 
 ## NAME
 
-**nt_owf_gen** - takes a unnamed paramaeter and returns NT one way hash.
+**nt_owf_gen** - takes an unnamed parameter and returns NT one way hash.
+
 ## SYNOPSIS
 
-*str* **nt_owf_gen**(str);
+_str_ **nt_owf_gen**(str);
 
 **nt_owf_gen** It takes one unnamed argument.
 
 ## DESCRIPTION
 
-nt_owf_gen is a type of hash function.
+nt_owf_gen is a type of hash function. It produces the NT Hash (part of NTLM) for the
+**[NTLMv1_HASH(3)](NTLMv1_HASH.md)** function. This is the counterpart to the
+**[lm_owf_gen(3)](lm_owf_gen.md)** function.
 
+NT - New Technology
+OWF - one way function
+gen - generate
 
 ## RETURN VALUE
 
-nt_owf_gen hash
+NT hash
 
 ## ERRORS
 
@@ -30,5 +36,6 @@ hash = nt_owf_gen("test");
 
 ## SEE ALSO
 
+**[NTLMv1_HASH(3)](NTLMv1_HASH.md)**
 **[lm_owf_gen(3)](lm_owf_gen.md)**,
 **[ntv2_owf_gen(3)](ntv2_owf_gen.md)**,

--- a/nasl/nasl_crypto.c
+++ b/nasl/nasl_crypto.c
@@ -708,7 +708,13 @@ nasl_ntlmv1_hash (lex_ctxt *lexic)
       return NULL;
     }
 
-  pass_len = pass_len < 16 ? pass_len : 16;
+  if (pass_len != 16)
+    {
+      nasl_perror (lexic, "passhash must be exact 16 bytes long, please use "
+                          "`nt_owf_gen` or `lm_owf_gen` to generate it");
+      return NULL;
+    }
+
   bzero (p21, sizeof (p21));
   memcpy (p21, password, pass_len);
 


### PR DESCRIPTION
There were a buffer overflow issue within the `nasl_ntlmv1_hash` function. While working on this, I noticed, that the implementation did not align with the actual NTLM specification. This function now only accepts passhashes of length 16 and throws an useful error message otherwise. I also adjusted the documentation of related functions, as there were almost no information about these functions available.

Jira: SC-1662