### PR TITLE
Fix: keep script stats timestamps ordered

### DIFF
--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -176,12 +176,15 @@ update_running_processes (kb_t main_kb, kb_t kb)
                 }
               else
                 {
-                  struct timeval old_now = now;
+                  long duration_sec =
+                    (long) (now.tv_sec - processes[i].start.tv_sec);
+                  long duration_usec =
+                    (long) (now.tv_usec - processes[i].start.tv_usec);
                   int e;
-                  if (now.tv_usec < processes[i].start.tv_usec)
+                  if (duration_usec < 0)
                     {
-                      processes[i].start.tv_sec++;
-                      now.tv_usec += 1000000;
+                      duration_sec--;
+                      duration_usec += 1000000;
                     }
 
                   if (log_whole)
@@ -189,21 +192,18 @@ update_running_processes (kb_t main_kb, kb_t kb)
                       char *name = nvticache_get_filename (oid);
                       g_message (
                         "%s (%s) [%d] finished its job in %ld.%.3ld seconds",
-                        name, oid, processes[i].pid,
-                        (long) (now.tv_sec - processes[i].start.tv_sec),
-                        (long) ((now.tv_usec - processes[i].start.tv_usec)
-                                / 1000));
+                        name, oid, processes[i].pid, duration_sec,
+                        duration_usec / 1000);
                       g_free (name);
 
                       char msg[2048];
                       g_snprintf (msg, sizeof (msg), "%s/%ld/%ld", oid,
-                                  (long) ((now.tv_sec * 1000)
-                                          + (long) (now.tv_usec / 1000)),
                                   (long) (processes[i].start.tv_sec * 1000
-                                          + processes[i].start.tv_usec / 1000));
+                                          + processes[i].start.tv_usec / 1000),
+                                  (long) ((now.tv_sec * 1000)
+                                          + (long) (now.tv_usec / 1000)));
                       kb_item_push_str (kb, "general/script_stats", msg);
                     }
-                  now = old_now;
                   do
                     {
                       e = waitpid (processes[i].pid, NULL, 0);


### PR DESCRIPTION
**What**:

Fixes the per-script timestamps written to `general/script_stats` so the generated `report_scripts` JSON records `start` before `stop` for each script entry.

The change also keeps the original process start timestamp untouched while calculating the human-readable duration. Previously the microsecond borrow path incremented `processes[i].start.tv_sec`, which could shift the recorded start time before the stats entry was written.

**Why**:

`write_host_stats()` labels the second stats field as `start` and the third as `stop`. `pluginlaunch.c` was pushing those fields in the opposite order, so per-script entries could show `start > stop` and produce negative durations for consumers of the stats JSON.

Fixes #2242

**How**:

Validated locally in WSL Ubuntu 24.04:

- `git diff --check`
- `clang-format --dry-run --Werror src/pluginlaunch.c`
- `cmake -S . -B build-pr-2242 -G Ninja`
  - Configure finds the standard scanner dependencies installed locally (`glib-2.0`, `json-glib-1.0`, `gnutls`, `libcurl`, `mit-krb5`).
  - Configure stops at `libgvm_base>=22.4`, which is provided by Greenbone's CI `gvm-libs` image and is not installed in this local WSL environment.

**Checklist**:

- [x] Tests
- [x] PR merge commit message adjusted