### PR TITLE
Remove unused trait impls

### DIFF
--- a/rust/src/feed/update/mod.rs
+++ b/rust/src/feed/update/mod.rs
@@ -19,8 +19,8 @@ use crate::nasl::utils::Executor;
 use crate::nasl::utils::scan_ctx::ContextStorage;
 use crate::nasl::utils::scan_ctx::Target;
 
+use crate::feed::verify::HashSumFileItem;
 use crate::feed::verify::check_signature;
-use crate::feed::verify::{HashSumFileItem, SignatureChecker};
 use crate::scanner::preferences::preference::ScanPrefs;
 use crate::storage::ScanID;
 use crate::storage::items::nvt::FeedVersion;
@@ -85,13 +85,6 @@ pub async fn feed_version(
         .map(|x| x.to_string())
         .unwrap_or_else(|_| "0".to_owned());
     Ok(feed_version)
-}
-
-impl<'a, S, V> SignatureChecker for Update<'a, S, V>
-where
-    S: Sync + Send + ContextStorage,
-    V: Iterator<Item = Result<HashSumFileItem<'a>, verify::Error>>,
-{
 }
 
 impl<'a, S, V> Update<'a, S, V>

--- a/rust/src/feed_filter/error.rs
+++ b/rust/src/feed_filter/error.rs
@@ -30,5 +30,3 @@ impl From<&str> for CliError {
         Self::Message(value.to_string())
     }
 }
-
-impl std::error::Error for CliError {}

--- a/rust/src/nasl/builtin/mod.rs
+++ b/rust/src/nasl/builtin/mod.rs
@@ -71,6 +71,7 @@ pub fn nasl_std_executor() -> Executor {
     executor.add_set(raw_ip::RawIp);
     executor.add_global_vars(raw_ip::RawIp);
     executor.add_global_vars(network::socket::SocketFns);
+    executor.add_global_vars(misc::Misc);
 
     executor
 }

--- a/rust/src/nasl/builtin/network/mod.rs
+++ b/rust/src/nasl/builtin/network/mod.rs
@@ -5,10 +5,7 @@
 use std::{fmt::Display, net::IpAddr};
 
 use crate::nasl::raw_ip_utils::raw_ip_utils;
-use crate::{
-    nasl::{prelude::*, utils::DefineGlobalVars},
-    storage::items::kb::KbKey,
-};
+use crate::{nasl::prelude::*, storage::items::kb::KbKey};
 
 #[allow(clippy::module_inception)]
 pub mod network;
@@ -156,13 +153,5 @@ impl FromNaslValue<'_> for Port {
         } else {
             Ok(Port(port as u16))
         }
-    }
-}
-
-pub struct Network;
-
-impl DefineGlobalVars for Network {
-    fn get_global_vars() -> Vec<(&'static str, NaslValue)> {
-        socket::SocketFns::get_global_vars().into_iter().collect()
     }
 }

--- a/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
+++ b/rust/src/nasl/builtin/raw_ip/frame_forgery.rs
@@ -76,11 +76,6 @@ impl Frame {
     }
 }
 
-impl Default for Frame {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 impl From<Frame> for Vec<u8> {
     fn from(f: Frame) -> Vec<u8> {
         let mut raw_frame = vec![];
@@ -210,12 +205,6 @@ impl ArpFrame {
     pub(crate) fn set_dstip(&mut self, dstip: Ipv4Addr) -> &ArpFrame {
         self.dstip = dstip;
         self
-    }
-}
-
-impl Default for ArpFrame {
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
This removes a bunch of trait impls which are never used.

While doing this, I noticed that `DefineGlobalVars` for `Misc` and `Network` is also never used. The latter is alright, since it just defaults to the sample impl for `Sockets` and would not add anything useful. However, the former seems like a mistake - these variables should be defined, so I added them in `Executor`.

Jira: SC-1699