### PR TITLE
Fix: openvasd result

### DIFF
--- a/rust/src/nasl/builtin/report/mod.rs
+++ b/rust/src/nasl/builtin/report/mod.rs
@@ -60,7 +60,7 @@ impl Reporting {
             r_type: typus,
             ip_address: Some(ip_address.to_string()),
             hostname,
-            oid: Some(ctx.scan().0.clone()),
+            oid: ctx.nvt().as_ref().map(|vt| vt.oid.clone()),
             port,
             protocol: Some(protocol),
             message: data,

--- a/rust/src/nasl/builtin/report/tests.rs
+++ b/rust/src/nasl/builtin/report/tests.rs
@@ -38,7 +38,7 @@ async fn verify(function: &str, result_type: ResultType) {
             r_type: result_type.clone(),
             ip_address: Some(ctx.target().ip_addr().to_string()),
             hostname: Some("".into()),
-            oid: Some(ctx.scan().0.clone()),
+            oid: ctx.nvt().as_ref().map(|vt| vt.oid.clone()),
             port,
             protocol: Some(protocol),
             message: Some(format!("test{id}")),


### PR DESCRIPTION
Fix: openvasd result
openvasd builtin scanner create results with the scan_id instead of the script oid

SC-1727

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
