### PR TITLE
Fix: orchestrator ignoring feed update error.

### DIFF
--- a/rust/src/openvasd/database/sqlite/vts.rs
+++ b/rust/src/openvasd/database/sqlite/vts.rs
@@ -78,6 +78,11 @@ impl PluginFetcher for SqlPluginStorage {
 }
 // TODO: verify before loading the plugin
 impl PluginStorer for SqlPluginStorage {
+    fn prepare_feed(&self, hash: &FeedHash) -> Promise<Result<(), WorkerError>> {
+        let pending = crate::vts::pending_hash(hash);
+        self.store_hash(&pending)
+    }
+
     fn store_plugin<T>(&self, hash: &FeedHash, plugin: T) -> Promise<Result<(), WorkerError>>
     where
         T: Plugin + Send + Sync + 'static,
@@ -104,13 +109,16 @@ impl PluginStorer for SqlPluginStorage {
         let ht = hash.typus;
         let hash = hash.hash.clone();
         Box::pin(async move {
-            query("INSERT OR REPLACE INTO feed (hash, path, type) VALUES (?, ?, ?)")
-                .bind(hash)
-                .bind(path)
-                .bind(ht.as_ref())
-                .execute(&pool)
-                .await
-                .map_err(error_vts_error)?;
+            query(
+                "INSERT INTO feed (hash, path, type) VALUES (?, ?, ?)
+                 ON CONFLICT(type) DO UPDATE SET hash = excluded.hash, path = excluded.path",
+            )
+            .bind(hash)
+            .bind(path)
+            .bind(ht.as_ref())
+            .execute(&pool)
+            .await
+            .map_err(error_vts_error)?;
             Ok(())
         })
     }

--- a/rust/src/openvasd/vts/mod.rs
+++ b/rust/src/openvasd/vts/mod.rs
@@ -157,10 +157,17 @@ pub async fn init(
 }
 
 pub trait PluginStorer {
+    fn prepare_feed(&self, hash: &FeedHash) -> Promise<Result<(), WorkerError>>;
     fn store_hash(&self, hash: &FeedHash) -> Promise<Result<(), WorkerError>>;
     fn store_plugin<T>(&self, hash: &FeedHash, plugin: T) -> Promise<Result<(), WorkerError>>
     where
         T: Plugin + Send + Sync + 'static;
+}
+
+pub(crate) fn pending_hash(hash: &FeedHash) -> FeedHash {
+    let mut pending = hash.clone();
+    pending.hash.clear();
+    pending
 }
 
 async fn synchronize_json<F, T, PS>(ps: &PS, hash: &FeedHash, f: F) -> Result<(), WorkerError>
@@ -211,12 +218,18 @@ where
     match feed_hash.typus {
         FeedType::Products => tracing::debug!(?feed_hash.typus, "Not supported, ignoring."),
         FeedType::Advisories => {
+            let path = feed_hash.path.clone();
+            let hash = feed_hash.hash.clone();
+            ps.prepare_feed(&feed_hash).await?;
+            synchronize_advisories(ps, path, hash, signature_check).await?;
             ps.store_hash(&feed_hash).await?;
-            synchronize_advisories(ps, feed_hash.path, feed_hash.hash, signature_check).await?
         }
         FeedType::NASL => {
+            let path = feed_hash.path.clone();
+            let hash = feed_hash.hash.clone();
+            ps.prepare_feed(&feed_hash).await?;
+            synchronize_plugins(ps, path, hash, signature_check).await?;
             ps.store_hash(&feed_hash).await?;
-            synchronize_plugins(ps, feed_hash.path, feed_hash.hash, signature_check).await?
         }
     };
     Ok(())

--- a/rust/src/openvasd/vts/orchestrator.rs
+++ b/rust/src/openvasd/vts/orchestrator.rs
@@ -346,18 +346,23 @@ where
             }
         }
 
-        let handle_worker_result = async move |feed_type, result: Result<(), WorkerError>| {
-            if let Err(error) = result {
-                tracing::warn!(%error, %feed_type, "Unable to update feed.");
-            }
-            send_synced(feed_type).await
-        };
-
         if let Some(handle) = nasl_handle {
-            handle_worker_result(FeedType::NASL, handle.await.unwrap()).await?;
+            match handle.await.unwrap() {
+                Ok(()) => send_synced(FeedType::NASL).await?,
+                Err(error) => {
+                    tracing::warn!(%error, feed_type = %FeedType::NASL, "Unable to update feed.");
+                    return Err(error);
+                }
+            }
         }
         if let Some(handle) = advisory_handle {
-            handle_worker_result(FeedType::Advisories, handle.await.unwrap()).await?;
+            match handle.await.unwrap() {
+                Ok(()) => send_synced(FeedType::Advisories).await?,
+                Err(error) => {
+                    tracing::warn!(%error, feed_type = %FeedType::Advisories, "Unable to update feed.");
+                    return Err(error);
+                }
+            }
         }
         self.change_outer_state(FeedState::Synced(calc_nasl, calc_advisories))
             .await;

--- a/rust/src/openvasd/vts/redis.rs
+++ b/rust/src/openvasd/vts/redis.rs
@@ -264,6 +264,11 @@ impl PluginFetcher for RedisPluginHandler {
 }
 
 impl PluginStorer for RedisPluginHandler {
+    fn prepare_feed(&self, hash: &super::FeedHash) -> scannerlib::Promise<Result<(), WorkerError>> {
+        let pending = super::pending_hash(hash);
+        self.store_hash(&pending)
+    }
+
     fn store_hash(&self, hash: &super::FeedHash) -> scannerlib::Promise<Result<(), WorkerError>> {
         redis_with_hash(
             self.address.clone(),


### PR DESCRIPTION
Jira: SC-1686

The orchestrator marked the feed as synced first then performed the actual update. It also ignored any errors that occurred during the update.

This led to the following wonderful chain of events:
1. We start a openvasd instance, it quickly does something, finishes and cancels the feed sync before it finishes
2. We start another openvasd instance with the same redis storage, it considers the feed synced and works on an outdated feed.