### PR TITLE
Fix: respect existing fortify source flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,11 @@ if (ENABLE_COVERAGE)
   set (COVERAGE_FLAGS "--coverage")
 endif (ENABLE_COVERAGE)
 
-set (HARDENING_FLAGS            "-Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -fstack-protector")
+set (HARDENING_FLAGS            "-Wformat -Wformat-security -fstack-protector")
+if (NOT CMAKE_C_FLAGS MATCHES "(^|[ ;])-D_FORTIFY_SOURCE="
+    AND NOT CMAKE_C_FLAGS_RELEASE MATCHES "(^|[ ;])-D_FORTIFY_SOURCE=")
+  set (HARDENING_FLAGS          "${HARDENING_FLAGS} -D_FORTIFY_SOURCE=2")
+endif ()
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 # The "-D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1" is necessary for GPGME!
 set (GPGME_C_FLAGS              "-D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1")


### PR DESCRIPTION
## Summary

OpenVAS currently appends `-D_FORTIFY_SOURCE=2` to the Release hardening flags unconditionally. Some distributions, including Arch, may already provide a different `_FORTIFY_SOURCE` value through their compiler flags. When warnings are treated as errors, that duplicate definition can stop the build.

This keeps the existing default hardening behavior, but only adds `_FORTIFY_SOURCE=2` when neither `CMAKE_C_FLAGS` nor `CMAKE_C_FLAGS_RELEASE` already contains a `_FORTIFY_SOURCE` definition.

## Testing

Configured two WSL Ubuntu CMake builds with `SKIP_SRC=ON` to verify the flag logic without needing the full scanner dependency stack.

Default configuration still adds the project default:

```sh
cmake -S . -B build-fortify-trace-default -DSKIP_SRC=ON -DCMAKE_BUILD_TYPE=Release --trace-expand --trace-source=CMakeLists.txt
```

Relevant trace:

```text
set(HARDENING_FLAGS -Wformat -Wformat-security -fstack-protector )
set(HARDENING_FLAGS -Wformat -Wformat-security -fstack-protector -D_FORTIFY_SOURCE=2 )
```

Configuration with an existing distro/user value does not append a duplicate:

```sh
cmake -S . -B build-fortify-trace-existing -DSKIP_SRC=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS='-D_FORTIFY_SOURCE=3' --trace-expand --trace-source=CMakeLists.txt
```

Relevant trace:

```text
set(HARDENING_FLAGS -Wformat -Wformat-security -fstack-protector )
```

Also checked whitespace:

```sh
git diff --check
```

## Generative AI disclosure

I used OpenAI Codex while preparing this patch and reviewed the change and test output before submission.

Refs #1710