### PR TITLE
Remove storage-related traits

### DIFF
--- a/rust/src/openvas/openvas.rs
+++ b/rust/src/openvas/openvas.rs
@@ -117,10 +117,7 @@ impl OpenvasScanner {
         self.running.lock().unwrap().remove(id)
     }
 
-    fn create_redis_connector(
-        &self,
-        dbid: Option<u32>,
-    ) -> Result<RedisHelper<RedisCtx>, ScanError> {
+    fn create_redis_connector(&self, dbid: Option<u32>) -> Result<RedisHelper, ScanError> {
         let namespace = match dbid {
             Some(id) => [NameSpaceSelector::Fix(id)],
             None => [NameSpaceSelector::Free],
@@ -139,7 +136,7 @@ impl OpenvasScanner {
                 Err(e) => return Err(ScanError::Connection(format!("nvticache: {e}"))),
             },
         ));
-        Ok(RedisHelper::<RedisCtx>::new(nvtcache, kbctx))
+        Ok(RedisHelper::new(nvtcache, kbctx))
     }
 }
 

--- a/rust/src/openvas/openvas_redis.rs
+++ b/rust/src/openvas/openvas_redis.rs
@@ -2,42 +2,33 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use crate::storage::redis::{DbError, RedisCtx, RedisGetNvt, RedisStorageResult, RedisWrapper};
+use crate::storage::redis::{DbError, RedisCtx, RedisStorageResult};
 use greenbone_scanner_framework::models::VTData;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Debug, Default)]
