### PR TITLE
Deterministic ordering of `POST` notus endpoint

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/result.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/result.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::{collections::BTreeMap, fmt::Display, str::FromStr};
 
 use super::port::Protocol;
 use crate::models::Specifier;
@@ -124,7 +124,7 @@ impl Display for ResultType {
 }
 
 /// Notus Results are a Map from OIDs to vulnerable Packages
-pub type NotusResults = HashMap<String, Vec<VulnerablePackage>>;
+pub type NotusResults = BTreeMap<String, Vec<VulnerablePackage>>;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct VulnerablePackage {

--- a/rust/src/notus/notus.rs
+++ b/rust/src/notus/notus.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use greenbone_scanner_framework::models::{NotusResults, VulnerablePackage};
 use tracing::debug;
@@ -60,7 +60,7 @@ impl Notus {
     }
 
     fn compare<P: Package>(packages: &Vec<P>, vts: &VulnerabilityTests<P>) -> NotusResults {
-        let mut results: NotusResults = HashMap::new();
+        let mut results: NotusResults = BTreeMap::new();
         tracing::trace!(vts_keys = ?vts.keys().collect::<Vec<_>>(), packages=?packages.iter().map(|x|x.get_name()).collect::<Vec<_>>());
         for package in packages {
             let pname = package.get_name();

--- a/rust/src/openvasd/container_image_scanner/notus/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/notus/mod.rs
@@ -1,13 +1,16 @@
 // We allow this fow now, since it would require lots of changes
 // but should eventually solve this.
 #![allow(clippy::result_large_err)]
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use greenbone_scanner_framework::models::{self, FixedVersion, VulnerablePackage};
+use greenbone_scanner_framework::models::{self, FixedVersion};
 use tokio::sync::RwLock;
 
 use crate::container_image_scanner::detection::OperatingSystem;
-use scannerlib::notus::{Notus, NotusError};
+use scannerlib::{
+    models::NotusResults,
+    notus::{Notus, NotusError},
+};
 
 /// Some products have unique requirements that we have to generate somehow.
 ///
@@ -45,8 +48,6 @@ fn generate_key(architecture: &str, os: &OperatingSystem) -> String {
         (_, name) => format!("{}_{}", name, os.version_id),
     }
 }
-
-type NotusResults = HashMap<String, Vec<VulnerablePackage>>;
 
 fn to_result(image: String, digest: Option<String>, results: NotusResults) -> Vec<models::Result> {
     let hostname = Some(image);
@@ -106,10 +107,7 @@ pub async fn vulnerabilities(
     let result = tokio::task::spawn_blocking(move || p.scan(&os, &packages))
         .await
         .unwrap();
-    match result {
-        Ok(x) => Ok(to_result(image, digest, x)),
-        Err(error) => Err(error),
-    }
+    result.map(|result| to_result(image, digest, result))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This uses a `BTreeMap` for the notus results to maintain deterministic ordering of the results.

Jira: SC-1687