### PR TITLE
Add: Support Skiron within openvas-scanner

### DIFF
--- a/doc/man/openvas.8.in
+++ b/doc/man/openvas.8.in
@@ -226,7 +226,12 @@ Username for authenticated MQTT communication.
 Password for authenticated MQTT communication.
 
 .IP openvasd_server
-Openvasd server URI to Rust implementation of Notus. It has priority over MQTT settings.
+Openvasd server URI to Rust implementation of Notus. It has priority over mqtt_server_uri setting. It is deprecated
+and will be removed in the next major release. Use notus_route instead.
+
+.IP notus_route
+A route to a Notus endpoint. The value must conain a server uri, as well as the route to its notus endpoint.
+E.g. http://127.0.0.1:3000/notus
 
 .IP x-apikey
 API Key for authenticate against openvasd when Notus Rust implementation is enabled.

--- a/doc/manual/openvas/openvas.md
+++ b/doc/manual/openvas/openvas.md
@@ -377,7 +377,13 @@ mqtt_pass
 openvasd_server
 
 :   Openvasd server URI to Rust implementation of Notus. It has
-    priority over MQTT settings.
+    priority over MQTT settings. It is deprecated and will be removed
+    in the next major release. Use notus_route instead.
+
+IP notus_route
+:   A route to a Notus endpoint. The value must conain a server uri,
+    as well as the route to its notus endpoint.
+    E.g. http://127.0.0.1:3000/notus
 
 x-apikey
 

--- a/doc/misc/undocumented-preferences.md
+++ b/doc/misc/undocumented-preferences.md
@@ -7,8 +7,8 @@ Some scanner preferences are found in the scanner code but are not documented in
 - TARGET: Is the host list to be attacked. Internally used and set by the client.
 - exclude_hosts: excluded host from the TARGET list. Internally used and set by the client.
 - hosts_ordering: intended to be used by the client. If Boreas is active, this option is ignored, since the host order changes in the mean the host are detected as alive
-- mqtt_enabled: internally used for selection of python implementation of Notus
-- openvasd_lsc_enabled: internally used for selection of rust implementation of Notus
+- mqtt_enabled: internally used for selection of MQTT implementation of Notus (LSC)
+- http_lsc_enabled: internally used for selection of HTTP endpoint is used for Notus (LSC)
 - ov_maindbid: internally used.
 - plugin_set: List of plugin OIDs to be run against the target. This is set by the client and used to initialize the plugin scheduler.
 - reverse_lookup_only: Only scan IP addresses that can be resolved into a DNS name. To be set by the client.

--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -240,7 +240,7 @@ cleanup:
  */
 struct notus_info
 {
-  char *server; // original openvasd server URL
+  char *route;  // original notus route
   char *schema; // schema is http or https
   char *host;   // server hostname
   char *alpn; // Application layer protocol negotiation: http/1.0, http/1.1, h2
@@ -264,7 +264,7 @@ init_notus_info (const char *server)
   notusdata = g_malloc0 (sizeof (struct notus_info));
   if (!notusdata)
     return NULL;
-  notusdata->server = g_strdup (server);
+  notusdata->route = g_strdup (server);
   return notusdata;
 }
 
