### PR TITLE
Fix: Skiron URL within openvasd and Rust NASL

### DIFF
--- a/doc/man/openvas.8.in
+++ b/doc/man/openvas.8.in
@@ -227,9 +227,9 @@ Password for authenticated MQTT communication.
 
 .IP openvasd_server
 Openvasd server URI to Rust implementation of Notus. It has priority over mqtt_server_uri setting. It is deprecated
-and will be removed in the next major release. Use notus_route instead.
+and will be removed in the next major release. Use notus_url instead.
 
-.IP notus_route
+.IP notus_url
 A route to a Notus endpoint. The value must conain a server uri, as well as the route to its notus endpoint.
 E.g. http://127.0.0.1:3000/notus
 

--- a/doc/man/openvas.8.in
+++ b/doc/man/openvas.8.in
@@ -230,7 +230,7 @@ Openvasd server URI to Rust implementation of Notus. It has priority over mqtt_s
 and will be removed in the next major release. Use notus_url instead.
 
 .IP notus_url
-A route to a Notus endpoint. The value must conain a server uri, as well as the route to its notus endpoint.
+A route to a Notus endpoint. The value must contain a server uri, as well as the route to its notus endpoint.
 E.g. http://127.0.0.1:3000/notus
 
 .IP x-apikey

--- a/doc/manual/openvas/openvas.md
+++ b/doc/manual/openvas/openvas.md
@@ -6,7 +6,7 @@ openvas - The Scanner of the Greenbone Vulnerability Management
 
 ## SYNOPSIS
 
-**openvas** \[ -V \] \[ -h \] \[ -c *config-file* \] \[\--scan-start *scan-uuid* \] \[-u\] \[-s\] \[-y\]
+**openvas** \[ -V \] \[ -h \] \[ -c _config-file_ \] \[\--scan-start _scan-uuid_ \] \[-u\] \[-s\] \[-y\]
 
 ## DESCRIPTION
 
@@ -25,93 +25,93 @@ to be placed and from where the results can be retrieved.
 
 ## OPTIONS
 
-**-c ***\<config-file\>***, \--config-file=***\<config-file\>*
+**-c \***\<config-file\>**_, \--config-file=_**\<config-file\>\*
 
-:   Use the alternate configuration file instead of *\@OPENVAS_CONF@*
+: Use the alternate configuration file instead of _\@OPENVAS_CONF@_
 
 **-V, \--version**
 
-:   Prints the version number and exits
+: Prints the version number and exits
 
 **-h, \--help**
 
-:   Show a summary of the commands
+: Show a summary of the commands
 
-**\--scan-start=***\<scan-uuid\>*
+**\--scan-start=\***\<scan-uuid\>\*
 
-:   ID for a single scan task. The scanner will start the scan with the
-    data already loaded in a redis KB, which will be found using the
-    given scan-id.
+: ID for a single scan task. The scanner will start the scan with the
+data already loaded in a redis KB, which will be found using the
+given scan-id.
 
-**\--scan-stop=***\<scan-uuid\>*
+**\--scan-stop=\***\<scan-uuid\>\*
 
-:   ID for a single scan task. The scanner will search the redis kb
-    associated to the given scan_id. It takes the pid from the kb and
-    sends the SIGUSR1 kill signal to stop the scan.
+: ID for a single scan task. The scanner will search the redis kb
+associated to the given scan_id. It takes the pid from the kb and
+sends the SIGUSR1 kill signal to stop the scan.
 
 **-u, \--update-vt-info**
 
-:   Updates VT info into redis store from VT files.
+: Updates VT info into redis store from VT files.
 
 ## THE CONFIGURATION FILE
 
-The default **openvas** configuration file, *\@OPENVAS_CONF@* contains
+The default **openvas** configuration file, _\@OPENVAS_CONF@_ contains
 these options:
 
 plugins_folder
 
-:   Contains the location of the plugins folder. This is usually
-    \@OPENVAS_NVT_DIR@, but you may change this.
+: Contains the location of the plugins folder. This is usually
+\@OPENVAS_NVT_DIR@, but you may change this.
 
 include_folders
 
-:   Contains the location of the include file folder. This is usually
-    \@OPENVAS_NVT_DIR@, but you may change this.
+: Contains the location of the include file folder. This is usually
+\@OPENVAS_NVT_DIR@, but you may change this.
 
 max_hosts
 
-:   is maximum number of hosts to test at the same time which should be
-    given to the client (which can override it). This value must be
-    computed given your bandwidth, the number of hosts you want to test,
-    your amount of memory and the horsepower of your processor(s).
+: is maximum number of hosts to test at the same time which should be
+given to the client (which can override it). This value must be
+computed given your bandwidth, the number of hosts you want to test,
+your amount of memory and the horsepower of your processor(s).
 
 max_checks
 
-:   is the number of plugins that will run against each host being
-    tested. Note that the total number of process will be *max_checks* x
-    *max_hosts* so you need to find a balance between these two options.
-    Note that launching too many plugins at the same time may disable
-    the remote host, either temporarily (ie: inetd closes its ports) or
-    definitely (the remote host crash because it is asked to do too many
-    things at the same time), so be careful.
+: is the number of plugins that will run against each host being
+tested. Note that the total number of process will be _max_checks_ x
+_max_hosts_ so you need to find a balance between these two options.
+Note that launching too many plugins at the same time may disable
+the remote host, either temporarily (ie: inetd closes its ports) or
+definitely (the remote host crash because it is asked to do too many
+things at the same time), so be careful.
 
 log_whole_attack
 
-:   If this option is set to \'yes\', openvas will store the name, pid,
-    date and target of each plugin launched. This is helpful for
-    monitoring and debugging purpose, however this option might make
-    openvas fill your disk rather quickly.
+: If this option is set to \'yes\', openvas will store the name, pid,
+date and target of each plugin launched. This is helpful for
+monitoring and debugging purpose, however this option might make
+openvas fill your disk rather quickly.
 
 db_address
 
