### PR TITLE
Fix: allow interrupted scans to be started again

### DIFF
--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -345,9 +345,11 @@ paths:
           description: "Scan not found"
     post:
       description: "This endpoint is used to perform an action on the scan. The scan can be either started
-        or stopped. Notice, that only a stored scan can be started and only a running scan can be
-        stopped. To create a scan, use [POST /scans](#/scan/create_scan). After it is created, the
-        scan is in the status stored."
+        or stopped. Notice, that only a scan in the status stored, stopped or failed can be started
+        and only a running scan can be stopped. Starting a stopped or failed scan continues it,
+        which is used to resume a scan that was stopped by a client or that was interrupted, e.g.
+        because the scanner went down while it was running. To create a scan, use
+        [POST /scans](#/scan/create_scan). After it is created, the scan is in the status stored."
       operationId: "scan_action"
       tags:
       - "scan"

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -31,6 +31,19 @@ use crate::{
 
 const LOCK_FILE: &str = "feed-update.lock";
 
+/// Phases a scan can be set to 'requested' from.
+///
+/// - 'stored': the scan was never started.
+/// - 'stopped': the scan was stopped by a client and is continued.
+/// - 'failed': the scan was interrupted; either the scan itself failed, or it was still running
+///   when openvasd went down (see `running_to_failed`), or starting it at the scanner failed. In
+///   each of those cases the scan is not running anywhere, so a client must be able to start it
+///   again.
+///
+/// 'requested' and 'running' are left out on purpose, a scan that is already on its way must not
+/// be restarted. 'succeeded' is left out as well, a finished scan is started as a new scan.
+const STARTABLE_PHASES: [&str; 3] = ["stored", "stopped", "failed"];
+
 #[derive(Default, Debug)]
 struct IsInProgress {
     need_approval_nasl: bool,
@@ -165,12 +178,28 @@ impl<T, C> ScanScheduler<T, C> {
     }
 
     async fn scan_to_requested(&self, id: i64) -> R<()> {
-        self.scan_state
-            .change_state(id, "stored", "requested")
-            .await?;
-        self.scan_state
-            .change_state(id, "stopped", "requested")
-            .await?;
+        let mut changed = false;
+        for phase in STARTABLE_PHASES {
+            changed |= self.scan_state.change_state(id, phase, "requested").await?;
+        }
+
+        if !changed {
+            // Nothing to do for the scheduler, therefore we tell why the start request had no
+            // effect. Without that a start of e.g. an already running scan is silently ignored.
+            let phase = match self.scan_state.scan_get_status(id).await {
+                Ok(status) => status.status.to_string(),
+                Err(error) => {
+                    tracing::warn!(id, %error, "Unable to get status of scan to be started.");
+                    return Ok(());
+                }
+            };
+            tracing::warn!(
+                id,
+                phase = %phase,
+                startable_phases = ?STARTABLE_PHASES,
+                "Ignoring start of scan because it is not in a phase it can be started from."
+            );
+        }
 
         Ok(())
     }
@@ -693,6 +722,44 @@ pub(crate) mod tests {
         assert_eq!(
             status.iter().filter(|s| s as &str == "requested").count(),
             status.len()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_interrupted_scan() -> TR {
+        // Scans that were still running when openvasd went down are set to failed. They are not
+        // running anywhere anymore, so a client (e.g. gvmd resuming an interrupted task) must be
+        // able to start them again.
+        let (under_test, known_scans) = setup_test_env().await?;
+
+        for id in known_scans.iter() {
+            under_test
+                .on_user_action(&Message::Start(id.to_string()))
+                .await?;
+        }
+        under_test.on_schedule().await?;
+        under_test.running_to_failed().await?;
+        let failed: i64 = query_scalar("SELECT count(id) FROM scans WHERE status = 'failed'")
+            .fetch_one(&under_test.pool)
+            .await?;
+        assert_eq!(failed as usize, under_test.max_concurrent_scan);
+
+        for id in known_scans.iter() {
+            under_test
+                .on_user_action(&Message::Start(id.to_string()))
+                .await?;
+        }
+
+        let status: Vec<String> = query_scalar("SELECT status FROM scans")
+            .fetch_all(&under_test.pool)
+            .await?;
+        assert_eq!(status.len(), known_scans.len());
+        assert_eq!(
+            status.iter().filter(|s| s as &str == "requested").count(),
+            status.len(),
+            "interrupted scans must be requested again, got {status:?}"
         );
 
         Ok(())


### PR DESCRIPTION
## What

Add `failed` to the phases a scan can be started from, so an interrupted scan can be started again, and log a warning when a start action does not apply to the current phase.

## Why

`scan_to_requested()` only moved a scan from `stored` or `stopped` to `requested`:

```rust
self.scan_state.change_state(id, "stored", "requested").await?;
self.scan_state.change_state(id, "stopped", "requested").await?;
```

A scan that was interrupted sits in `failed`, and there are several ways to get there:

* `running_to_failed()` sets every scan that was still running to `failed` when openvasd starts, i.e. after a restart or a crash,
* starting the scan at the scanner failed,
* the results of a scan the scanner no longer knows were requested,
* the scanner reported the scan as failed.

In none of those cases is the scan running anywhere, so a client must be able to start it again. For gvmd such a scan is an interrupted task, and resuming that task is a start action on the scan. The action is accepted with `204`, the scheduler then changes nothing, and the scan never runs again — without a single line in the log to explain it.

## How to reproduce

With the released container image:

```
POST /scans, POST /scans/{id} {"action":"start"}   -> status running
docker restart openvasd                            -> status failed
POST /scans/{id} {"action":"start"}                -> HTTP 204, status stays failed forever
```

Log of the unpatched run:

```
WARN openvasd::scans::scheduling: Set scans to failed from previous runs. scans_failed=1
(then nothing at all for the start request)
```

With this change the same sequence continues the scan:

```
INFO openvasd::scans::scheduling: Started scan id=2 running=true
INFO openvasd::scans::scheduling: Scan is finished. internal_id=2 status=succeeded
```

## Notes

* `requested` and `running` are deliberately not startable, a scan that is already on its way must not be restarted. `succeeded` is left out as well, a finished scan is started as a new scan.
* The API description claimed that only a stored scan can be started, which was already wrong for `stopped` before this change. It now describes all three phases.
* The endpoint still answers `204` for a start that does not apply — the message is passed to the scheduler through a channel. The new warning at least makes it visible. The OpenAPI description documents a `409` for this case, which the endpoint never returns; that is left for a separate change, since clients retry start requests and would newly see errors.

## Testing

New regression test `start_interrupted_scan`: start scans, let the scheduler run them, call `running_to_failed()` to simulate the restart, then start them again and assert they are all `requested`. Without the change it fails with the interrupted scans stuck in `failed`.

```
cargo test --bin openvasd scans::scheduling
test result: ok. 7 passed; 0 failed
```

## Jira

Internal tracking Jira: SC-1711
