### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -29,13 +29,9 @@ on:
     # rebuild image every sunday
     - cron: "0 0 * * 0"
 
-# Grants rights to push to the Github container registry.
-# The main workflow has to set the permissions.
+# Jobs that publish containers opt into additional permissions below.
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  pull-requests: write
 
 jobs:
   # sets the release kind when it wasn't triggered by an workflow dispatch
@@ -89,6 +85,10 @@ jobs:
   container:
     if: github.event_name != 'merge_group'
     needs: [init]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/push-container.yml
     secrets:
       dockerhub_user: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -112,6 +112,9 @@ jobs:
     if: github.event_name == 'merge_group'
     needs: [init]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out merge group
         uses: actions/checkout@v7

--- a/.github/workflows/control.yml
+++ b/.github/workflows/control.yml
@@ -22,6 +22,8 @@ on:
       - synchronize
       - reopened
       - closed
+  merge_group:
+    types: [checks_requested]
   repository_dispatch:
   schedule:
     # rebuild image every sunday
@@ -71,8 +73,9 @@ jobs:
     uses: ./.github/workflows/init.yaml
     with:
       release: ${{ needs.adapt_release.outputs.kind }}
+      base_ref: ${{ github.event.merge_group.base_ref || github.base_ref }}
   unittests:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     name: unit-tests
     uses: ./.github/workflows/tests.yml
   build:
@@ -81,9 +84,10 @@ jobs:
     with:
       binary_version: ${{ needs.init.outputs.binary_version }}
   linting:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     uses: ./.github/workflows/linting.yml
   container:
+    if: github.event_name != 'merge_group'
     needs: [init]
     uses: ./.github/workflows/push-container.yml
     secrets:
@@ -103,15 +107,75 @@ jobs:
       is_latest_tag: ${{needs.init.outputs.docker_build_is_latest}}
       is_version_tag: ${{needs.init.outputs.docker_build_is_version }}
       binary_version: ${{ needs.init.outputs.binary_version }}
+  merge_container:
+    name: Build merge-group container
+    if: github.event_name == 'merge_group'
+    needs: [init]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out merge group
+        uses: actions/checkout@v7
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679fb # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b05f3f5519dd87d3ba754cc423b652a5edd6d2c5 # v4.2.0
+      - name: Build and push merge-group container
+        uses: docker/build-push-action@3b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: .docker/prod.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:merge-${{ github.sha }}
+          build-args: |
+            BIN_VERSION=${{ needs.init.outputs.binary_version }}
   functional:
-    if: github.event_name == 'pull_request'
-    needs: [build, container]
+    if: >-
+      ${{
+        always() &&
+        needs.build.result == 'success' &&
+        (
+          (github.event_name == 'merge_group' && needs.merge_container.result == 'success') ||
+          (github.event_name == 'pull_request' && github.event.action != 'closed' && needs.container.result == 'success')
+        )
+      }}
+    needs: [build, container, merge_container]
     uses: ./.github/workflows/functional.yaml
     with:
