### PR TITLE
Fix: keep script stats timestamps ordered

### DIFF
--- a/RELICENSE/BharatDeva.md
+++ b/RELICENSE/BharatDeva.md
@@ -1,0 +1,80 @@
+Thank you for your interest in the project openvas-scanner managed by Greenbone.
+In order for you to make Contributions now or in the future to this
+project, You agree to license your Contributions under the MIT-0 license (see below).
+Please note that You remain the copyright owner, and anyone receives the right to
+use your Contribution in proprietary and open source software without any
+attribution.
+
+..................
+
+MIT No Attribution (MIT-0)
+
+Copyright 2026 BharatDeva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+.........................
+
+Please note that You remain the copyright owner, and anyone receives the
+right to use your Contribution in proprietary and open source software
+without attribution. However, we will include your name as a Contributor
+in our CREDITS list as long as your Contribution is used in the project
+openvas-scanner.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is submitted by you
+to Greenbone for inclusion in the project openvas-scanner.
+
+Greenbone requires that each Contribution you submit now or in the
+future to comply with the following commitments documented in the
+Developer Certificate of Origin (DCO) [https://developercertificate.org/]:
+
+........
+
+Developer Certificate of Origin
+
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+
+(c) The contribution was provided directly to me by some other
+   person who certified (a), (b) or (c) and I have not modified
+   it.
+
+(d) I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.
+
+.....

--- a/src/pluginlaunch.c
+++ b/src/pluginlaunch.c
@@ -176,12 +176,15 @@ update_running_processes (kb_t main_kb, kb_t kb)
                 }
               else
                 {
-                  struct timeval old_now = now;
+                  long duration_sec =
+                    (long) (now.tv_sec - processes[i].start.tv_sec);
+                  long duration_usec =
+                    (long) (now.tv_usec - processes[i].start.tv_usec);
                   int e;
-                  if (now.tv_usec < processes[i].start.tv_usec)
+                  if (duration_usec < 0)
                     {
-                      processes[i].start.tv_sec++;
-                      now.tv_usec += 1000000;
+                      duration_sec--;
+                      duration_usec += 1000000;
                     }
 
                   if (log_whole)
@@ -189,21 +192,18 @@ update_running_processes (kb_t main_kb, kb_t kb)
                       char *name = nvticache_get_filename (oid);
                       g_message (
                         "%s (%s) [%d] finished its job in %ld.%.3ld seconds",
-                        name, oid, processes[i].pid,
-                        (long) (now.tv_sec - processes[i].start.tv_sec),
-                        (long) ((now.tv_usec - processes[i].start.tv_usec)
-                                / 1000));
+                        name, oid, processes[i].pid, duration_sec,
+                        duration_usec / 1000);
                       g_free (name);
 
                       char msg[2048];
                       g_snprintf (msg, sizeof (msg), "%s/%ld/%ld", oid,
-                                  (long) ((now.tv_sec * 1000)
-                                          + (long) (now.tv_usec / 1000)),
                                   (long) (processes[i].start.tv_sec * 1000
-                                          + processes[i].start.tv_usec / 1000));
+                                          + processes[i].start.tv_usec / 1000),
+                                  (long) ((now.tv_sec * 1000)
+                                          + (long) (now.tv_usec / 1000)));
                       kb_item_push_str (kb, "general/script_stats", msg);
                     }
-                  now = old_now;
                   do
                     {
                       e = waitpid (processes[i].pid, NULL, 0);


### PR DESCRIPTION
**What**

Fixes #2242.

The `general/script_stats` entries written by `pluginlaunch.c` now keep the timestamp order expected by `write_host_stats()`: `oid/start/stop`. Previously the code pushed `oid/stop/start`, which made generated `report_scripts` JSON show per-script `start` values after `stop`.

The duration calculation also no longer mutates `processes[i].start.tv_sec` when borrowing microseconds. That keeps the original process start timestamp intact for the stats entry.

**Why**

Consumers of `report_scripts` expect each script entry to have ordered timestamps. With the fields swapped, downstream readers can see negative script durations even though the plugin process completed normally.

**How**

Validation run locally in WSL Ubuntu 24.04:

- `git diff --check origin/main...HEAD` - passed
- `clang-format --dry-run --Werror src/pluginlaunch.c` - passed with clang-format 18.1.3
- `cmake -S . -B build-pr-2242-new -G Ninja` - configuration reached dependency discovery and found `glib-2.0`, `json-glib-1.0`, `gnutls`, `libcurl`, `mit-krb5`, and `mit-krb5-gssapi`; it stopped at missing local package `libgvm_base>=22.4`, which is not installed in this WSL environment.

**Data / downstream impact**

The stats schema is unchanged. The fix only corrects the ordering of values already written to `general/script_stats` and avoids changing the stored start timestamp during duration formatting.

**Template checks**

- First-time contributor RELICENSE file added: `RELICENSE/BharatDeva.md`
- Conventional commit / PR title uses `Fix:` for the code change
- Generative AI disclosure: OpenAI Codex was used to help prepare and validate this pull request. I reviewed the changes and test evidence before submission.