### PR TITLE
Remove unused items, mark others as `unused`

### DIFF
--- a/rust/src/feed/mod.rs
+++ b/rust/src/feed/mod.rs
@@ -30,5 +30,4 @@ pub use verify::HashSumFileItem;
 pub use verify::HashSumNameLoader;
 pub use verify::Hasher;
 pub use verify::NoVerifier;
-pub use verify::SignatureChecker;
 pub use verify::check_signature;

--- a/rust/src/feed/verify/mod.rs
+++ b/rust/src/feed/verify/mod.rs
@@ -244,16 +244,6 @@ where
     }
 }
 
-/// Trait for signature check
-pub trait SignatureChecker {
-    /// For signature check the GNUPGHOME environment variable
-    /// must be set with the path to the keyring.
-    /// If this is satisfied, the signature check is performed
-    fn signature_check(feed_path: &str) -> Result<(), Error> {
-        check_signature(feed_path)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Hasher implements the used hashing algorithm to calculate the hashsum
 pub enum Hasher {
@@ -395,10 +385,6 @@ impl HashSumFileItem<'_> {
             }
         }
         Ok(())
-    }
-
-    pub fn load(&self) -> Result<String, LoadError> {
-        self.reader.load(&self.file_name)
     }
 
     /// returns file name

--- a/rust/src/models/product.rs
+++ b/rust/src/models/product.rs
@@ -9,8 +9,6 @@ use serde::Deserialize;
 /// Represents an product json file for notus
 #[derive(Deserialize, Debug)]
 pub struct Product {
-    /// Version of the file, some version might not be supported by notus
-    pub version: String,
     /// Package type, important for parsing the corresponding package
     pub package_type: PackageType,
     /// List of vulnerability tests for product

--- a/rust/src/nasl/builtin/network/socket.rs
+++ b/rust/src/nasl/builtin/network/socket.rs
@@ -163,19 +163,6 @@ impl NaslSocket {
         &None
     }
 
-    pub fn set_transport(&mut self, transport: Option<OpenvasEncaps>) {
-        if let NaslSocket::Tcp(tcp_connection) = self {
-            tcp_connection.set_transport(transport);
-        };
-    }
-
-    pub fn transport(&self) -> &Option<OpenvasEncaps> {
-        if let NaslSocket::Tcp(tcp_connection) = self {
-            return tcp_connection.transport();
-        }
-        &None
-    }
-
     pub fn set_session_id(&mut self, sid: Arc<Mutex<Option<String>>>) {
         if let NaslSocket::Tcp(tcp_connection) = self {
             tcp_connection.set_session_id(sid);
@@ -880,6 +867,7 @@ async fn socket_get_error(
 }
 
 #[nasl_function(named(socket))]
+#[allow(unused)]
 async fn socket_check_ssl_safe_renegotiation(
     nasl_sockets: &mut NaslSockets,
     socket: usize,
@@ -1362,7 +1350,6 @@ fn join_multicast_group(script_ctx: &mut ScriptCtx, ip: String) -> Result<NaslVa
         let new_jmp = JmpDesc {
             in_addr: Some(multicast_addr),
             count: 1,
-            socket: Some(s),
         };
         script_ctx.multicast_groups.push(new_jmp);
     }

--- a/rust/src/nasl/builtin/network/tcp.rs
+++ b/rust/src/nasl/builtin/network/tcp.rs
@@ -46,10 +46,6 @@ impl TcpDataStream {
         &self.tls
     }
 
-    pub fn set_transport(&mut self, transport: Option<OpenvasEncaps>) {
-        self.transport = transport;
-    }
-
     pub fn transport(&self) -> &Option<OpenvasEncaps> {
         &self.transport
     }
@@ -141,16 +137,6 @@ impl TcpConnection {
     pub fn set_tls(&mut self, tls: ClientConnection) {
         let stream = self.stream.get_mut();
         stream.set_tls(tls);
-    }
-
-    pub fn tls(&self) -> &Option<ClientConnection> {
-        let stream = self.stream.get_ref();
-        stream.tls()
-    }
-
-    pub fn set_transport(&mut self, transport: Option<OpenvasEncaps>) {
-        let stream = self.stream.get_mut();
-        stream.set_transport(transport);
     }
 
     pub fn transport(&self) -> &Option<OpenvasEncaps> {

--- a/rust/src/nasl/builtin/raw_ip/tcp_scan.rs
+++ b/rust/src/nasl/builtin/raw_ip/tcp_scan.rs
@@ -33,9 +33,12 @@ pub enum PortState {
     Unknown,
     Closed,
     Open,
-    Silent,   // Filtered - no response
+    Silent, // Filtered - no response
+    #[allow(unused)]
     Rejected, // Filtered - ICMP unreachable
+    #[allow(unused)]
     NotTested,
+    #[allow(unused)]
     Testing,
 }
 
@@ -119,6 +122,7 @@ pub struct ScannerConfig {
     pub read_timeout: Duration,
     pub min_connections: usize,
     pub max_connections: usize,
+    #[allow(unused)]
     pub safe_checks: bool,
 }
 

--- a/rust/src/nasl/code.rs
+++ b/rust/src/nasl/code.rs
@@ -49,13 +49,6 @@ impl ParseResult {
         self.result
     }
 
-    pub fn num_errors(&self) -> usize {
-        match &self.result {
-            Ok(_) => 0,
-            Err(errs) => errs.len(),
-        }
-    }
-
     pub fn emit_errors(self) -> Result<Ast, Vec<ParseError>> {
         match self.result {
             Ok(result) => Ok(result),

--- a/rust/src/nasl/interpreter/forking_interpreter.rs
+++ b/rust/src/nasl/interpreter/forking_interpreter.rs
@@ -1,6 +1,8 @@
 use futures::{Stream, stream};
 
-use crate::nasl::{NaslVersion, Register, ScanCtx, syntax::grammar::Ast};
+#[cfg(test)]
+use crate::nasl::NaslVersion;
+use crate::nasl::{Register, ScanCtx, syntax::grammar::Ast};
 
 use super::{Interpreter, Result};
 
@@ -39,6 +41,7 @@ impl<'ctx> ForkingInterpreter<'ctx> {
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn iter_blocking(self) -> impl Iterator<Item = Result> + use<> {
         use futures::StreamExt;
 
@@ -116,6 +119,7 @@ impl<'ctx> ForkingInterpreter<'ctx> {
         &self.interpreters[0].register
     }
 
+    #[cfg(test)]
     pub fn with_version(mut self, version: NaslVersion) -> ForkingInterpreter<'ctx> {
         for interpreter in self.interpreters.iter_mut() {
             interpreter.version = version;

--- a/rust/src/nasl/interpreter/tests/retry.rs
+++ b/rust/src/nasl/interpreter/tests/retry.rs
@@ -5,7 +5,10 @@
 //! Checks that errors that specify that they are solvable by
 //! retrying are actually retried within the interpreter.
 
-use crate::nasl::{test_prelude::*, utils::Executor};
+use crate::nasl::{
+    test_prelude::*,
+    utils::{Executor, error::Retryable},
+};
 
 struct Counter {
     count: usize,

--- a/rust/src/nasl/mod.rs
+++ b/rust/src/nasl/mod.rs
@@ -29,7 +29,6 @@ pub mod prelude {
     pub use super::utils::ArgumentError;
     pub use super::utils::FnError;
     pub use super::utils::NaslResult;
-    pub use super::utils::error::Retryable;
     pub use super::utils::error::ReturnValue;
     pub use super::utils::error::WithErrorInfo;
     pub use super::utils::function::CheckedPositionals;

--- a/rust/src/nasl/syntax/grammar.rs
+++ b/rust/src/nasl/syntax/grammar.rs
@@ -29,6 +29,7 @@ impl Ast {
         Self { stmts }
     }
 
+    #[cfg(test)]
     pub fn stmts(self) -> Vec<Statement> {
         self.stmts
     }

--- a/rust/src/nasl/syntax/loader.rs
+++ b/rust/src/nasl/syntax/loader.rs
@@ -228,10 +228,6 @@ impl TestLoader {
         }
     }
 
-    pub fn insert(&mut self, format: String, script: String) {
-        self.files.insert(format, script);
-    }
-
     pub fn with_file(mut self, file_name: &str, contents: String) -> Self {
         self.files.insert(file_name.into(), contents);
         self

--- a/rust/src/nasl/syntax/parser/error.rs
+++ b/rust/src/nasl/syntax/parser/error.rs
@@ -4,7 +4,7 @@ use codespan_reporting::diagnostic::Diagnostic;
 
 use crate::nasl::{
     error::{IntoDiagnostic, Span, Spanned, basic_error_diagnostic},
-    syntax::{Keyword, TokenKind, TokenizerError, tokenizer::TokenizerErrorKind},
+    syntax::{TokenKind, TokenizerError, tokenizer::TokenizerErrorKind},
 };
 
 #[derive(Debug)]
@@ -25,8 +25,6 @@ pub enum ErrorKind {
     TokensExpected(Vec<TokenKind>),
     TokenExpected(TokenKind),
     ExpressionExpected,
-    EofExpected,
-    UnexpectedKeyword(Keyword),
     IdentExpected,
     LiteralExpected,
     StringExpected,
@@ -34,7 +32,6 @@ pub enum ErrorKind {
     ExpectedUnaryOperator,
     ExpectedBinaryOperator,
     NotAllowedInPlaceExpr,
-    InvalidDescriptionBlock(String),
     RecursionLimitExceeded,
 }
 
@@ -68,8 +65,6 @@ impl Display for ErrorKind {
                 write!(f, "Error during tokenization: {e}")
             }
             ErrorKind::ExpressionExpected => write!(f, "Expected expression"),
-            ErrorKind::EofExpected => write!(f, "Expected end of file"),
-            ErrorKind::UnexpectedKeyword(kw) => write!(f, "Unexpected keyword {kw:?}"),
             ErrorKind::IdentExpected => write!(f, "Expected identifier."),
             ErrorKind::LiteralExpected => write!(f, "Expected literal."),
             ErrorKind::StringExpected => {
@@ -96,9 +91,6 @@ impl Display for ErrorKind {
             }
             ErrorKind::NotAllowedInPlaceExpr => {
                 write!(f, "Not a valid assignment target.")
-            }
-            ErrorKind::InvalidDescriptionBlock(s) => {
-                write!(f, "Invalid description block. {s}")
             }
             ErrorKind::RecursionLimitExceeded => {
                 write!(f, "Recursion limit exceeded")

--- a/rust/src/nasl/utils/error.rs
+++ b/rust/src/nasl/utils/error.rs
@@ -179,8 +179,10 @@ pub trait WithErrorInfo<Info> {
     fn with(self, e: Info) -> Self::Error;
 }
 
+#[cfg(test)]
 pub struct Retryable;
 
+#[cfg(test)]
 impl<E: Into<FnError>> WithErrorInfo<Retryable> for E {
     type Error = FnError;
 

--- a/rust/src/nasl/utils/executor/mod.rs
+++ b/rust/src/nasl/utils/executor/mod.rs
@@ -42,6 +42,7 @@ pub struct Executor {
 
 impl Executor {
     /// Construct an executor for a single function set.
+    #[cfg(test)]
     pub fn single<S: IntoFunctionSet + 'static>(s: S) -> Self
     where
         <S as IntoFunctionSet>::State: Send + Sync,

--- a/rust/src/nasl/utils/mod.rs
+++ b/rust/src/nasl/utils/mod.rs
@@ -149,7 +149,7 @@ pub mod scan_ctx;
 pub use super::interpreter::Register;
 pub use error::ArgumentError;
 pub use error::FnError;
-pub use scan_ctx::{ScanCtx, ScriptCtx};
+pub use scan_ctx::ScanCtx;
 
 pub use executor::{Executor, IntoFunctionSet, NaslFunction, StoredFunctionSet};
 

--- a/rust/src/nasl/utils/scan_ctx.rs
+++ b/rust/src/nasl/utils/scan_ctx.rs
@@ -669,7 +669,6 @@ impl Drop for ScanCtx<'_> {
 pub struct JmpDesc {
     pub in_addr: Option<IpAddr>,
     pub count: usize,
-    pub socket: Option<socket2::Socket>,
 }
 
 #[derive(Default)]

--- a/rust/src/notus/loader/mod.rs
+++ b/rust/src/notus/loader/mod.rs
@@ -8,7 +8,7 @@ use crate::models::Product;
 
 use crate::nasl::syntax::{LoadError, Loader};
 
-use crate::feed::{HashSumFileItem, HashSumNameLoader, SignatureChecker, VerifyError};
+use crate::feed::{HashSumFileItem, HashSumNameLoader, VerifyError};
 use crate::feed::{NoVerifier, check_signature};
 use crate::notus::advisories::ProductsAdvisories;
 use crate::notus::error::{Error, LoadProductErrorKind};
@@ -18,8 +18,6 @@ pub struct ProductLoader {
     loader: Loader,
     feed_integrity_check: bool,
 }
-
-impl SignatureChecker for ProductLoader {}
 
 impl ProductLoader {
     pub fn new(feed_integrity_check: bool, loader: Loader) -> Self {

--- a/rust/src/openvas/error.rs
+++ b/rust/src/openvas/error.rs
@@ -8,16 +8,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum OpenvasError {
-    #[error("A scan with ID {0} already exists.")]
-    DuplicateScanID(String),
-    #[error("Unable to launch openvas executable.")]
-    MissingExec,
     #[error("A scan with ID {0} not found.")]
     ScanNotFound(String),
     #[error("Unable to run command: {0}")]
     CmdError(io::Error),
-    #[error("Maximum number of queued scan reached.")]
-    MaxQueuedScans,
-    #[error("Unable to run openvas.")]
-    UnableToRunExec,
 }

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/alive.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/alive.rs
@@ -15,6 +15,7 @@ pub trait GetHealthAlive: Prefixed + Send + Sync {
 
 pub enum Alive {
     Alive,
+    #[allow(unused)]
     NotAlive,
 }
 

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/ready.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/ready.rs
@@ -15,6 +15,7 @@ pub trait GetHealthReady: Prefixed + Send + Sync {
 
 pub enum Ready {
     Ready,
+    #[allow(unused)]
     NotReady,
 }
 

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/started.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/started.rs
@@ -15,6 +15,7 @@ pub trait GetHealthStarted: Send + Sync {
 
 pub enum Started {
     Started,
+    #[allow(unused)]
     NotStarted,
 }
 

--- a/rust/src/scanner/error.rs
+++ b/rust/src/scanner/error.rs
@@ -95,6 +95,7 @@ impl ScriptResult {
     }
 
     /// Returns true when the script didn't run
+    #[cfg(test)]
     pub fn has_not_run(&self) -> bool {
         matches!(
             self.kind,

--- a/rust/src/scanner/preferences/preference.rs
+++ b/rust/src/scanner/preferences/preference.rs
@@ -263,9 +263,6 @@ impl Default for ScanPrefValue {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct FullScanPreferences(Vec<FullScanPreference>);
-
 /// Configuration preference information for a scan. The type can be derived from the default value.
 #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct FullScanPreference {

--- a/rust/src/scanner/scan.rs
+++ b/rust/src/scanner/scan.rs
@@ -13,6 +13,7 @@ pub struct Scan {
     pub vts: Vec<VT>,
     pub scan_preferences: ScanPrefs,
     pub alive_test_methods: Vec<AliveTestMethods>,
+    #[allow(unused)]
     pub alive_test_ports: Vec<Port>,
 }
 

--- a/rust/src/storage/items/nvt.rs
+++ b/rust/src/storage/items/nvt.rs
@@ -134,14 +134,6 @@ impl Display for Nvt {
     }
 }
 
-impl Nvt {
-    /// Returns Err with the feed_version if it is a version Ok otherwise
-    /// // TODO: delete
-    pub fn set_from_field(&mut self, field: NvtField) {
-        field.move_to_data(&mut self.data);
-    }
-}
-
 impl From<VulnerabilityData> for Nvt {
     fn from(value: VulnerabilityData) -> Self {
         let oid = value.adv.oid.clone();


### PR DESCRIPTION
Part of the monthly clean up sessions, removing some unused items and marking others as `#[allow(unused)]` or `#[cfg(test)]`.

Critical items here: `Product.version` is never used - is this intended?

Jira: SC-1716