### PR TITLE
Fix: underflows to  on an empty line, wild OOB read.

### DIFF
--- a/misc/openvas-krb5.c
+++ b/misc/openvas-krb5.c
@@ -106,8 +106,12 @@ o_krb5_find_kdc (const OKrb5Credential *creds, char **kdc)
 
   while (fgets (line, MAX_LINE_LENGTH, file))
     {
+      int l_len;
       line[strcspn (line, "\n")] = 0;
-      last_element = strlen (line) - 1;
+      l_len = strlen (line);
+      if (l_len == 0)
+        continue;
+      last_element = l_len - 1;
       SKIP_WS (line, last_element, 0, i);
       if (line[i] == '[' && line[last_element] == ']')
         {

--- a/nasl/nasl_packet_forgery.c
+++ b/nasl/nasl_packet_forgery.c
@@ -2106,7 +2106,7 @@ forge_igmp_packet (lex_ctxt *lexic)
       if (data != NULL)
         {
           char *ptmp = (char *) (pkt + ip->ip_hl * 4 + sizeof (struct igmp));
-          bcopy (ptmp, data, len);
+          bcopy (data, ptmp, len);
         }
       retc = alloc_typed_cell (CONST_DATA);
       retc->x.str_val = (char *) pkt;

--- a/nasl/nasl_packet_forgery_v6.c
+++ b/nasl/nasl_packet_forgery_v6.c
@@ -2222,7 +2222,7 @@ forge_igmp_v6_packet (lex_ctxt *lexic)
       if (data != NULL)
         {
           char *ptmp = (char *) (pkt + 40 + sizeof (struct igmp6_hdr));
-          bcopy (ptmp, data, len);
+          bcopy (data, ptmp, len);
         }
       retc = alloc_typed_cell (CONST_DATA);
       retc->x.str_val = (char *) pkt;


### PR DESCRIPTION
SC-1649
SC-1693
- Fix: underflows to on an empty line, wild OOB read.
- Fix: bcopy(ptmp, data, len) has source/dest reversed

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.
