### PR TITLE
Fix: keep openvasd port ranges compact

### DIFF
--- a/rust/crates/greenbone-scanner-framework/src/models/port.rs
+++ b/rust/crates/greenbone-scanner-framework/src/models/port.rs
@@ -95,18 +95,8 @@ impl AsRef<str> for Protocol {
 
 pub fn ports_to_openvas_port_list(ports: Vec<Port>) -> Option<String> {
     fn add_range_to_list(list: &mut String, start: usize, end: Option<usize>) {
-        // Add range
-        if let Some(end) = end {
-            for p in start..=end {
-                list.push_str(p.to_string().as_str());
-                list.push(',');
-            }
-
-        // Add single port
-        } else {
-            list.push_str(start.to_string().as_str());
-            list.push(',');
-        }
+        list.push_str(PortRange { start, end }.to_string().as_str());
+        list.push(',');
     }
     if ports.is_empty() {
         return None;
@@ -195,7 +185,23 @@ mod tests {
         ];
         assert_eq!(
             ports_to_openvas_port_list(ports),
-            Some("T:22,23,24,25,80,1000,U:30,31,32,33,34,35,36,37,38,39,40,5060,1000,".to_string())
+            Some("T:22-25,80,1000,U:30-40,5060,1000,".to_string())
+        );
+    }
+
+    #[test]
+    fn test_port_conversion_keeps_large_ranges_compact() {
+        let ports = vec![Port {
+            protocol: Some(Protocol::TCP),
+            range: vec![PortRange {
+                start: 1,
+                end: Some(65535),
+            }],
+        }];
+
+        assert_eq!(
+            ports_to_openvas_port_list(ports),
+            Some("T:1-65535,".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

`openvasd` converts structured scan target ports into the OpenVAS `port_range` preference. Large ranges such as `1-65535` were expanded into one comma-separated port per value, which can make the `nmap -p` argument exceed Linux's per-argument size limit.

This keeps ranges compact by reusing the existing `PortRange` display format, so a full TCP range is emitted as `T:1-65535,` instead of thousands of individual ports.

## Testing

Run from WSL Ubuntu in `rust/crates/greenbone-scanner-framework`:

```sh
cargo test --lib models::port::tests::test_port_conversion -- --nocapture
```

Result:

```text
running 2 tests
test models::port::tests::test_port_conversion_keeps_large_ranges_compact ... ok
test models::port::tests::test_port_conversion_to_string ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 60 filtered out; finished in 0.01s
```

Also checked formatting/whitespace:

```sh
cargo fmt --check
git diff --check
```

## Generative AI disclosure

I used OpenAI Codex while preparing this patch and reviewed the change and test output before submission.

Fixes #2223