-pub struct RedisHelper<R>
-where
-    R: RedisWrapper,
-{
-    cache: Arc<Mutex<R>>,
-    task_kb: Arc<Mutex<R>>,
+pub struct RedisHelper {
+    cache: Arc<Mutex<RedisCtx>>,
+    task_kb: Arc<Mutex<RedisCtx>>,
 }
 
-impl<R> RedisHelper<R>
-where
-    R: RedisWrapper,
-{
+impl RedisHelper {
     /// Initialize a RedisHelper struct with the connection to access the NVT cache
     /// and a empty task knowledge base to store the scan configuration to be sent to openvas.
-    pub fn new(
-        nvti_cache: Arc<Mutex<RedisCtx>>,
-        kb_cache: Arc<Mutex<RedisCtx>>,
-    ) -> RedisHelper<RedisCtx> {
-        RedisHelper::<RedisCtx> {
+    pub fn new(nvti_cache: Arc<Mutex<RedisCtx>>, kb_cache: Arc<Mutex<RedisCtx>>) -> RedisHelper {
+        RedisHelper {
             cache: nvti_cache,
             task_kb: kb_cache,
         }
     }
 
-    fn lock_task_kb(&self) -> Result<MutexGuard<'_, R>, DbError> {
+    fn lock_task_kb(&self) -> Result<MutexGuard<'_, RedisCtx>, DbError> {
         self.task_kb
             .lock()
             .map_err(|e| DbError::PoisonedLock(format!("{e:?}")))
     }
 
-    fn lock_cache(&self) -> Result<MutexGuard<'_, R>, DbError> {
+    fn lock_cache(&self) -> Result<MutexGuard<'_, RedisCtx>, DbError> {
         self.cache
             .lock()
             .map_err(|e| DbError::PoisonedLock(format!("{e:?}")))
@@ -65,7 +56,7 @@ pub trait KbAccess {
     }
 }
 
-impl KbAccess for RedisHelper<RedisCtx> {
+impl KbAccess for RedisHelper {
     /// Provide access to the cache
     fn kb_id(&self) -> RedisStorageResult<u32> {
         // TODO: Should this really be self.lock_task_kb? This seems
@@ -109,7 +100,7 @@ pub trait VtHelper {
     }
 }
 
-impl VtHelper for RedisHelper<RedisCtx> {
+impl VtHelper for RedisHelper {
     fn get_vt(&self, oid: &str) -> RedisStorageResult<Option<VTData>> {
         self.lock_cache()?.redis_get_vt(oid)
     }

--- a/rust/src/openvasd/vts/redis.rs
+++ b/rust/src/openvasd/vts/redis.rs
@@ -4,10 +4,7 @@ use futures::Stream;
 use greenbone_scanner_framework::GetVTsError;
 use scannerlib::{
     models::{FeedType, VTData},
-    storage::redis::{
-        CACHE_KEY, DbError, NOTUS_KEY, RedisAddAdvisory, RedisAddNvt, RedisCtx, RedisGetNvt,
-        RedisWrapper,
-    },
+    storage::redis::{CACHE_KEY, DbError, NOTUS_KEY, RedisCtx},
 };
 
 use crate::{

--- a/rust/src/scannerctl/feed/mod.rs
+++ b/rust/src/scannerctl/feed/mod.rs
@@ -13,9 +13,7 @@ use scannerlib::{
     storage::{
         error::StorageError,
         json::{ArrayWrapper, JsonStorage},
-        redis::{
-            FEEDUPDATE_SELECTOR, NOTUSUPDATE_SELECTOR, NameSpaceSelector, RedisCtx, RedisStorage,
-        },
+        redis::{FEEDUPDATE_SELECTOR, NOTUSUPDATE_SELECTOR, NameSpaceSelector, RedisStorage},
     },
 };
 use tracing::warn;
@@ -71,7 +69,7 @@ struct TransformArgs {
 fn make_redis_storage(
     redis: &str,
     selector: &[NameSpaceSelector],
-) -> Result<RedisStorage<RedisCtx>, CliErrorKind> {
+) -> Result<RedisStorage, CliErrorKind> {
     Ok(RedisStorage::init(redis, selector).map_err(StorageError::from)?)
 }
 

--- a/rust/src/scannerctl/notus_update/update.rs
+++ b/rust/src/scannerctl/notus_update/update.rs
@@ -16,31 +16,19 @@ use scannerlib::notus::advisories::VulnerabilityData;
 use scannerlib::notus::advisory_loader;
 use scannerlib::storage::Dispatcher;
 use scannerlib::storage::items::notus_advisory::NotusCache;
-use scannerlib::storage::redis::RedisAddAdvisory;
-use scannerlib::storage::redis::RedisAddNvt;
-use scannerlib::storage::redis::RedisGetNvt;
+use scannerlib::storage::redis::RedisCtx;
 use scannerlib::storage::redis::RedisStorage;
-use scannerlib::storage::redis::RedisWrapper;
-
-pub(crate) trait NotusStorage:
-    Dispatcher<(), Item = VulnerabilityData> + Dispatcher<NotusCache, Item = ()>
-{
-}
-
-impl<S> NotusStorage for RedisStorage<S> where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt + Send
-{
-}
 
 pub fn signature_error(e: impl std::fmt::Display) -> CliError {
     CliErrorKind::LoadError(LoadError::Dirty(e.to_string()))
         .with(Filename(Path::new(feed::Hasher::Sha256.sum_file())))
 }
 
-pub async fn run<S>(storage: S, path: PathBuf, signature_check: bool) -> Result<(), CliError>
-where
-    S: NotusStorage,
-{
+pub async fn run(
+    storage: RedisStorage<RedisCtx>,
+    path: PathBuf,
+    signature_check: bool,
+) -> Result<(), CliError> {
     let loader = Loader::from_feed_path(path);
     let advisories_files = match advisory_loader(signature_check, &loader) {
         Ok(loader) => loader,

--- a/rust/src/scannerctl/notus_update/update.rs
+++ b/rust/src/scannerctl/notus_update/update.rs
@@ -16,7 +16,6 @@ use scannerlib::notus::advisories::VulnerabilityData;
 use scannerlib::notus::advisory_loader;
 use scannerlib::storage::Dispatcher;
 use scannerlib::storage::items::notus_advisory::NotusCache;
-use scannerlib::storage::redis::RedisCtx;
 use scannerlib::storage::redis::RedisStorage;
 
 pub fn signature_error(e: impl std::fmt::Display) -> CliError {
@@ -25,7 +24,7 @@ pub fn signature_error(e: impl std::fmt::Display) -> CliError {
 }
 
 pub async fn run(
-    storage: RedisStorage<RedisCtx>,
+    storage: RedisStorage,
     path: PathBuf,
     signature_check: bool,
 ) -> Result<(), CliError> {

--- a/rust/src/scannerctl/scan_config.rs
+++ b/rust/src/scannerctl/scan_config.rs
@@ -5,13 +5,12 @@
 use std::fmt::{Display, Formatter};
 use std::{io::BufReader, path::PathBuf, sync::Arc};
 
-use greenbone_scanner_framework::models::VTData;
 use scannerlib::models::{Parameter, Port, Protocol, Scan, ScanPreference, VT};
 use scannerlib::nasl::WithErrorInfo;
 use scannerlib::storage::Retriever;
 use scannerlib::storage::error::StorageError;
 use scannerlib::storage::inmemory::InMemoryStorage;
-use scannerlib::storage::items::nvt::{Feed, Oid};
+use scannerlib::storage::items::nvt::Feed;
 use serde::{Deserialize, Deserializer};
 
 use crate::{CliError, CliErrorKind, Filename, get_path_from_openvas, read_openvas_config};
@@ -287,17 +286,13 @@ struct ScanConfigPreferenceNvt {
     name: String,
 }
 
-trait OspStorage: Retriever<Oid, Item = VTData> + Retriever<Feed, Item = Vec<VTData>> {}
-
-impl OspStorage for InMemoryStorage {}
-
 #[derive(Clone)]
 struct VtsScanPrefs {
     pub vts_list: Vec<VT>,
     pub scan_preferences: Vec<ScanPreference>,
 }
 
-async fn parse_vts<R>(sc: R, retriever: &dyn OspStorage, vts: &[VT]) -> Result<VtsScanPrefs, Error>
+async fn parse_vts<R>(sc: R, retriever: &InMemoryStorage, vts: &[VT]) -> Result<VtsScanPrefs, Error>
 where
     R: BufRead,
 {
@@ -454,7 +449,10 @@ where
 #[cfg(test)]
 mod tests {
 
-    use scannerlib::storage::{Dispatcher, items::nvt::FileName};
+    use scannerlib::{
+        models::VTData,
+        storage::{Dispatcher, items::nvt::FileName},
+    };
 
     use super::*;
 

--- a/rust/src/scheduling/mod.rs
+++ b/rust/src/scheduling/mod.rs
@@ -13,7 +13,7 @@ use crate::storage::{
     inmemory::InMemoryStorage,
     items::nvt::{ACT, FileName, Oid},
     json::JsonStorage,
-    redis::{RedisAddAdvisory, RedisAddNvt, RedisGetNvt, RedisStorage, RedisWrapper},
+    redis::RedisStorage,
 };
 
 use greenbone_scanner_framework::models::VTData;
@@ -99,10 +99,7 @@ pub trait SchedulerStorage:
 
 impl SchedulerStorage for InMemoryStorage {}
 impl<T: Write + Send> SchedulerStorage for JsonStorage<T> {}
-impl<T> SchedulerStorage for RedisStorage<T> where
-    T: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt + Send
-{
-}
+impl SchedulerStorage for RedisStorage {}
 impl<T: SchedulerStorage> SchedulerStorage for Arc<T> where Arc<T>: Sync {}
 
 pub struct Scheduler<S> {

--- a/rust/src/storage/redis/connector.rs
+++ b/rust/src/storage/redis/connector.rs
@@ -177,41 +177,31 @@ pub const FEEDUPDATE_SELECTOR: &[NameSpaceSelector] =
 pub const NOTUSUPDATE_SELECTOR: &[NameSpaceSelector] =
     &[NameSpaceSelector::Key(NOTUS_KEY), NameSpaceSelector::Free];
 
-pub trait RedisWrapper {
-    fn rpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()>;
-    fn lpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()>;
-    fn del(&mut self, key: &str) -> RedisStorageResult<()>;
-    fn lindex(&mut self, key: &str, index: isize) -> RedisStorageResult<String>;
-    fn lrange(&mut self, key: &str, start: isize, end: isize) -> RedisStorageResult<Vec<String>>;
-    fn keys(&mut self, pattern: &str) -> RedisStorageResult<Vec<String>>;
-    fn pop(&mut self, pattern: &str) -> RedisStorageResult<Vec<String>>;
-}
-
-impl RedisWrapper for RedisCtx {
+impl RedisCtx {
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn rpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
+    pub fn rpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
         redis::Commands::rpush(self.kb.as_mut().expect("Valid redis connection"), key, val)
             .map_err(DbError::from)
     }
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn lpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
+    pub fn lpush<T: ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
         redis::Commands::lpush(self.kb.as_mut().expect("Valid redis connection"), key, val)
             .map_err(DbError::from)
     }
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn del(&mut self, key: &str) -> RedisStorageResult<()> {
+    pub fn del(&mut self, key: &str) -> RedisStorageResult<()> {
         redis::Commands::del(self.kb.as_mut().expect("Valid redis connection"), key)
             .map_err(DbError::from)
     }
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn lindex(&mut self, key: &str, index: isize) -> RedisStorageResult<String> {
+    pub fn lindex(&mut self, key: &str, index: isize) -> RedisStorageResult<String> {
         let value: Value = redis::Commands::lindex(
             self.kb.as_mut().expect("Valid redis connection"),
             key,
@@ -223,7 +213,12 @@ impl RedisWrapper for RedisCtx {
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn lrange(&mut self, key: &str, start: isize, end: isize) -> RedisStorageResult<Vec<String>> {
+    pub fn lrange(
+        &mut self,
+        key: &str,
+        start: isize,
+        end: isize,
+    ) -> RedisStorageResult<Vec<String>> {
         let values: Vec<Value> = redis::Commands::lrange(
             self.kb.as_mut().expect("Valid redis connection"),
             key,
@@ -239,14 +234,14 @@ impl RedisWrapper for RedisCtx {
 
     ///Wrapper function to avoid accessing kb member directly.
     #[inline(always)]
-    fn keys(&mut self, pattern: &str) -> RedisStorageResult<Vec<String>> {
+    pub fn keys(&mut self, pattern: &str) -> RedisStorageResult<Vec<String>> {
         let ret: Vec<String> =
             redis::Commands::keys(self.kb.as_mut().expect("Valid redis connection"), pattern)
                 .map_err(DbError::from)?;
         Ok(ret)
     }
 
-    fn pop(&mut self, key: &str) -> RedisStorageResult<Vec<String>> {
+    pub fn pop(&mut self, key: &str) -> RedisStorageResult<Vec<String>> {
         let ret: (Vec<String>,) = redis::pipe()
             .cmd("LRANGE")
             .arg(key)
@@ -265,7 +260,7 @@ impl RedisWrapper for RedisCtx {
     }
 }
 
-pub trait RedisAddAdvisory: RedisWrapper {
+impl RedisCtx {
     /// Add an NVT in the redis cache.
     ///
     /// The NVT metadata is stored in two different keys:
@@ -276,7 +271,7 @@ pub trait RedisAddAdvisory: RedisWrapper {
     ///
     /// To call with None is only required when using ospd-openvas and updating the feed into
     /// redis.
-    fn redis_add_advisory(&mut self, adv: Option<VulnerabilityData>) -> RedisStorageResult<()> {
+    pub fn redis_add_advisory(&mut self, adv: Option<VulnerabilityData>) -> RedisStorageResult<()> {
         match adv {
             Some(data) => {
                 let key = format!("internal/notus/advisories/{}", &data.adv.oid);
@@ -289,17 +284,13 @@ pub trait RedisAddAdvisory: RedisWrapper {
         };
         Ok(())
     }
-}
 
-impl RedisAddAdvisory for RedisCtx {}
-
-pub trait RedisGetNvt: RedisWrapper {
     fn redis_address(&self) -> Option<&str> {
-        None
+        Some(&self.address)
     }
 
     fn redis_db(&self) -> Option<u32> {
-        None
+        Some(self.db)
     }
 
     #[inline(always)]
@@ -364,7 +355,7 @@ pub trait RedisGetNvt: RedisWrapper {
         tag_map
     }
 
-    fn redis_get_advisory(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
+    pub fn redis_get_advisory(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
         let keyname = format!("internal/notus/advisories/{oid}");
         let nvt_data = self.lindex(&keyname, 0)?;
         if nvt_data.is_empty() {
@@ -378,7 +369,7 @@ pub trait RedisGetNvt: RedisWrapper {
         }
     }
 
-    fn redis_get_nasl_vt(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
+    pub fn redis_get_nasl_vt(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
         let keyname = format!("nvt:{oid}");
         let nvt_data = self.lrange(&keyname, 0, -1)?;
 
@@ -437,7 +428,7 @@ pub trait RedisGetNvt: RedisWrapper {
     /// - 'nvt:<OID>': stores the general metadata ordered following the KbNvtPos indexes
     /// - 'oid:<OID>:prefs': stores the plugins preferences, including the script_timeout
     ///   (which is especial and uses preferences id 0)
-    fn redis_get_vt(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
+    pub fn redis_get_vt(&mut self, oid: &str) -> RedisStorageResult<Option<VTData>> {
         if let Some(vt) = self.redis_get_advisory(oid)? {
             return Ok(Some(vt));
         }
@@ -466,19 +457,7 @@ pub trait RedisGetNvt: RedisWrapper {
 
         Ok(None)
     }
-}
 
-impl RedisGetNvt for RedisCtx {
-    fn redis_address(&self) -> Option<&str> {
-        Some(&self.address)
-    }
-
-    fn redis_db(&self) -> Option<u32> {
-        Some(self.db)
-    }
-}
-
-pub trait RedisAddNvt: RedisWrapper {
     /// Get References. It returns a tuple of three strings
     /// Each string is a references type, and each string
     /// can contain a list of references of the same type.
@@ -550,7 +529,7 @@ pub trait RedisAddNvt: RedisWrapper {
     /// - 'nvt:<OID>': stores the general metadata ordered following the KbNvtPos indexes
     /// - 'oid:<OID>:prefs': stores the plugins preferences, including the script_timeout
     ///   (which is especial and uses preferences id 0)
-    fn redis_add_nvt(
+    pub fn redis_add_nvt(
         &mut self,
         nvt: VTData,
         mtime: String,
@@ -647,8 +626,6 @@ pub trait RedisAddNvt: RedisWrapper {
     }
 }
 
-impl RedisAddNvt for RedisCtx {}
-
 impl RedisCtx {
     pub fn open(address: &str, selector: &[NameSpaceSelector]) -> RedisStorageResult<Self> {
         let client = redis::Client::open(address)?;
@@ -699,134 +676,12 @@ impl RedisCtx {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-
-    #[derive(Default)]
-    struct FakeRedis {
-        lists: HashMap<String, Vec<String>>,
-    }
-
-    impl FakeRedis {
-        fn with_nasl(oid: &str, name: &str) -> Self {
-            let mut lists = HashMap::new();
-            lists.insert(
-                format!("nvt:{oid}"),
-                vec![
-                    "test.nasl".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "summary=nasl".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    (ACT::GatherInfo as i32).to_string(),
-                    "General".to_string(),
-                    name.to_string(),
-                ],
-            );
-            Self { lists }
-        }
-
-        fn add_advisory(&mut self, oid: &str, name: &str) {
-            let advisory = Vulnerability {
-                name: name.to_string(),
-                filename: "test.notus".to_string(),
-                family: "Notus".to_string(),
-                category: "3".to_string(),
-                ..Default::default()
-            };
-            self.lists.insert(
-                format!("internal/notus/advisories/{oid}"),
-                vec![serde_json::to_string(&advisory).expect("valid advisory json")],
-            );
-        }
-    }
-
-    impl RedisWrapper for FakeRedis {
-        fn rpush<T: ToRedisArgs>(&mut self, _key: &str, _val: T) -> RedisStorageResult<()> {
-            unimplemented!()
-        }
-
-        fn lpush<T: ToRedisArgs>(&mut self, _key: &str, _val: T) -> RedisStorageResult<()> {
-            unimplemented!()
-        }
-
-        fn del(&mut self, _key: &str) -> RedisStorageResult<()> {
-            unimplemented!()
-        }
-
-        fn lindex(&mut self, key: &str, index: isize) -> RedisStorageResult<String> {
-            Ok(self
-                .lists
-                .get(key)
-                .and_then(|values| values.get(index as usize))
-                .cloned()
-                .unwrap_or_default())
-        }
-
-        fn lrange(
-            &mut self,
-            key: &str,
-            _start: isize,
-            _end: isize,
-        ) -> RedisStorageResult<Vec<String>> {
-            Ok(self.lists.get(key).cloned().unwrap_or_default())
-        }
-
-        fn keys(&mut self, _pattern: &str) -> RedisStorageResult<Vec<String>> {
-            unimplemented!()
-        }
-
-        fn pop(&mut self, _pattern: &str) -> RedisStorageResult<Vec<String>> {
-            unimplemented!()
-        }
-    }
-
-    impl RedisGetNvt for FakeRedis {}
-
-    #[test]
-    fn redis_get_vt_falls_back_to_nasl() {
-        let mut redis = FakeRedis::with_nasl("1.3.6.1.4.1", "NASL VT");
-
-        let vt = redis.redis_get_vt("1.3.6.1.4.1").unwrap().unwrap();
-
-        assert_eq!(vt.name, "NASL VT");
-        assert_eq!(vt.filename, "test.nasl");
-    }
-
-    #[test]
-    fn redis_get_vt_prefers_advisory_over_nasl() {
-        let mut redis = FakeRedis::with_nasl("1.3.6.1.4.2", "NASL VT");
-        redis.add_advisory("1.3.6.1.4.2", "Notus Advisory");
-
-        let vt = redis.redis_get_vt("1.3.6.1.4.2").unwrap().unwrap();
-
-        assert_eq!(vt.name, "Notus Advisory");
-        assert_eq!(vt.filename, "test.notus");
-        assert_eq!(vt.family, "Notus");
-    }
-
-    #[test]
-    fn redis_get_nasl_vt_excludes_advisory() {
-        let mut redis = FakeRedis::default();
-        redis.add_advisory("1.3.6.1.4.3", "Notus Advisory");
-
-        assert!(redis.redis_get_nasl_vt("1.3.6.1.4.3").unwrap().is_none());
-
-        let vt = redis.redis_get_vt("1.3.6.1.4.3").unwrap().unwrap();
-        assert_eq!(vt.name, "Notus Advisory");
-        assert_eq!(vt.family, "Notus");
-    }
 
     #[test]
     fn redis_value_to_string_reads_valid_utf8() {
-        let value = Value::BulkString("Hütte".as_bytes().to_vec());
+        let value = Value::BulkString("äöüabc{}".as_bytes().to_vec());
 
-        assert_eq!(redis_value_to_string("nvt:1.2.3", value), "Hütte");
+        assert_eq!(redis_value_to_string("nvt:1.2.3", value), "äöüabc{}");
     }
 
     #[test]
@@ -839,7 +694,6 @@ mod tests {
         // 0xE9 is 'é' in latin-1 but an invalid UTF-8 byte on its own. Instead
         // of aborting the whole read, the value is converted lossily.
         let value = Value::BulkString(vec![b'a', b'b', 0xE9]);
-
         assert_eq!(redis_value_to_string("nvt:1.2.3", value), "ab\u{FFFD}");
     }
 }

--- a/rust/src/storage/redis/mod.rs
+++ b/rust/src/storage/redis/mod.rs
@@ -22,7 +22,7 @@ pub use connector::FEEDUPDATE_SELECTOR;
 pub use connector::NOTUS_KEY;
 pub use connector::NOTUSUPDATE_SELECTOR;
 pub use connector::NameSpaceSelector;
-pub use connector::{RedisAddAdvisory, RedisAddNvt, RedisCtx, RedisGetNvt, RedisWrapper};
+pub use connector::RedisCtx;
 pub use dberror::{DbError, RedisStorageResult};
 
 use super::Dispatcher;
@@ -54,15 +54,12 @@ use super::items::result::ResultItem;
 /// we need to have all references and preferences to respect the order to be downwards compatible.
 /// This should be changed when there is new OSP frontend available.
 #[derive(Debug, Default)]
-pub struct RedisStorage<R>
-where
-    R: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
-    cache: Mutex<R>,
+pub struct RedisStorage {
+    cache: Mutex<RedisCtx>,
     kbs: InMemoryKbStorage,
 }
 
-impl RedisStorage<RedisCtx> {
+impl RedisStorage {
     /// Initialize and return an NVT Cache Object
     ///
     /// The redis_url must be a complete url including the used protocol e.g.:
@@ -70,7 +67,7 @@ impl RedisStorage<RedisCtx> {
     pub fn init(
         redis_url: &str,
         selector: &[NameSpaceSelector],
-    ) -> RedisStorageResult<RedisStorage<RedisCtx>> {
+    ) -> RedisStorageResult<RedisStorage> {
         let rctx = RedisCtx::open(redis_url, selector)?;
 
         Ok(RedisStorage {
@@ -81,10 +78,7 @@ impl RedisStorage<RedisCtx> {
 }
 
 #[async_trait]
-impl<S: Send> Dispatcher<KbContextKey> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
+impl Dispatcher<KbContextKey> for RedisStorage {
     type Item = KbItem;
     async fn dispatch(&self, key: KbContextKey, item: Self::Item) -> Result<(), StorageError> {
         self.kbs.dispatch(key, item).await
@@ -92,11 +86,7 @@ where
 }
 
 #[async_trait]
-impl<S> Retriever<KbContextKey> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Retriever<KbContextKey> for RedisStorage {
     type Item = Vec<KbItem>;
     async fn retrieve(&self, key: &KbContextKey) -> Result<Option<Self::Item>, StorageError> {
         self.kbs.retrieve(key).await
@@ -104,11 +94,7 @@ where
 }
 
 #[async_trait]
-impl<S> Retriever<GetKbContextKey> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Retriever<GetKbContextKey> for RedisStorage {
     type Item = Vec<(String, Vec<KbItem>)>;
     async fn retrieve(&self, key: &GetKbContextKey) -> Result<Option<Self::Item>, StorageError> {
         self.kbs.retrieve(key).await
@@ -116,11 +102,7 @@ where
 }
 
 #[async_trait]
-impl<S> Remover<KbContextKey> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Remover<KbContextKey> for RedisStorage {
     type Item = Vec<KbItem>;
     async fn remove(&self, key: &KbContextKey) -> Result<Option<Vec<KbItem>>, StorageError> {
         self.kbs.remove(key).await
@@ -128,10 +110,7 @@ where
 }
 
 #[async_trait]
-impl<S: RedisAddNvt + Send> Dispatcher<FileName> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
+impl Dispatcher<FileName> for RedisStorage {
     type Item = VTData;
     async fn dispatch(
         &self,
@@ -145,10 +124,7 @@ where
 }
 
 #[async_trait]
-impl<S: RedisWrapper + Send> Dispatcher<FeedVersion> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
+impl Dispatcher<FeedVersion> for RedisStorage {
     type Item = String;
     async fn dispatch(&self, _: FeedVersion, item: Self::Item) -> Result<(), StorageError> {
         let mut vts = self.cache.lock()?;
@@ -159,11 +135,7 @@ where
 }
 
 #[async_trait]
-impl<S: RedisWrapper> Retriever<Oid> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Retriever<Oid> for RedisStorage {
     type Item = VTData;
     async fn retrieve(&self, _: &Oid) -> Result<Option<Self::Item>, StorageError> {
         unimplemented!()
@@ -171,11 +143,7 @@ where
 }
 
 #[async_trait]
-impl<S: RedisWrapper> Retriever<FileName> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Retriever<FileName> for RedisStorage {
     type Item = VTData;
     async fn retrieve(&self, _: &FileName) -> Result<Option<Self::Item>, StorageError> {
         unimplemented!()
@@ -183,10 +151,7 @@ where
 }
 
 #[async_trait]
-impl<S> Dispatcher<ScanID> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt + Send,
-{
+impl Dispatcher<ScanID> for RedisStorage {
     type Item = ResultItem;
     async fn dispatch(&self, _: ScanID, _: Self::Item) -> Result<(), StorageError> {
         unimplemented!()
@@ -194,11 +159,7 @@ where
 }
 
 #[async_trait]
-impl<S> Retriever<ResultContextKeySingle> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Retriever<ResultContextKeySingle> for RedisStorage {
     type Item = ResultItem;
     async fn retrieve(
         &self,
@@ -209,11 +170,7 @@ where
 }
 
 #[async_trait]
-impl<S> Remover<ScanID> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-    RedisStorage<S>: Sync,
-{
+impl Remover<ScanID> for RedisStorage {
     type Item = Vec<ResultItem>;
     async fn remove(&self, _: &ScanID) -> Result<Option<Self::Item>, StorageError> {
         unimplemented!()
@@ -221,10 +178,7 @@ where
 }
 
 #[async_trait]
-impl<S: RedisAddAdvisory + Send> Dispatcher<()> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
+impl Dispatcher<()> for RedisStorage {
     type Item = NotusAdvisory;
     async fn dispatch(&self, _: (), item: Self::Item) -> Result<(), StorageError> {
         let mut cache = self.cache.lock()?;
@@ -234,161 +188,11 @@ where
 }
 
 #[async_trait]
-impl<S: RedisAddAdvisory + Send> Dispatcher<NotusCache> for RedisStorage<S>
-where
-    S: RedisWrapper + RedisAddNvt + RedisAddAdvisory + RedisGetNvt,
-{
+impl Dispatcher<NotusCache> for RedisStorage {
     type Item = ();
     async fn dispatch(&self, _: NotusCache, _: Self::Item) -> Result<(), StorageError> {
         let mut cache = self.cache.lock()?;
         cache.redis_add_advisory(None)?;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Mutex;
-    use std::sync::mpsc::{self, Sender, TryRecvError};
-
-    use crate::storage::Dispatcher;
-    use crate::storage::inmemory::kb::InMemoryKbStorage;
-    use crate::storage::items::nvt::{
-        ACT, FeedVersion, FileName, NvtPreference, NvtRef, TagKey, TagValue,
-    };
-    use crate::storage::redis::RedisStorage;
-    use greenbone_scanner_framework::models::PreferenceType;
-    use greenbone_scanner_framework::models::VTData;
-
-    use super::{RedisAddAdvisory, RedisAddNvt, RedisGetNvt, RedisStorageResult, RedisWrapper};
-
-    #[derive(Clone)]
-    struct FakeRedis {
-        sender: Sender<(String, Vec<Vec<u8>>)>,
-    }
-    impl RedisWrapper for FakeRedis {
-        fn rpush<T: redis::ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
-            self.sender
-                .send((key.to_owned(), val.to_redis_args()))
-                .unwrap();
-            Ok(())
-        }
-
-        fn lpush<T: redis::ToRedisArgs>(&mut self, key: &str, val: T) -> RedisStorageResult<()> {
-            self.sender
-                .send((key.to_owned(), val.to_redis_args()))
-                .unwrap();
-            Ok(())
-        }
-        fn del(&mut self, _: &str) -> RedisStorageResult<()> {
-            Ok(())
-        }
-
-        fn lindex(&mut self, _: &str, _: isize) -> RedisStorageResult<String> {
-            Ok(String::new())
-        }
-
-        fn keys(&mut self, _: &str) -> RedisStorageResult<Vec<String>> {
-            Ok(Vec::new())
-        }
-        fn pop(&mut self, _: &str) -> RedisStorageResult<Vec<String>> {
-            Ok(Vec::new())
-        }
-
-        fn lrange(&mut self, _: &str, _: isize, _: isize) -> RedisStorageResult<Vec<String>> {
-            Ok(Vec::new())
-        }
-    }
-
-    impl RedisAddNvt for FakeRedis {}
-    impl RedisAddAdvisory for FakeRedis {}
-    impl RedisGetNvt for FakeRedis {}
-
-    #[tokio::test]
-    async fn transform_nvt() {
-        let version = "202212101125".to_owned();
-        let filename = "test.nasl".to_owned();
-        let mut tag = BTreeMap::new();
-        tag.insert(TagKey::CreationDate, TagValue::Number(23));
-        let nvt = VTData {
-            oid: "0.0.0.0.0.0.0.0.0.1".to_owned(),
-            name: "fancy name".to_owned(),
-            filename: filename.clone(),
-            tag,
-            dependencies: vec!["ssh_detect.nasl".to_owned(), "ssh2.nasl".to_owned()],
-            required_keys: vec!["WMI/Apache/RootPath".to_owned()],
-            mandatory_keys: vec!["ssh/blubb/detected".to_owned()],
-            excluded_keys: vec![
-                "Settings/disable_cgi_scanning".to_owned(),
-                "bla/bla".to_owned(),
-            ],
-            required_ports: vec!["Services/ssh".to_owned(), "22".to_owned()],
-            required_udp_ports: vec!["Services/udp/unknown".to_owned(), "17".to_owned()],
-            references: vec![
-                NvtRef {
-                    class: "cve".to_owned(),
-                    id: "CVE-1999-0524".to_owned(),
-                },
-                NvtRef {
-                    class: "http://freshmeat.sourceforge.net/projects/eventh/".to_owned(),
-                    id: "URL".to_owned(),
-                },
-            ],
-            preferences: vec![NvtPreference {
-                id: Some(2),
-                class: PreferenceType::Password,
-                name: "Enable Password".to_owned(),
-                default: "".to_owned(),
-            }],
-            category: ACT::Denial,
-            family: "Denial of Service".to_owned(),
-        };
-        let (sender, rx) = mpsc::channel();
-        let fr = FakeRedis { sender };
-        let cache = Mutex::new(fr);
-        let kbs = InMemoryKbStorage::default();
-        let key = FileName(filename);
-        let storage = RedisStorage { cache, kbs };
-        storage.dispatch(FeedVersion, version).await.unwrap();
-        storage.dispatch(key, nvt).await.unwrap();
-        let mut results = 0;
-        loop {
-            match rx.try_recv() {
-                Ok((key, values)) => {
-                    results += 1;
-                    match &key as &str {
-                        "nvticache" => {
-                            let values = values.first().unwrap().clone();
-                            let nversion = String::from_utf8(values);
-                            assert_eq!(Ok("202212101125".to_owned()), nversion);
-                        }
-                        "nvt:0.0.0.0.0.0.0.0.0.1" => {
-                            assert_eq!(14, values.len());
-                        }
-                        "oid:0.0.0.0.0.0.0.0.0.1:prefs" => {
-                            let values = values.first().unwrap().clone();
-                            let enable_pw = String::from_utf8(values);
-                            assert_eq!(
-                                Ok("2|||Enable Password|||password|||".to_owned()),
-                                enable_pw
-                            );
-                        }
-                        "filename:test.nasl" => {
-                            assert_eq!(values.len(), 2);
-                            let mut vals = values.clone();
-                            let oid = String::from_utf8(vals.pop().unwrap());
-                            assert_eq!(Ok("0.0.0.0.0.0.0.0.0.1".to_owned()), oid);
-                            let _mtime = vals.pop().unwrap();
-                        }
-                        "signaturecheck:test.nasl" => {}
-                        _ => panic!("{key} should not occur"),
-                    }
-                }
-                Err(TryRecvError::Empty) => break,
-                Err(e) => panic!("{e:?}"),
-            }
-        }
-        assert_eq!(results, 5);
     }
 }


### PR DESCRIPTION
This removes the utterly pointless `NotusStorage` and `OspStorage` traits.
Jira: SC-1706

Removes all redis-related traits and replace all generics implementing them with `RedisCtx`.

This might look suspicious because before we had a `FakeRedis` which technically implemented some of these traits. However, the tests share basically no code with the actual implementation. There is one test, `transform_nvt` that tested something that we now don't test, but the test is very contrived and mostly tests the `FakeRedis` implementation. The removed tests in `redis/connector.rs` shared NO code with the actual redis implementation, they ONLY tested their locally defined `FakeRedis` implementation.
Jira: SC-1707
