### PR TITLE
Fix: add table index on plugins table

### DIFF
--- a/rust/migrations/20260804140000_add_plugins_filename_index.sql
+++ b/rust/migrations/20260804140000_add_plugins_filename_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_plugins_filename ON plugins (json_extract(json_blob, '$.filename'));


### PR DESCRIPTION
Fix: add table index on plugins table. This avoid "slow statement" warnings and stalling scan starts. Now Sqlite resolve lhe lookup directly for the `Retriever<Filename>`

SC-1734

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
