### PR TITLE
Fix: specify the value parser to clap

### DIFF
--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -523,6 +523,7 @@ impl Config {
                     .env("MAX_QUEUED_SCANS")
                     .long("max-queued-scans")
                     .action(ArgAction::Set)
+                    .value_parser(clap::value_parser!(usize))
                     .help("Maximum number of queued scans")
             )
             .arg(
@@ -530,6 +531,7 @@ impl Config {
                     .env("MAX_RUNNING_SCANS")
                     .long("max-running-scans")
                     .action(ArgAction::Set)
+                    .value_parser(clap::value_parser!(usize))
                     .help("Maximum number of active running scans, omit for no limits")
 
             )


### PR DESCRIPTION
Fix: specify the value parser to clap, so it doesn't panic when the setting is passed via environment variable

SC-1723

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
