### PR TITLE
Fix: ensure a scan is not running before deleting it

### DIFF
--- a/rust/src/openvasd/scans/mod.rs
+++ b/rust/src/openvasd/scans/mod.rs
@@ -214,6 +214,18 @@ where
         id: String,
     ) -> Pin<Box<dyn Future<Output = Result<(), DeleteScansIDError>> + Send + '_>> {
         Box::pin(async move {
+            // Ensure the scan is not running.
+            let internal_id: i64 = id
+                .parse()
+                .map_err(|e| DeleteScansIDError::External(Box::new(e)))?;
+            let status: models::Status = ScanDB::new(&self.pool, internal_id)
+                .fetch()
+                .await
+                .map_err(|e| DeleteScansIDError::External(Box::new(e)))?;
+            if status.is_running() {
+                return Err(DeleteScansIDError::Running);
+            }
+
             // everything else should have ON DELETE CASCADE
             ScanDB::new(&self.pool, id)
                 .exec()


### PR DESCRIPTION
Fix: ensure a scan is not running before deleting it.

This fixes an issue in which the scan can be delete before stopping . So, openvas keeps running and the scan doesn't exist anymore in the openvasd db. This happend also when a DELETE is immediately sent after the stop. The delete is not treat via the scheduler, so a race condition was possible, deleting the scan before the treatment of the stop.

SC-1694

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.