-:   Path to the redis socket where the plugins cache and knowledge
-    bases are stored.
+: Path to the redis socket where the plugins cache and knowledge
+bases are stored.
 
 report_scripts
 
-:   Stores in a file the script run duration in json format. This
-    option expects a valid path to store a file with scripts stats.
-    Script run durations are collected only if the log_whole_attack
-    setting is set to 'yes'. This is helpful for monitoring and
-    debugging purpose, however this option might make openvas fill
-    your disk rather quickly.
+: Stores in a file the script run duration in json format. This
+option expects a valid path to store a file with scripts stats.
+Script run durations are collected only if the log_whole_attack
+setting is set to 'yes'. This is helpful for monitoring and
+debugging purpose, however this option might make openvas fill
+your disk rather quickly.
 
 debug_tls
 
-:   This is an scanner-only option which allows you to set the TLS log
-    level. The level is an integer between 0 and 9. Higher values mean
-    more verbosity and might make openvas fill your disk rather quickly.
-    The default value is 0 (disabled).
+: This is an scanner-only option which allows you to set the TLS log
+level. The level is an integer between 0 and 9. Higher values mean
+more verbosity and might make openvas fill your disk rather quickly.
+The default value is 0 (disabled).
 
 Larger values should only be used with care, since they may reveal
 sensitive information in the scanner logs.
@@ -120,280 +120,280 @@ Use a debug level over 10 to enable all debugging options.
 
 log_plugins_name_at_load
 
-:   If this option is set to \'yes\', openvas will log the name of each
-    plugin being loaded at startup, or each time it receives the HUP
-    signal.
+: If this option is set to \'yes\', openvas will log the name of each
+plugin being loaded at startup, or each time it receives the HUP
+signal.
 
 cgi_path
 
-:   By default, openvas looks for default CGIs in /cgi-bin and /scripts.
-    You may change these to something else to reflect the policy of your
-    site. The syntax of this option is the same as the shell \$PATH
-    variable: path1:path2:\...
+: By default, openvas looks for default CGIs in /cgi-bin and /scripts.
+You may change these to something else to reflect the policy of your
+site. The syntax of this option is the same as the shell \$PATH
+variable: path1:path2:\...
 
 port_range
 
