### PR TITLE
Remove build time creation of .tar file.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -154,8 +154,6 @@ insta = { workspace = true }
 mockito = "1.7.2"
 
 [build-dependencies]
-flate2 = "1"
-tar = "0"
 vergen-git2 = "10.0.0"
 
 [features]

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,53 +1,4 @@
-use std::{
-    fmt::Display,
-    fs::{self, File},
-    io::BufWriter,
-    path::Path,
-};
-
-use flate2::{Compression, write::GzEncoder};
-use tar::Builder;
 use vergen_git2::{Emitter, Git2};
-
-fn create_test_layer(name: &str) -> Option<()> {
-    fn ignore_error<O, E>(input: Result<O, E>) -> Option<O>
-    where
-        E: Display,
-    {
-        match input {
-            Ok(x) => Some(x),
-            Err(e) => {
-                println!("cargo:warning={e}: Some tests may fail due to missing layer.");
-                None
-            }
-        }
-    }
-
-    let input_dir = format!("data/tests/images/{name}");
-    let input_dir = Path::new(&input_dir);
-    let output = format!("data/tests/layers/{name}.tar.gz");
-    let output_path = Path::new(&output);
-
-    if !output_path.exists() {
-        println!("cargo:info=Creating {output}");
-
-        if let Some(parent_dir) = output_path.parent() {
-            ignore_error(fs::create_dir_all(parent_dir))?;
-        }
-        let tar_gz = ignore_error(File::create(output_path))?;
-        let enc = GzEncoder::new(BufWriter::new(tar_gz), Compression::default());
-        let mut tar = Builder::new(enc);
-        ignore_error(tar.append_dir_all(".", input_dir))?;
-        ignore_error(ignore_error(tar.into_inner())?.finish())?;
-
-        println!("cargo:info=Created {output}.");
-    }
-    Some(())
-}
-
-fn create_test_binaries() {
-    create_test_layer("victim");
-}
 
 fn set_version() {
     if let Some(bv) = std::option_env!("BIN_VERSION") {
@@ -64,7 +15,5 @@ fn set_version() {
 }
 
 fn main() {
-    //println!("cargo:rerun-if-changed=migrations");
-    create_test_binaries();
     set_version();
 }

--- a/rust/data/tests/layers/.gitignore
+++ b/rust/data/tests/layers/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -567,12 +567,18 @@ impl Timed<Result<Vec<u8>, RegistryError>> {
 
 #[cfg(test)]
 pub mod fake {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        path::Path,
+        sync::OnceLock,
+    };
 
     use docker_registry::mediatypes::MediaTypes;
+    use flate2::{Compression, write::GzEncoder};
     use itertools::Itertools;
     use mockito::Matcher;
     use sha2::{Digest, Sha256};
+    use tar::Builder;
 
     use crate::container_image_scanner::image::Image;
 
@@ -585,6 +591,24 @@ pub mod fake {
 
     fn digest(input: &[u8]) -> String {
         format!("sha256:{}", hash_hex(input))
+    }
+
+    fn victim_layer() -> &'static [u8] {
+        static LAYER: OnceLock<Vec<u8>> = OnceLock::new();
+
+        LAYER.get_or_init(|| {
+            let input = Path::new(env!("CARGO_MANIFEST_DIR")).join("data/tests/images/victim");
+            let encoder = GzEncoder::new(Vec::new(), Compression::default());
+            let mut archive = Builder::new(encoder);
+            archive
+                .append_dir_all(".", input)
+                .expect("create victim test layer");
+            archive
+                .into_inner()
+                .expect("finish victim test archive")
+                .finish()
+                .expect("compress victim test layer")
+        })
     }
 
     #[derive(Debug, Clone)]
@@ -814,13 +838,8 @@ pub mod fake {
             server: &mut mockito::ServerGuard,
             status_codes: Vec<usize>,
         ) -> Vec<mockito::Mock> {
-            const NICHTSFREI_VICTIM_LAYER: &[u8] = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/data/tests/layers/victim.tar.gz"
-            ));
-
             // we currently just have one layer example and are repeating it for each image.
-            let layer = vec![Layer::from(NICHTSFREI_VICTIM_LAYER)];
+            let layer = vec![Layer::from(victim_layer())];
 
             let manifests = self.images.iter().map(|image| {
                 let manifest = Manifest {
@@ -1001,9 +1020,6 @@ pub mod fake {
         /// Creates caralog and image list for each given image, but manifest as well as block
         /// download only for nichtsfrei/victim:latest. This is because there is just one binary
         /// layer available at the moment.
-        ///
-        /// If new entries are added to the build.rs and inside `data/tests/layers` those
-        /// manifest_mocks needs to be extended within FakeResponses::Pull.
         pub async fn serve_images(images: &[Image], status_codes: &[usize]) -> Self {
             let mut port_expander: PortExpander = status_codes.into();
             let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
In order to test the container image scanner, we set up a mock registry which serves a tar file. This tar was prepared from the `build.rs` and written into a specific directory. This PR moves the creation of this tar to test run-time by creating it in memory. This simplifies the build system and makes my life easier in #2336 .
