### PR TITLE
Fix: flatten plugin struct to store right serialized data

### DIFF
--- a/rust/src/openvasd/vts/mod.rs
+++ b/rust/src/openvasd/vts/mod.rs
@@ -411,6 +411,7 @@ fn verify_signature_and_send(
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 struct VTDataMessage {
+    #[serde(flatten)]
     item: VTData,
     hashsum: String,
 }

--- a/rust/src/scanner/running_scan.rs
+++ b/rust/src/scanner/running_scan.rs
@@ -82,11 +82,16 @@ where
     }
 
     async fn run(self) -> Result<(), Error> {
-        let runner = self.make_runner().await?;
+        let runner = match self.make_runner().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Something went wrong: {}", e.to_string());
+                return Err(e);
+            }
+        };
         self.update_status_at_beginning_of_run(runner.host_info())
             .await;
         let end_phase = self.run_to_completion(runner).await;
-
         self.update_status_at_end_of_run(end_phase).await;
         Ok(())
     }

--- a/rust/src/scanner/running_scan.rs
+++ b/rust/src/scanner/running_scan.rs
@@ -85,7 +85,7 @@ where
         let runner = match self.make_runner().await {
             Ok(r) => r,
             Err(e) => {
-                tracing::warn!("Something went wrong: {}", e.to_string());
+                tracing::error!("{}", e);
                 return Err(e);
             }
         };


### PR DESCRIPTION
Fix: flatten plugin struct to store right serialized data
Each VT was stored under the object name item which later triggered an error during deserializing

SC-1710

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
