### PR TITLE
Fix deadlock when image resolution fails.

### DIFF
--- a/rust/data/tests/scanner/config/cis_single_db_connection.toml
+++ b/rust/data/tests/scanner/config/cis_single_db_connection.toml
@@ -1,0 +1,9 @@
+[scanner]
+type = 'openvasd'
+
+[container_image_scanner.database]
+location = 'in-memory'
+max_connections = 1
+
+[container_image_scanner.image]
+batch_size = 1

--- a/rust/src/openvasd/api_tests/mod.rs
+++ b/rust/src/openvasd/api_tests/mod.rs
@@ -208,6 +208,38 @@ async fn container_image_scan_docker_hub_ubuntu_24_04() {
     scan.delete().await;
 }
 
+#[tokio::test]
+async fn container_image_scanner_deadlock() {
+    let mut registry = mockito::Server::new_async().await;
+    // Set up a registry that returns unauthorized. The exact failure
+    // mode here is probably not very important, what is important is that
+    // the image resolution fails.
+    registry
+        .mock("GET", "/v2/")
+        .with_status(StatusCode::UNAUTHORIZED.as_u16().into())
+        .create();
+
+    let t = Test::new("container_image_scanner_deadlock")
+        .config("cis_single_db_connection")
+        .await;
+    let scan = Scan {
+        scan_id: "fake_id".into(),
+        target: Target {
+            hosts: vec![format!("oci://{}", registry.host_with_port())],
+            ..Default::default()
+        },
+        scan_preferences: vec![("registry_allow_insecure", "true").into()],
+        ..Default::default()
+    };
+
+    let scan = t.create_container_image_scan(scan).await;
+    scan.start().await;
+    scan.wait_for(Phase::Failed.with_timeout(Duration::from_secs(5)))
+        .await
+        .body::<Status>()
+        .snapshot("status");
+}
+
 #[cfg(feature = "requires-compose")]
 mod requires_compose {
     use std::path::PathBuf;

--- a/rust/src/openvasd/api_tests/snapshots/container_image_scanner_deadlock GET __container-image-scanner__scans__fake_id__status_status.snap
+++ b/rust/src/openvasd/api_tests/snapshots/container_image_scanner_deadlock GET __container-image-scanner__scans__fake_id__status_status.snap
@@ -1,0 +1,17 @@
+---
+source: src/openvasd/api_tests/test_builder.rs
+expression: inner
+---
+Status(
+  start_time: "[redacted]",
+  end_time: "[redacted]",
+  status: failed,
+  host_info: Some(HostInfo(
+    all: 1,
+    excluded: 0,
+    dead: 1,
+    alive: 0,
+    queued: 0,
+    finished: 0,
+  )),
+)

--- a/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/scan.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/scan.rs
@@ -53,8 +53,7 @@ async fn set_scan_images(
     id: &str,
     images: &[Result<Image, RegistryError>],
 ) -> Result<(), sqlx::Error> {
-    let mut conn = pool.acquire().await?;
-    let mut tx = conn.begin().await?;
+    let mut tx = pool.begin().await?;
     let count = images.len();
     let dead_count = images.iter().filter(|x| x.is_err()).count();
     let success_count = images.iter().filter(|x| x.is_ok()).count();


### PR DESCRIPTION
This adds a API test that mocks a registry which returns unauthorized/401 on any request.

On `main`, this test times out because the get_scan_images function tries to obtain two connections to the pool while `max_connections` is set to 1. 

This bug is then fixed by a minor change in `set_scan_images`: We previously acquired two connections to the DB unnecessarily. Now we use only one and let it go out of scope before we re-use the connection pool.

Jira: SC-1726