@@ -277,7 +277,7 @@ free_notus_info (notus_info_t notusdata)
 {
   if (notusdata)
     {
-      g_free (notusdata->server);
+      g_free (notusdata->route);
       g_free (notusdata->schema);
       g_free (notusdata->host);
       g_free (notusdata->alpn);
@@ -366,9 +366,9 @@ parse_server (notus_info_t *notusdata)
   if (!notusdata)
     return -1;
 
-  if (curl_url_set (h, CURLUPART_URL, (*notusdata)->server, 0) > 0)
+  if (curl_url_set (h, CURLUPART_URL, (*notusdata)->route, 0) > 0)
     {
-      g_warning ("%s: Error parsing URL %s", __func__, (*notusdata)->server);
+      g_warning ("%s: Error parsing URL %s", __func__, (*notusdata)->route);
       return -1;
     }
 
@@ -380,7 +380,7 @@ parse_server (notus_info_t *notusdata)
     {
       g_warning ("%s: Invalid URL %s. It must be in format: "
                  "schema://host:port. E.g. http://localhost:8080",
-                 __func__, (*notusdata)->server);
+                 __func__, (*notusdata)->route);
       curl_url_cleanup (h);
       curl_free (schema);
       curl_free (host);
@@ -411,7 +411,7 @@ parse_server (notus_info_t *notusdata)
     }
   else
     {
-      g_warning ("%s: Invalid openvasd server schema", (*notusdata)->server);
+      g_warning ("%s: Invalid openvasd server schema", (*notusdata)->route);
       curl_url_cleanup (h);
       curl_free (schema);
       curl_free (host);
@@ -924,7 +924,7 @@ send_request (notus_info_t notusdata, const char *os, const char *pkg_list,
               char **response)
 {
   CURL *curl;
-  GString *url = NULL;
+  GString *route = NULL;
   long http_code = -1;
   struct string resp;
   struct curl_slist *customheader = NULL;
@@ -937,10 +937,8 @@ send_request (notus_info_t notusdata, const char *os, const char *pkg_list,
       return http_code;
     }
 
-  url = g_string_new (notusdata->server);
-  g_string_append (url, "/notus/");
+  route = g_string_new (notusdata->route);
 
-  //
   os_aux = help_tolower (g_strdup (os));
   for (size_t i = 0; i < strlen (os_aux); i++)
     {
@@ -948,18 +946,21 @@ send_request (notus_info_t notusdata, const char *os, const char *pkg_list,
         os_aux[i] = '_';
     }
 
-  g_string_append (url, os_aux);
+  if (route->len == 0 || route->str[route->len - 1] != '/')
+    g_string_append_c (route, '/');
+
+  g_string_append (route, os_aux);
   g_free (os_aux);
 
-  g_debug ("%s: URL: %s", __func__, url->str);
+  g_debug ("%s: URL: %s", __func__, route->str);
   // Set URL
-  if (curl_easy_setopt (curl, CURLOPT_URL, g_strdup (url->str)) != CURLE_OK)
+  if (curl_easy_setopt (curl, CURLOPT_URL, g_strdup (route->str)) != CURLE_OK)
     {
       g_warning ("Not possible to set the URL");
       curl_easy_cleanup (curl);
       return http_code;
     }
-  g_string_free (url, TRUE);
+  // g_string_free (route, TRUE);
 
   // Accept an insecure connection. Don't verify the server certificate
   curl_easy_setopt (curl, CURLOPT_SSL_VERIFYPEER, 0L);
@@ -989,7 +990,8 @@ send_request (notus_info_t notusdata, const char *os, const char *pkg_list,
   int ret = CURLE_OK;
   if ((ret = curl_easy_perform (curl)) != CURLE_OK)
     {
-      g_warning ("%s: Error sending request: %d", __func__, ret);
+      g_warning ("%s: Error sending request to %s: %d", __func__, route->str,
+                 ret);
       curl_easy_cleanup (curl);
       g_free (resp.ptr);
       return http_code;
@@ -1025,7 +1027,7 @@ lsc_get_response (const char *pkg_list, const char *os)
 
   // Parse the server and get the port, host, schema
   // and necessary information to build the message
-  server = prefs_get ("openvasd_server");
+  server = prefs_get ("notus_route");
   notusdata = init_notus_info (server);
 
   if (parse_server (&notusdata) < 0)
@@ -1178,9 +1180,9 @@ run_table_driven_lsc (const char *scan_id, const char *ip_str,
   if (!os_release || !package_list)
     return 0;
 
-  if (prefs_get ("openvasd_server"))
+  if (prefs_get ("http_lsc_enabled"))
     {
-      g_message ("Running Notus for %s via openvasd", ip_str);
+      g_message ("Running Notus for %s via HTTP", ip_str);
       err = call_rs_notus (ip_str, hostname, package_list, os_release);
 
       return err;

--- a/src/attack.c
+++ b/src/attack.c
@@ -388,7 +388,7 @@ process_ipc_data (struct attack_start_args *args, const gchar *result)
           set_lsc_flag ();
           if (!scan_is_stopped () && prefs_get_bool ("table_driven_lsc")
               && (prefs_get_bool ("mqtt_enabled")
-                  || prefs_get_bool ("openvasd_lsc_enabled")))
+                  || prefs_get_bool ("http_lsc_enabled")))
             {
               struct in6_addr hostip;
               gchar ip_str[INET6_ADDRSTRLEN];
@@ -680,7 +680,7 @@ attack_host (struct scan_globals *globals, struct in6_addr *ip,
   if (!scan_is_stopped () && prefs_get_bool ("table_driven_lsc")
       && !lsc_has_run ()
       && (prefs_get_bool ("mqtt_enabled")
-          || prefs_get_bool ("openvasd_lsc_enabled")))
+          || prefs_get_bool ("http_lsc_enabled")))
     {
       call_lsc (args, ip_str);
     }

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -410,7 +410,7 @@ static int
 attack_network_init (struct scan_globals *globals, const gchar *config_file)
 {
   const char *mqtt_server_uri;
-  const char *openvasd_server_uri;
+  const char *notus_route;
 
   set_default_openvas_prefs ();
   prefs_config (config_file);
@@ -432,40 +432,57 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
   nvticache_reset ();
 
   /* Init Notus communication */
-  openvasd_server_uri = prefs_get ("openvasd_server");
-  if (openvasd_server_uri)
+  notus_route = prefs_get ("openvasd_server");
+  if (notus_route)
     {
+      gchar *full_notus_route;
+      g_warning ("%s: option openvasd_server is deprecated and will be removed "
+                 "in the next major release. Please use notus_route instead.",
+                 __func__);
+      full_notus_route = g_strconcat (notus_route, "/notus/", NULL);
+      prefs_set ("notus_route", full_notus_route);
+      g_free (full_notus_route);
       g_message ("%s: LSC via openvasd", __func__);
-      prefs_set ("openvasd_lsc_enabled", "yes");
+      prefs_set ("http_lsc_enabled", "yes");
     }
   else
     {
-      mqtt_server_uri = prefs_get ("mqtt_server_uri");
-      if (mqtt_server_uri)
+      notus_route = prefs_get ("notus_route");
+      if (notus_route)
         {
-#ifdef AUTH_MQTT
-          const char *mqtt_user = prefs_get ("mqtt_user");
-          const char *mqtt_pass = prefs_get ("mqtt_pass");
-          if ((mqtt_init_auth (mqtt_server_uri, mqtt_user, mqtt_pass)) != 0)
-#else
-          if ((mqtt_init (mqtt_server_uri)) != 0)
-#endif
-            {
-              g_message ("%s: INIT MQTT: FAIL", __func__);
-              send_message_to_client_and_finish_scan (
-                "ERRMSG||| ||| ||| ||| |||MQTT initialization failed");
-            }
-          else
-            {
-              g_message ("%s: INIT MQTT: SUCCESS", __func__);
-              prefs_set ("mqtt_enabled", "yes");
-            }
+          g_message ("%s: LSC via HTTP(S)", __func__);
+          prefs_set ("http_lsc_enabled", "yes");
         }
       else
         {
-          g_message ("%s: Neither openvasd_server nor mqtt_server_uri given, "
-                     "LSC disabled",
-                     __func__);
+          mqtt_server_uri = prefs_get ("mqtt_server_uri");
+          if (mqtt_server_uri)
+            {
+#ifdef AUTH_MQTT
+              const char *mqtt_user = prefs_get ("mqtt_user");
+              const char *mqtt_pass = prefs_get ("mqtt_pass");
+              if ((mqtt_init_auth (mqtt_server_uri, mqtt_user, mqtt_pass)) != 0)
+#else
+              if ((mqtt_init (mqtt_server_uri)) != 0)
+#endif
+                {
+                  g_message ("%s: INIT MQTT: FAIL", __func__);
+                  send_message_to_client_and_finish_scan (
+                    "ERRMSG||| ||| ||| ||| |||MQTT initialization failed");
+                }
+              else
+                {
+                  g_message ("%s: INIT MQTT: SUCCESS", __func__);
+                  prefs_set ("mqtt_enabled", "yes");
+                }
+            }
+          else
+            {
+              g_message (
+                "%s: Neither openvasd_server nor mqtt_server_uri given, "
+                "LSC disabled",
+                __func__);
+            }
         }
     }
 


### PR DESCRIPTION
This will introduce a new preference `notus_route` and deprecate `openvasd_server`. The reason for this is, that the path of the notus endpoint of skiron is different than in openvasd and might change in the future. In this case the path can be adjusted with this config, instead of hardcoding it.

SC-1622