-:   This is the default range of ports that the scanner plugins will
-    probe. The syntax of this option is flexible, it can be a single
-    range (\"1-1500\"), several ports (\"21,23,80\"), several ranges of
-    ports (\"1-1500,32000-33000\"). Note that you can specify UDP and
-    TCP ports by prefixing each range by T or U. For instance, the
-    following range will make openvas scan UDP ports 1 to 1024 and TCP
-    ports 1 to 65535 : \"T:1-65535,U:1-1024\".
+: This is the default range of ports that the scanner plugins will
+probe. The syntax of this option is flexible, it can be a single
+range (\"1-1500\"), several ports (\"21,23,80\"), several ranges of
+ports (\"1-1500,32000-33000\"). Note that you can specify UDP and
+TCP ports by prefixing each range by T or U. For instance, the
+following range will make openvas scan UDP ports 1 to 1024 and TCP
+ports 1 to 65535 : \"T:1-65535,U:1-1024\".
 
 test_alive_hosts_only
 
-:   If this option is set to \'yes\', openvas will scan the target list
-    for alive hosts in a separate process while only testing those hosts
-    which are identified as alive. This boosts the scan speed of target
-    ranges with a high amount of dead hosts significantly.
+: If this option is set to \'yes\', openvas will scan the target list
+for alive hosts in a separate process while only testing those hosts
+which are identified as alive. This boosts the scan speed of target
+ranges with a high amount of dead hosts significantly.
 
 alive_test_ports
 
-:   Preference to set the port list for the TCP SYN and TCP ACK alive test
-    methods. This setting overwrites the default port list:
-    "21-23,25,53,80,110-111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080".
+: Preference to set the port list for the TCP SYN and TCP ACK alive test
+methods. This setting overwrites the default port list:
+"21-23,25,53,80,110-111,135,139,143,443,445,993,995,1723,3306,3389,5900,8080".
 
 test_alive_wait_timeout
 
-:   This option is to set how long (in sec) Boreas (alive test) waits for
-    replies after last packet was sent. Default: 3 seconds.
+: This option is to set how long (in sec) Boreas (alive test) waits for
+replies after last packet was sent. Default: 3 seconds.
 
 icmp_retries
 
-:   This is the default amount of icmp packets that will be sent to
-    the host target during an alive test. Defaults to 1.
+: This is the default amount of icmp packets that will be sent to
+the host target during an alive test. Defaults to 1.
 
 icmp_grace_period
 
-:   Wait time between icmp packets during alive tests. Useful for
-    sensitive targets. It can slow down the alive test.
+: Wait time between icmp packets during alive tests. Useful for
+sensitive targets. It can slow down the alive test.
 
 optimize_test
 
-:   By default, optimize_test is enabled which means openvas does trust
-    the remote host banners and is only launching plugins against the
-    services they have been designed to check. For example it will check
-    a web server claiming to be IIS only for IIS related flaws but will
-    skip plugins testing for Apache flaws, and so on. This default
-    behavior is used to optimize the scanning performance and to avoid
-    false positives. If you are not sure that the banners of the remote
-    host have been tampered with, you can disable this option.
+: By default, optimize_test is enabled which means openvas does trust
+the remote host banners and is only launching plugins against the
+services they have been designed to check. For example it will check
+a web server claiming to be IIS only for IIS related flaws but will
+skip plugins testing for Apache flaws, and so on. This default
+behavior is used to optimize the scanning performance and to avoid
+false positives. If you are not sure that the banners of the remote
+host have been tampered with, you can disable this option.
 
 optimization_level
 
-:   Level of test optimization. It checks if plugins requirement are
-    met. Level=1 checks only that required ports are open, level=2
-    checks open ports and keys requirements are met, else checks also
-    if excluded keys are present or not. Default: no optimization,
-    check everything.
+: Level of test optimization. It checks if plugins requirement are
+met. Level=1 checks only that required ports are open, level=2
+checks open ports and keys requirements are met, else checks also
+if excluded keys are present or not. Default: no optimization,
+check everything.
 
 test_empty_vhost
 
-:   If set to yes, the scanner will also test the target by using empty
-    vhost value in addition to the target\'s associated vhost values.
+: If set to yes, the scanner will also test the target by using empty
+vhost value in addition to the target\'s associated vhost values.
 
 checks_read_timeout
 
-:   Number of seconds that the security checks will wait for when doing
-    a recv(). You should increase this value if you are running openvas
-    across a slow network link (testing a host via a dialup connection
-    for instance).
+: Number of seconds that the security checks will wait for when doing
+a recv(). You should increase this value if you are running openvas
+across a slow network link (testing a host via a dialup connection
+for instance).
 
 timeout_retry
 
-:   Number of retries when a socket connection attempt times out.
+: Number of retries when a socket connection attempt times out.
 
 open_sock_max_attempts
 
-:   When a port is found as opened at the beginning of the scan, and for
-    some reason the status changes to filtered/closed, it will not be
-    possible to open a socket. This is the number of unsuccessful
-    retries to open the socket before to set the port as closed. This
-    avoids to launch plugins which need the opened port as a mandatory
-    key, therefore it avoids an overlong scan duration. If the set value
-    is 0 or a negative value, this option is disabled. It should be take
-    in account that one unsuccessful attempt needs the number of retries
-    set in \"timeout_retry\".
+: When a port is found as opened at the beginning of the scan, and for
+some reason the status changes to filtered/closed, it will not be
+possible to open a socket. This is the number of unsuccessful
+retries to open the socket before to set the port as closed. This
+avoids to launch plugins which need the opened port as a mandatory
+key, therefore it avoids an overlong scan duration. If the set value
+is 0 or a negative value, this option is disabled. It should be take
+in account that one unsuccessful attempt needs the number of retries
+set in \"timeout_retry\".
 
 time_between_request
 
-:   Some devices do not appreciate quick connection establishment and
-    termination neither quick request. This option allows you to set a
-    wait time between two actions like to open a tcp socket, to send a
-    request through the open tcp socket, and to close the tcp socket.
-    This value should be given in milliseconds. If the set value is 0
-    (default value), this option is disabled and there is no wait time
-    between requests.
+: Some devices do not appreciate quick connection establishment and
+termination neither quick request. This option allows you to set a
+wait time between two actions like to open a tcp socket, to send a
+request through the open tcp socket, and to close the tcp socket.
+This value should be given in milliseconds. If the set value is 0
+(default value), this option is disabled and there is no wait time
+between requests.
 
 expand_vhosts
 
-:   Whether to expand the target host\'s list of vhosts with values
-    gathered from sources such as reverse-lookup queries and VT checks
-    for SSL/TLS certificates.
+: Whether to expand the target host\'s list of vhosts with values
+gathered from sources such as reverse-lookup queries and VT checks
+for SSL/TLS certificates.
 
 non_simult_ports
 
-:   Some services (in particular SMB) do not appreciate multiple
-    connections at the same time coming from the same host. This option
-    allows you to prevent openvas to make two connections on the same
-    given ports at the same time. The syntax of this option is
-    \"port1\[, port2\...\]\". Note that you can use the KB notation of
-    openvas to designate a service formally. Ex: \"139, Services/www\",
-    will prevent openvas from making two connections at the same time on
-    port 139 and on every port which hosts a web server.
+: Some services (in particular SMB) do not appreciate multiple
+connections at the same time coming from the same host. This option
+allows you to prevent openvas to make two connections on the same
+given ports at the same time. The syntax of this option is
+\"port1\[, port2\...\]\". Note that you can use the KB notation of
+openvas to designate a service formally. Ex: \"139, Services/www\",
+will prevent openvas from making two connections at the same time on
+port 139 and on every port which hosts a web server.
 
 allow_simultaneous_ips
 
-:   If set to no, this option prevent openvas to scan more than one
-    different IPs (e.g. the IPv4 and IPv6 addresses) which belong to the
-    same host at the same time. Default, yes.
+: If set to no, this option prevent openvas to scan more than one
+different IPs (e.g. the IPv4 and IPv6 addresses) which belong to the
+same host at the same time. Default, yes.
 
 plugins_timeout
 
-:   This is the maximum lifetime, in seconds of a plugin. It may happen
-    that some plugins are slow because of the way they are written or
-    the way the remote server behaves. This option allows you to make
-    sure your scan is never caught in an endless loop because of a
-    non-finishing plugin. Doesn\'t affect ACT_SCANNER plugins.
+: This is the maximum lifetime, in seconds of a plugin. It may happen
+that some plugins are slow because of the way they are written or
+the way the remote server behaves. This option allows you to make
+sure your scan is never caught in an endless loop because of a
+non-finishing plugin. Doesn\'t affect ACT_SCANNER plugins.
 
 scanner_plugins_timeout
 
-:   Like plugins_timeout, but for ACT_SCANNER plugins.
+: Like plugins_timeout, but for ACT_SCANNER plugins.
 
 max_vts_timeouts
 
-:   During a scan it might happen that a host unexpectedly shuts down, a
-    firewall blocks the traffic, a network device issue break the
-    connection, etc. This leads to many NVT timeouts and long scan
-    durations. This option checks the alive status of the host again
-    after the provided amount of max NVT timeouts are reached. If the
-    host is considered dead the scan will be stopped for this host.
-    Otherwise the scan will continue. This option requires Boreas alive
-    test to be enabled. Default: option not set, disabled.
+: During a scan it might happen that a host unexpectedly shuts down, a
+firewall blocks the traffic, a network device issue break the
+connection, etc. This leads to many NVT timeouts and long scan
+durations. This option checks the alive status of the host again
+after the provided amount of max NVT timeouts are reached. If the
+host is considered dead the scan will be stopped for this host.
+Otherwise the scan will continue. This option requires Boreas alive
+test to be enabled. Default: option not set, disabled.
 
 safe_checks
 
-:   Most of the time, openvas attempts to reproduce an exceptional
-    condition to determine if the remote services are vulnerable to
-    certain flaws. This includes the reproduction of buffer overflows or
-    format strings, which may make the remote server crash. If you set
-    this option to \'yes\', openvas will disable the plugins which have
-    the potential to crash the remote services, and will at the same
-    time make several checks rely on the banner of the service tested
-    instead of its behavior towards a certain input. This reduces false
-    positives and makes openvas nicer towards your network, however this
-    may make you miss important vulnerabilities (as a vulnerability
-    affecting a given service may also affect another one).
+: Most of the time, openvas attempts to reproduce an exceptional
+condition to determine if the remote services are vulnerable to
+certain flaws. This includes the reproduction of buffer overflows or
+format strings, which may make the remote server crash. If you set
+this option to \'yes\', openvas will disable the plugins which have
+the potential to crash the remote services, and will at the same
+time make several checks rely on the banner of the service tested
+instead of its behavior towards a certain input. This reduces false
+positives and makes openvas nicer towards your network, however this
+may make you miss important vulnerabilities (as a vulnerability
+affecting a given service may also affect another one).
 
 auto_enable_dependencies
 
-:   OpenVAS plugins use the result of each other to execute their job.
-    For instance, a plugin which logs into the remote SMB registry will
-    need the results of the plugin which finds the SMB name of the
-    remote host and the results of the plugin which attempts to log into
-    the remote host. If you want to only select a subset of the plugins
-    available, tracking the dependencies can quickly become tiresome. If
-    you set this option to \'yes\', openvas will automatically enable
-    the plugins that are depended on.
+: OpenVAS plugins use the result of each other to execute their job.
+For instance, a plugin which logs into the remote SMB registry will
+need the results of the plugin which finds the SMB name of the
+remote host and the results of the plugin which attempts to log into
+the remote host. If you want to only select a subset of the plugins
+available, tracking the dependencies can quickly become tiresome. If
+you set this option to \'yes\', openvas will automatically enable
+the plugins that are depended on.
 
 hosts_allow
 
-:   Comma-separated list of the only targets that are authorized to be
-    scanned. Supports the same syntax as the list targets. Both target
-    hostnames and the address to which they resolve are checked.
-    Hostnames in hosts_allow list are not resolved however.
+: Comma-separated list of the only targets that are authorized to be
+scanned. Supports the same syntax as the list targets. Both target
+hostnames and the address to which they resolve are checked.
+Hostnames in hosts_allow list are not resolved however.
 
 hosts_deny
 
-:   Comma-separated list of targets that are not authorized to be
-    scanned. Supports the same syntax as the list targets. Both target
-    hostnames and the address to which they resolve are checked.
-    Hostnames in hosts_deny list are not resolved however.
+: Comma-separated list of targets that are not authorized to be
+scanned. Supports the same syntax as the list targets. Both target
+hostnames and the address to which they resolve are checked.
+Hostnames in hosts_deny list are not resolved however.
 
 sys_hosts_allow
 
-:   Like hosts_allow. Can\'t be overridden by the client.
+: Like hosts_allow. Can\'t be overridden by the client.
 
 sys_hosts_deny
 
-:   Like hosts_deny. Can\'t be overridden by the client.
+: Like hosts_deny. Can\'t be overridden by the client.
 
 max_sysload
 
-:   Maximum load on the system. Once this load is reached, no further
-    VTs are started until the load drops below this value again.
+: Maximum load on the system. Once this load is reached, no further
+VTs are started until the load drops below this value again.
 
 min_free_mem
 
-:   Minimum available memory (in MB) which should be kept free on the
-    system. Once this limit is reached, no further VTs are started until
-    sufficient memory is available again.
+: Minimum available memory (in MB) which should be kept free on the
+system. Once this limit is reached, no further VTs are started until
+sufficient memory is available again.
 
 max_mem_kb
 
-:   Maximum amount of memory (in MB) allowed to use for a single script.
-    If this value is set, the amount of memory put into redis is tracked
-    for every Script. If the amount of memory exceeds this limit, the
-    script is not able to set more kb items. The tracked the value
-    written into redis is only estimated, as it does not check, if a
-    value was replaced or appended. The size of the key is also not
-    tracked. If this value is not set or <= 0, the maximum amount is
-    unlimited (Default).
+: Maximum amount of memory (in MB) allowed to use for a single script.
+If this value is set, the amount of memory put into redis is tracked
+for every Script. If the amount of memory exceeds this limit, the
+script is not able to set more kb items. The tracked the value
+written into redis is only estimated, as it does not check, if a
+value was replaced or appended. The size of the key is also not
+tracked. If this value is not set or <= 0, the maximum amount is
+unlimited (Default).
 
 unscanned_closed
 
-:   This defines whether TCP ports that were not scanned should be treated like closed ports.
-    Defaults to "yes".
+: This defines whether TCP ports that were not scanned should be treated like closed ports.
+Defaults to "yes".
 
 unscanned_closed_udp
 
-:   This defines whether UDP ports that were not scanned should be treated as closed ports.
-    Defaults to "yes".
+: This defines whether UDP ports that were not scanned should be treated as closed ports.
+Defaults to "yes".
 
 table_driven_lsc
 
-:   This option will enable table driven local security Checks (LSC). This means
-    gathered packages are sent to a specialized scanner. This is far more efficient than doing
-    checks via NASL.
-    Defaults to "yes".
+: This option will enable table driven local security Checks (LSC). This means
+gathered packages are sent to a specialized scanner. This is far more efficient than doing
+checks via NASL.
+Defaults to "yes".
 
 mqtt_server_uri
 
-:   URI to the MQTT server used for internal communication with Notus
-    (table driven LSC). This implementation of Notus is in python and
-    it is deprecated, being replaced with a Rust implementation of
-    Notus.
+: URI to the MQTT server used for internal communication with Notus
+(table driven LSC). This implementation of Notus is in python and
+it is deprecated, being replaced with a Rust implementation of
+Notus.
 
 mqtt_user
 
-:   Username for authenticated MQTT communication.
+: Username for authenticated MQTT communication.
 
 mqtt_pass
 
-:   Password for authenticated MQTT communication The other options in
-    this file can usually be redefined by the client.
+: Password for authenticated MQTT communication The other options in
+this file can usually be redefined by the client.
 
 openvasd_server
 
-:   Openvasd server URI to Rust implementation of Notus. It has
-    priority over MQTT settings. It is deprecated and will be removed
-    in the next major release. Use notus_route instead.
+: Openvasd server URI to Rust implementation of Notus. It has
+priority over MQTT settings. It is deprecated and will be removed
+in the next major release. Use notus_url instead.
 
-IP notus_route
-:   A route to a Notus endpoint. The value must conain a server uri,
-    as well as the route to its notus endpoint.
-    E.g. http://127.0.0.1:3000/notus
+IP notus_url
+: A route to a Notus endpoint. The value must conain a server uri,
+as well as the route to its notus endpoint.
+E.g. http://127.0.0.1:3000/notus
 
 x-apikey
 
-:   API Key for authenticate against openvasd when Notus Rust
-    implementation is enabled.
+: API Key for authenticate against openvasd when Notus Rust
+implementation is enabled.
 
 nasl_no_signature_check
 
-:   Enable/disable the Feed signacture check. Pay attention to the
-    negative logic of this setting.
+: Enable/disable the Feed signacture check. Pay attention to the
+negative logic of this setting.
 
 The other options in this file can usually be redefined by the client.
 
@@ -406,55 +406,55 @@ received in TCP connections, etc.) so bandwidth use should always be
 closely monitored, with current server hardware, bandwidth is usually
 the bottleneck in a OpenVAS scan. It might not became too apparent in
 the final reports, scanners will still run, holes might be detected, but
-you will risk to run into *false negatives* (i.e. OpenVAS will not
+you will risk to run into _false negatives_ (i.e. OpenVAS will not
 report a security hole that is present in a remote host)
 
 Users might need to tune OpenVAS configuration if running the scanner in
-low bandwidth conditions (*low* being \'less bandwidth that the one your
+low bandwidth conditions (_low_ being \'less bandwidth that the one your
 hardware system can produce) or otherwise will get erratic results.
 There are several parameters that can be modified to reduce network
 load:
 
 checks_read_timeout
 
-:   The default value is set to 5 seconds, that can (should) be
-    increased if network bandwidth is low in the openvas.conf or
-    openvasrc configuration files. Notice that it is recommended to
-    increase this this value, if you are running a test outside your LAN
-    (i.e. to Internet hosts through an Internet connection), to over 10
-    seconds.
+: The default value is set to 5 seconds, that can (should) be
+increased if network bandwidth is low in the openvas.conf or
+openvasrc configuration files. Notice that it is recommended to
+increase this this value, if you are running a test outside your LAN
+(i.e. to Internet hosts through an Internet connection), to over 10
+seconds.
 
 max_hosts
 
-:   Number of hosts to test at the same time. It can be as low as you
-    want it to be (obviously 1 is the minimum)
+: Number of hosts to test at the same time. It can be as low as you
+want it to be (obviously 1 is the minimum)
 
 max_checks
 
-:   Number of checks to test at the same time it can be as low as you
-    want it to be and it will also reduce network load and improve
-    performance (obviously 1 is the minimum) Notice that OpenVAS will
-    spawn max_hosts \* max_checks processes.
+: Number of checks to test at the same time it can be as low as you
+want it to be and it will also reduce network load and improve
+performance (obviously 1 is the minimum) Notice that OpenVAS will
+spawn max_hosts \* max_checks processes.
 
 drop_privileges
 
-:   If this preference is set to \'yes\', OpenVAS will attempt to drop
-    its root privilege before launching any VT and the new process owner
-    is \'nobody\'; the default value of this preference is \'no\',
-    meaning no change in behaviour.
+: If this preference is set to \'yes\', OpenVAS will attempt to drop
+its root privilege before launching any VT and the new process owner
+is \'nobody\'; the default value of this preference is \'no\',
+meaning no change in behaviour.
 
 nasl_drop_privileges_user
 
-:   If a user is set, NASL functions can use this user to drop its root
-    privilege. The new process owner is set only for those process
-    calling a nasl function which supports a drop privileges action.
-    This preference must not be mixed with \'drop_privileges\'. If
-    \'drop_privileges\' is enabled, this option should not be used, as
-    \'drop_privileges\' sets the owner to \'nobody\'
+: If a user is set, NASL functions can use this user to drop its root
+privilege. The new process owner is set only for those process
+calling a nasl function which supports a drop privileges action.
+This preference must not be mixed with \'drop_privileges\'. If
+\'drop_privileges\' is enabled, this option should not be used, as
+\'drop_privileges\' sets the owner to \'nobody\'
 
 vendor_version
 
-:   Use the alternate vendor instead of the default one during scans.
+: Use the alternate vendor instead of the default one during scans.
 
 Other options might be using the QoS features offered by your server
 operating system or your network to improve the bandwidth use.

--- a/misc/table_driven_lsc.c
+++ b/misc/table_driven_lsc.c
@@ -1027,7 +1027,7 @@ lsc_get_response (const char *pkg_list, const char *os)
 
   // Parse the server and get the port, host, schema
   // and necessary information to build the message
-  server = prefs_get ("notus_route");
+  server = prefs_get ("notus_url");
   notusdata = init_notus_info (server);
 
   if (parse_server (&notusdata) < 0)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4986,6 +4986,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "url",
  "urlencoding",
  "uuid",
  "vergen-git2",
@@ -6406,6 +6407,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,8 +78,8 @@ pnet_base = { version = "0.35.0" }
 pnet_macros = { version = "0.35.0" }
 pnet_macros_support = { version = "0.35.0" }
 quick-xml = { version = "0.40.1", features = [
-    "serde", 
-    "serde-types", 
+    "serde",
+    "serde-types",
     "serialize",
 ] }
 rand = "0.10.1"
@@ -103,6 +103,7 @@ sqlx = { version = "0", features = ["sqlite", "runtime-tokio-rustls"] }
 sysinfo = "0.39.5"
 tempfile = "3.27.0"
 toml = "1.1.2"
+url = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1.3"
 walkdir = "2"
 x509-certificate = "0.25.0"
@@ -124,10 +125,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 uuid = { workspace = true }
 once_cell = { workspace = true }
-libssh-rs = { version = "0.3.6", features = [
-    "vendored-openssl",
-    "vendored",
-] }
+libssh-rs = { version = "0.3.6", features = ["vendored-openssl", "vendored"] }
 
 nasl-function-proc-macro = { path = "crates/nasl-function-proc-macro" }
 greenbone-scanner-framework = { path = "crates/greenbone-scanner-framework" }

--- a/rust/examples/notus.nasl
+++ b/rust/examples/notus.nasl
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+pkg_list = "libc6-1.28-10+deb10u2, libc-dev-bin-2.28-10+deb10u2";
+
+results = notus(product: "debian_10", pkg_list: pkg_list);
+
+if(!isnull(results)) {
+    foreach res (results) {
+        oid = res["oid"];
+        msg = res["message"];
+        display(oid);
+        display(msg);
+    }
+} else {
+    ret = notus_error();
+    display(ret);
+}

--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -18,8 +18,9 @@ check_interval = "3600s"
 products_path = "/var/lib/notus/products/"
 # path to the notus advisories feed. This is required for the /vts endpoint
 advisories_path = "/var/lib/notus/advisories/"
-# Address to reach notus on. If not set, internal notus implementation is used.
-# address = "127.0.0.1:3001"
+# URL to reach notus on, including the endpoint path. If not set, internal notus
+# implementation is used.
+# route = "http://127.0.0.1:3001/notus"
 
 [endpoints]
 # Enables GET /scans endpoint

--- a/rust/examples/openvasd/config.example.toml
+++ b/rust/examples/openvasd/config.example.toml
@@ -18,9 +18,8 @@ check_interval = "3600s"
 products_path = "/var/lib/notus/products/"
 # path to the notus advisories feed. This is required for the /vts endpoint
 advisories_path = "/var/lib/notus/advisories/"
-# URL to reach notus on, including the endpoint path. If not set, internal notus
-# implementation is used.
-# route = "http://127.0.0.1:3001/notus"
+# The URL to the Notus endpoint of a Skiron service
+# url = "http://127.0.0.1:8085/skiron/v2/api/scanNotus"
 
 [endpoints]
 # Enables GET /scans endpoint

--- a/rust/src/nasl/builtin/notus/mod.rs
+++ b/rust/src/nasl/builtin/notus/mod.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests;
 
-use std::{collections::HashMap, net::SocketAddr};
+use std::collections::HashMap;
 
 use greenbone_scanner_framework::models::FixedVersion;
 use http::StatusCode;
@@ -58,15 +58,16 @@ impl NaslNotus {
 
     async fn notus_extern(
         &self,
-        addr: &SocketAddr,
+        addr: &url::Url,
         pkg_list: &[String],
         product: &str,
     ) -> Result<NaslValue, FnError> {
         let pkg_json = serde_json::to_string(pkg_list)
             .map_err(|e| FnError::wrong_unnamed_argument("pkg_list", &e.to_string()))?;
 
-        // TODO: Currently we only support http
-        let url = format!("http://{}/notus/{}", addr, product);
+        // `addr` is the full endpoint URL (including scheme and path), the
+        // product is appended as the last path segment.
+        let url = format!("{}/{}", addr.as_str().trim_end_matches('/'), product);
 
         let client = reqwest::Client::new();
         let response = client
@@ -79,8 +80,9 @@ impl NaslNotus {
 
         if response.status() != StatusCode::OK {
             return Err(HttpError::Custom(format!(
-                "Notus service returned status code {}",
-                response.status()
+                "Notus service returned status code {} for URL {}",
+                response.status(),
+                url
             ))
             .into());
         }

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -274,8 +274,8 @@ impl<T> ContextStorage for T where
 #[derive(Clone)]
 pub enum NotusCtx {
     Direct(Arc<Mutex<Notus>>),
-    /// Full URL to reach notus on, including the endpoint path
-    /// (e.g. `http://127.0.0.1:3001/notus`).
+    /// The URL to the Notus endpoint of a Skiron service
+    ///(e.g. `http://127.0.0.1:8085/skiron/v2/api/scanNotus`).
     Address(url::Url),
 }
 

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -31,7 +31,7 @@ use super::error::ReturnBehavior;
 use super::executor::Executor;
 use super::hosts::{LOCALHOST, resolve_hostname};
 use super::{FnError, Register};
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -274,7 +274,9 @@ impl<T> ContextStorage for T where
 #[derive(Clone)]
 pub enum NotusCtx {
     Direct(Arc<Mutex<Notus>>),
-    Address(SocketAddr),
+    /// Full URL to reach notus on, including the endpoint path
+    /// (e.g. `http://127.0.0.1:3001/notus`).
+    Address(url::Url),
 }
 
 /// NASL execution context.

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -42,7 +42,10 @@ pub struct Feed {
 pub struct Notus {
     pub products_path: PathBuf,
     pub advisories_path: PathBuf,
-    pub address: Option<SocketAddr>,
+    /// Full URL to reach notus on, including the endpoint path
+    /// (e.g. `http://127.0.0.1:3001/notus`). If not set, the internal notus
+    /// implementation is used.
+    pub route: Option<url::Url>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -126,7 +129,7 @@ impl Default for Notus {
         Notus {
             products_path: PathBuf::from("/var/lib/notus/products"),
             advisories_path: PathBuf::from("/var/lib/notus/advisories"),
-            address: None,
+            route: None,
         }
     }
 }
@@ -450,10 +453,10 @@ impl Config {
                 clap::Arg::new("notus-address")
                     .env("NOTUS_ADDRESS")
                     .long("notus-address")
-                    .value_name("IP:PORT")
-                    .value_parser(clap::value_parser!(SocketAddr))
+                    .value_name("URL")
+                    .value_parser(clap::value_parser!(url::Url))
                     .action(ArgAction::Set)
-                    .help("the address to reach notus on"))
+                    .help("the URL to reach notus on, including the endpoint path (e.g. http://127.0.0.1:3001/notus)"))
             .arg(
                 clap::Arg::new("redis-url")
                     .long("redis-url")
@@ -691,8 +694,8 @@ impl Config {
         if let Some(path) = cmds.get_one::<PathBuf>("notus-advisories") {
             config.notus.advisories_path.clone_from(path);
         }
-        if let Some(address) = cmds.get_one::<SocketAddr>("notus-address") {
-            config.notus.address = Some(*address);
+        if let Some(address) = cmds.get_one::<url::Url>("notus-address") {
+            config.notus.route = Some(address.clone());
         }
         if let Some(_path) = cmds.get_one::<String>("redis-url") {
             // is actually ignored as on scanner openvas the redis-url of openvas is used

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -42,10 +42,8 @@ pub struct Feed {
 pub struct Notus {
     pub products_path: PathBuf,
     pub advisories_path: PathBuf,
-    /// Full URL to reach notus on, including the endpoint path
-    /// (e.g. `http://127.0.0.1:3001/notus`). If not set, the internal notus
-    /// implementation is used.
-    pub route: Option<url::Url>,
+    /// The URL to the Notus endpoint of a Skiron service (e.g. http://127.0.0.1:8085/skiron/v2/api/scanNotus)
+    pub url: Option<url::Url>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -129,7 +127,7 @@ impl Default for Notus {
         Notus {
             products_path: PathBuf::from("/var/lib/notus/products"),
             advisories_path: PathBuf::from("/var/lib/notus/advisories"),
-            route: None,
+            url: None,
         }
     }
 }
@@ -450,13 +448,13 @@ impl Config {
                     .action(ArgAction::Set)
                     .help("Path containing the Notus products directory"))
             .arg(
-                clap::Arg::new("notus-address")
-                    .env("NOTUS_ADDRESS")
-                    .long("notus-address")
+                clap::Arg::new("notus-url")
+                    .env("NOTUS_URL")
+                    .long("notus-url")
                     .value_name("URL")
                     .value_parser(clap::value_parser!(url::Url))
                     .action(ArgAction::Set)
-                    .help("the URL to reach notus on, including the endpoint path (e.g. http://127.0.0.1:3001/notus)"))
+                    .help("The URL to the Notus endpoint of a Skiron service (e.g. http://127.0.0.1:8085/skiron/v2/api/scanNotus)"))
             .arg(
                 clap::Arg::new("redis-url")
                     .long("redis-url")
@@ -694,8 +692,8 @@ impl Config {
         if let Some(path) = cmds.get_one::<PathBuf>("notus-advisories") {
             config.notus.advisories_path.clone_from(path);
         }
-        if let Some(address) = cmds.get_one::<url::Url>("notus-address") {
-            config.notus.route = Some(address.clone());
+        if let Some(url) = cmds.get_one::<url::Url>("notus-url") {
+            config.notus.url = Some(url.clone());
         }
         if let Some(_path) = cmds.get_one::<String>("redis-url") {
             // is actually ignored as on scanner openvas the redis-url of openvas is used

--- a/rust/src/openvasd/notus/mod.rs
+++ b/rust/src/openvasd/notus/mod.rs
@@ -164,7 +164,7 @@ mod tests {
         let notus = crate::config::Notus {
             advisories_path,
             products_path,
-            address: None,
+            route: None,
         };
 
         Config {

--- a/rust/src/openvasd/notus/mod.rs
+++ b/rust/src/openvasd/notus/mod.rs
@@ -164,7 +164,7 @@ mod tests {
         let notus = crate::config::Notus {
             advisories_path,
             products_path,
-            route: None,
+            url: None,
         };
 
         Config {

--- a/rust/src/openvasd/scans/mod.rs
+++ b/rust/src/openvasd/scans/mod.rs
@@ -523,7 +523,7 @@ pub mod tests {
         let notus = crate::config::Notus {
             advisories_path,
             products_path,
-            address: None,
+            route: None,
         };
         let scanner = crate::config::Scanner {
             scanner_type: ScannerType::Openvasd,

--- a/rust/src/openvasd/scans/mod.rs
+++ b/rust/src/openvasd/scans/mod.rs
@@ -523,7 +523,7 @@ pub mod tests {
         let notus = crate::config::Notus {
             advisories_path,
             products_path,
-            route: None,
+            url: None,
         };
         let scanner = crate::config::Scanner {
             scanner_type: ScannerType::Openvasd,

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -622,7 +622,8 @@ where
             let executor = nasl_std_executor();
             let notus = config
                 .notus
-                .address
+                .route
+                .clone()
                 .map(scannerlib::nasl::utils::scan_ctx::NotusCtx::Address);
             let storage = ScanStorage::new(pool.clone());
             let scanner = OpenvasdScanner::new(storage, loader, executor, notus);

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -622,7 +622,7 @@ where
             let executor = nasl_std_executor();
             let notus = config
                 .notus
-                .route
+                .url
                 .clone()
                 .map(scannerlib::nasl::utils::scan_ctx::NotusCtx::Address);
             let storage = ScanStorage::new(pool.clone());

--- a/rust/src/scannerctl/execute/mod.rs
+++ b/rust/src/scannerctl/execute/mod.rs
@@ -58,11 +58,11 @@ struct ScriptArgs {
     timeout: Option<u32>,
     #[clap(long = "vendor")]
     vendor_version: Option<String>,
-    /// Notus configuration. Use "<URL>" to connect to a running Notus
+    /// Notus configuration. Use "<URL>" to connect to a running Skiron
     /// instance or "<PATH>" to product files to use the internal
     /// implementation. If not given Notus will be disabled.
-    #[clap(short, long = "notus")]
-    notus: Option<NotusArgs>,
+    #[clap(short, long = "notus-url")]
+    notus_url: Option<NotusArgs>,
 }
 
 #[derive(clap::Parser)]
@@ -77,10 +77,10 @@ struct ScanArgs {
     /// Target to scan.
     #[clap(short, long)]
     target: Option<String>,
-    /// Notus configuration. Use "<URL>" to connect to a running Notus
-    /// instance or "<PATH>" to product files to use the internal
-    /// implementation. If not given Notus will be disabled.
-    #[clap(short, long = "notus")]
+    /// Notus configuration. Use "<URL>" to connect to a Notus endpoint of a
+    /// running Skiron instance or "<PATH>" to product files to use the
+    /// internal implementation. If not given Notus will be disabled.
+    #[clap(short, long = "notus-url")]
     notus: Option<NotusArgs>,
 }
 
@@ -163,7 +163,7 @@ async fn scan(args: ScanArgs) -> Result<(), CliError> {
 }
 
 async fn script(args: ScriptArgs) -> Result<(), CliError> {
-    let notus = args.notus.map(|x| match x {
+    let notus = args.notus_url.map(|x| match x {
         NotusArgs::Address(addr) => NotusCtx::Address(addr),
         NotusArgs::Internal(path) => NotusCtx::Direct(Arc::new(Mutex::new(Notus::new(
             // scannerctl doesn't require a proper feed

--- a/rust/src/scannerctl/execute/mod.rs
+++ b/rust/src/scannerctl/execute/mod.rs
@@ -58,7 +58,7 @@ struct ScriptArgs {
     timeout: Option<u32>,
     #[clap(long = "vendor")]
     vendor_version: Option<String>,
-    /// Notus configuration. Use "<IP:PORT>" to connect to a running Notus
+    /// Notus configuration. Use "<URL>" to connect to a running Notus
     /// instance or "<PATH>" to product files to use the internal
     /// implementation. If not given Notus will be disabled.
     #[clap(short, long = "notus")]
@@ -77,7 +77,7 @@ struct ScanArgs {
     /// Target to scan.
     #[clap(short, long)]
     target: Option<String>,
-    /// Notus configuration. Use "<IP:PORT>" to connect to a running Notus
+    /// Notus configuration. Use "<URL>" to connect to a running Notus
     /// instance or "<PATH>" to product files to use the internal
     /// implementation. If not given Notus will be disabled.
     #[clap(short, long = "notus")]

--- a/rust/src/scannerctl/utils.rs
+++ b/rust/src/scannerctl/utils.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
 #[derive(Clone)]
 pub enum ArgOrStdin<T> {
@@ -24,7 +24,8 @@ where
 
 #[derive(Clone)]
 pub enum NotusArgs {
-    Address(SocketAddr),
+    /// Full URL to reach notus on, including the endpoint path.
+    Address(url::Url),
     Internal(PathBuf),
 }
 
@@ -32,10 +33,9 @@ impl FromStr for NotusArgs {
     type Err = std::io::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Ok(addr) = s.parse() {
-            Ok(Self::Address(addr))
-        } else {
-            Ok(Self::Internal(PathBuf::from(s)))
+        match url::Url::parse(s) {
+            Ok(url) => Ok(Self::Address(url)),
+            Err(_) => Ok(Self::Internal(PathBuf::from(s))),
         }
     }
 }

--- a/src/openvas.c
+++ b/src/openvas.c
@@ -410,7 +410,7 @@ static int
 attack_network_init (struct scan_globals *globals, const gchar *config_file)
 {
   const char *mqtt_server_uri;
-  const char *notus_route;
+  const char *notus_url;
 
   set_default_openvas_prefs ();
   prefs_config (config_file);
@@ -432,23 +432,23 @@ attack_network_init (struct scan_globals *globals, const gchar *config_file)
   nvticache_reset ();
 
   /* Init Notus communication */
-  notus_route = prefs_get ("openvasd_server");
-  if (notus_route)
+  notus_url = prefs_get ("openvasd_server");
+  if (notus_url)
     {
-      gchar *full_notus_route;
+      gchar *full_notus_url;
       g_warning ("%s: option openvasd_server is deprecated and will be removed "
-                 "in the next major release. Please use notus_route instead.",
+                 "in the next major release. Please use notus_url instead.",
                  __func__);
-      full_notus_route = g_strconcat (notus_route, "/notus/", NULL);
-      prefs_set ("notus_route", full_notus_route);
-      g_free (full_notus_route);
+      full_notus_url = g_strconcat (notus_url, "/notus/", NULL);
+      prefs_set ("notus_url", full_notus_url);
+      g_free (full_notus_url);
       g_message ("%s: LSC via openvasd", __func__);
       prefs_set ("http_lsc_enabled", "yes");
     }
   else
     {
-      notus_route = prefs_get ("notus_route");
-      if (notus_route)
+      notus_url = prefs_get ("notus_url");
+      if (notus_url)
         {
           g_message ("%s: LSC via HTTP(S)", __func__);
           prefs_set ("http_lsc_enabled", "yes");


### PR DESCRIPTION
Previously the URL was almost fixed, with only the socket address to be adjustable. Skiron on the other hand does have a completely different path, than the openvasd integration we assumed. The complete URL is now adjustable via the config, except for the product part, which is set by the caller of the NASL function.

For testing use: 
```
target/release/scannerctl execute script --notus <URL> examples/notus.nasl
```

Jira: SC-1622