-      image: "ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}"
+      image: "ghcr.io/${{ github.repository }}:${{ github.event_name == 'merge_group' && format('merge-{0}', github.sha) || format('pr-{0}', github.event.pull_request.number) }}"
+
+  merge_gate:
+    name: Merge gate
+    if: ${{ always() && (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.action != 'closed')) }}
+    needs: [unittests, build, linting, container, merge_container, functional]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required CI jobs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          UNITTESTS_RESULT: ${{ needs.unittests.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          LINTING_RESULT: ${{ needs.linting.result }}
+          CONTAINER_RESULT: ${{ needs.container.result }}
+          MERGE_CONTAINER_RESULT: ${{ needs.merge_container.result }}
+          FUNCTIONAL_RESULT: ${{ needs.functional.result }}
+        run: |
+          test "$UNITTESTS_RESULT" = success
+          test "$BUILD_RESULT" = success
+          test "$LINTING_RESULT" = success
+          test "$FUNCTIONAL_RESULT" = success
+          if [ "$EVENT_NAME" = merge_group ]; then
+            test "$MERGE_CONTAINER_RESULT" = success
+          else
+            test "$CONTAINER_RESULT" = success
+          fi
 
   release:
-    name: "release (${{ needs.init.outputs.latest_version }} -> ${{ needs.init.outputs.new_version }}"
+    name: "release (${{ needs.init.outputs.release_latest_version }} -> ${{ needs.init.outputs.release_new_version }})"
     permissions:
       contents: write
     # we release after container build so that we can release on a closed pr as we don't push the release container yet

--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -1,7 +1,5 @@
 name: functional
 
-# github.event.pull_request.number
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/init.yaml
+++ b/.github/workflows/init.yaml
@@ -105,8 +105,10 @@ jobs:
         if: inputs.base_ref == '' 
         run: echo "RELEASE_REF=${{ inputs.ref_name }}" >> $GITHUB_ENV
       - name: "set RELEASE_REF = ${{ inputs.base_ref }}"
-        if: inputs.base_ref != '' 
-        run: echo "RELEASE_REF=${{ inputs.base_ref }}" >> $GITHUB_ENV
+        if: inputs.base_ref != ''
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: echo "RELEASE_REF=${BASE_REF#refs/heads/}" >> "$GITHUB_ENV"
       - name: RELEASE_REF != NULL
         run: ([ -n "${{ env.RELEASE_REF }}" ])
       - name: "LATEST_VERSION"

--- a/.github/workflows/push-container.yml
+++ b/.github/workflows/push-container.yml
@@ -96,26 +96,24 @@ jobs:
       labels: |
         org.opencontainers.image.vendor=Greenbone
         org.opencontainers.image.base.name=debian:stable-slim
-      prefix: ${{ matrix.build.prefix }}
-      tags: ${{ matrix.tags }}
+      tags: ${{ matrix.build.tags }}
       build-args: |
         BIN_VERSION=${{ inputs.binary_version }}
         ${{ matrix.build.variant-build-args }}
       images: |
         ghcr.io/${{ github.repository }},enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
-        ${{ vars.GREENBONE_REGISTRY }}/openvas-detect-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event_name == 'schedule' }}
+        ${{ vars.GREENBONE_REGISTRY }}/openvas-detect-dev/${{ github.event.repository.name }},enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event_name == 'schedule' }}
     secrets: inherit
 
   trigger-replication:
     needs:
       - build
-    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.repository == 'greenbone/openvas-scanner' }}
+    if: ${{ !cancelled() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event_name == 'schedule') && github.repository == 'greenbone/openvas-scanner' }}
     runs-on: self-hosted-generic
     steps:
       - name: Ensure all tags are replicated on the public registry
         uses: greenbone/actions/trigger-harbor-replication@v3.36.12
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           registry: ${{ vars.GREENBONE_REGISTRY }}
           token: ${{ secrets.GREENBONE_REGISTRY_REPLICATION_TOKEN }}

--- a/.github/workflows/push-container.yml
+++ b/.github/workflows/push-container.yml
@@ -43,7 +43,6 @@ permissions:
   contents: read
   packages: write
   id-token: write
-  pull-requests: write
 
 jobs:
   build:
@@ -104,7 +103,9 @@ jobs:
         ghcr.io/${{ github.repository }},enable=true
         ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event_name == 'schedule' }}
         ${{ vars.GREENBONE_REGISTRY }}/openvas-detect-dev/${{ github.event.repository.name }},enable=${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event_name == 'schedule' }}
-    secrets: inherit
+    secrets:
+      GREENBONE_REGISTRY_USER: ${{ secrets.greenbone_registry_user }}
+      GREENBONE_REGISTRY_TOKEN: ${{ secrets.greenbone_registry_token }}
 
   trigger-replication:
     needs:


### PR DESCRIPTION
This adds a workflow `merge_gate` which we can use to run in the merge queue (once it is enabled, cannot do that in advance). 

The `merge_gate` workflow basically just checks whether linting, unit tests, functional tests and container builds succeded.

The other changes in this PR are to make sure that the actions that the merge queue triggers do not accidentally build releases.