### PR TITLE
Add Prometheus metrics endpoint and real health probes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4167,6 +4167,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quick-xml"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4929,6 +4950,7 @@ dependencies = [
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
+ "prometheus",
  "quick-xml",
  "rand 0.10.1",
  "rc4",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -73,6 +73,7 @@ pathdiff = "0.2.3"
 pbkdf2 = { version = "0.13.0", features = ["password-hash"] }
 pcap = { version = "2.4.0", features = ["capture-stream"] }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem", "std"] }
+prometheus = "0.13"
 pnet = { version = "0.35.0" }
 pnet_base = { version = "0.35.0" }
 pnet_macros = { version = "0.35.0" }

--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -51,6 +51,8 @@ tags:
   description: Feed related
 - name: notus
   description: Notus vulnerability scanner
+- name: metrics
+  description: Prometheus metrics endpoint
 paths:
   /health:
     head:
@@ -83,15 +85,15 @@ paths:
 
   /health/ready:
     get:
-      description: "Get application's health information"
+      description: "Get application's readiness. Returns 200 when the feed is synced and the scanner is ready to accept scans; 503 otherwise."
       operationId: "get_health_ready"
       tags:
       - "health"
       responses:
         "200":
-          description: "Ok"
+          description: "Ready - feed synced"
         "503":
-          description: "Service Unavailable"
+          description: "Service Unavailable - feed not yet synced"
   /health/started:
     get:
       description: "Get application's health information"
@@ -101,6 +103,24 @@ paths:
       responses:
         "200":
           description: "Ok"
+        "503":
+          description: "Service Unavailable"
+  /metrics:
+    get:
+      description: "Prometheus metrics endpoint. Exposes scan, feed, VT execution, DB, and HTTP metrics in Prometheus text format."
+      operationId: "get_metrics"
+      tags:
+      - "metrics"
+      security: []
+      responses:
+        "200":
+          description: "Prometheus text-format metrics"
+          content:
+            text/plain:
+              schema:
+                type: string
+        "401":
+          description: "Unauthorized (when metrics authentication is enabled)"
         "503":
           description: "Service Unavailable"
 

--- a/rust/doc/observability.md
+++ b/rust/doc/observability.md
@@ -1,0 +1,89 @@
+# Observability
+
+openvasd exposes Prometheus metrics and meaningful health probes for production monitoring.
+
+## Metrics Endpoint
+
+Enable the `/metrics` endpoint with the `--enable-metrics` flag or the `ENABLE_METRICS=true`
+environment variable:
+
+```bash
+openvasd --enable-metrics
+```
+
+By default, `/metrics` follows the global authentication setting (API key or mTLS).
+You can override this with `--metrics-auth`:
+
+```bash
+# Expose /metrics without authentication (for internal scrape configs)
+openvasd --enable-metrics --metrics-auth false
+
+# Require authentication for /metrics
+openvasd --enable-metrics --metrics-auth true
+```
+
+### Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: 'openvasd'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:3000']
+    metrics_path: /metrics
+    # If authentication is enabled, add the API key header:
+    # bearer_token: 'your-api-key'
+```
+
+## Metric Catalog
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `openvasd_scans_started_total` | counter | — | Total scans started |
+| `openvasd_scans_completed_total` | counter | `status` | Scans that reached a terminal state (`succeeded`, `failed`, `stopped`) |
+| `openvasd_scans_active` | gauge | — | Currently running scans |
+| `openvasd_vt_executions_total` | counter | `result` | VT executions by outcome (`ok`, `error`, `timeout`) |
+| `openvasd_vt_execution_seconds` | histogram | `stage` | VT execution duration by scheduling stage |
+| `openvasd_feed_state` | gauge | `type` | Feed state: 0=unknown, 1=syncing, 2=synced |
+| `openvasd_feed_last_sync_timestamp` | gauge | — | Unix timestamp of last successful feed sync |
+| `openvasd_results_total` | counter | `type` | Results emitted by type (`alarm`, `log`, `error`, `hostdetail`, ...) |
+| `openvasd_db_active_connections` | gauge | — | Active database connections |
+| `openvasd_db_query_seconds` | histogram | `op` | Database query duration |
+| `openvasd_http_requests_total` | counter | `method`, `status` | HTTP requests handled |
+| `openvasd_http_request_seconds` | histogram | `method` | HTTP request duration |
+| `openvasd_http_active` | gauge | — | In-flight HTTP requests |
+
+## Health Probes
+
+openvasd provides three health endpoints:
+
+### `/health/alive`
+Returns 200 if the HTTP server is responsive. Returns 503 if the server is
+overloaded (too many connections).
+
+### `/health/ready`
+Returns 200 when the feed has reached `Synced` state, meaning the scanner is
+ready to accept and execute scans. Returns 503 while the feed is loading or
+syncing. Use this for Kubernetes readiness probes:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 3000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+```
+
+### `/health/started`
+Returns 200 once the feed has been synced at least once. Use this for Kubernetes
+startup probes:
+
+```yaml
+startupProbe:
+  httpGet:
+    path: /health/started
+    port: 3000
+  failureThreshold: 30
+  periodSeconds: 10
+```

--- a/rust/src/openvasd/README.md
+++ b/rust/src/openvasd/README.md
@@ -176,6 +176,10 @@ Options:
           enable get scans endpoint. Default 'true'. [env: ENABLE_GET_SCANS=] [possible values: true, false]
       --enable-get-performance [<enable-get-performance>]
           enable get performance endpoint. Default 'false'. [env: ENABLE_GET_PERFORMANCE=] [possible values: true, false]
+      --enable-metrics [<enable-metrics>]
+          enable /metrics endpoint (Prometheus text format). Default 'false'. [env: ENABLE_METRICS=] [possible values: true, false]
+      --metrics-auth [<metrics-auth>]
+          require auth for /metrics (true/false). Default: follow global auth. [env: METRICS_AUTH=] [possible values: true, false]
       --api-key <api-key>
           API key that must be set as X-API-KEY header to gain access [env: API_KEY=]
       --scanner-type <ospd,openvas>

--- a/rust/src/openvasd/config/mod.rs
+++ b/rust/src/openvasd/config/mod.rs
@@ -191,6 +191,14 @@ pub struct Endpoints {
     pub enable_get_performance: Option<bool>,
     #[serde(default)]
     pub key: Option<String>,
+    /// Enable the `/metrics` endpoint (Prometheus text format).
+    #[serde(default)]
+    pub enable_metrics: bool,
+    /// When `Some(true)`, `/metrics` requires authentication (API key or mTLS).
+    /// When `Some(false)`, `/metrics` is exposed without authentication.
+    /// When `None` (default), follows the global authentication setting.
+    #[serde(default)]
+    pub metrics_auth: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
@@ -509,6 +517,23 @@ impl Config {
                     .help("enable get performance endpoint. Default 'false'."),
             )
             .arg(
+                clap::Arg::new("enable-metrics")
+                    .env("ENABLE_METRICS")
+                    .long("enable-metrics")
+                    .num_args(0..=1)
+                    .value_parser(clap::builder::BoolValueParser::new())
+                    .default_missing_value("true")
+                    .help("enable /metrics endpoint (Prometheus). Default 'false'."),
+            )
+            .arg(
+                clap::Arg::new("metrics-auth")
+                    .env("METRICS_AUTH")
+                    .long("metrics-auth")
+                    .num_args(0..=1)
+                    .value_parser(clap::builder::BoolValueParser::new())
+                    .help("require auth for /metrics (true/false). Default: follow global."),
+            )
+            .arg(
                 clap::Arg::new("api-key")
                     .env("API_KEY")
                     .long("api-key")
@@ -723,6 +748,12 @@ impl Config {
         }
         if let Some(enable) = cmds.get_one::<bool>("enable-get-performance") {
             config.endpoints.enable_get_performance = Some(*enable);
+        }
+        if let Some(enable) = cmds.get_one::<bool>("enable-metrics") {
+            config.endpoints.enable_metrics = *enable;
+        }
+        if let Some(auth) = cmds.get_one::<bool>("metrics-auth") {
+            config.endpoints.metrics_auth = Some(*auth);
         }
         if let Some(api_key) = cmds.get_one::<String>("api-key") {
             config.endpoints.key = Some(api_key.clone());

--- a/rust/src/openvasd/greenbone_scanner_framework/entry/mod.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/entry/mod.rs
@@ -347,9 +347,20 @@ where
 
         let acc = self.counter.clone();
         let max_connections = self.max_connections;
+        let req_method = req.method().clone();
         Box::pin(async move {
+            let metrics = crate::metrics::scanner_metrics();
+            let start = std::time::Instant::now();
+            metrics.http_request_started();
+
             if acc.load(Ordering::Relaxed) > max_connections {
                 tracing::trace!("Too many open connections, returning 503");
+                metrics.http_request_finished();
+                metrics.record_http_request(
+                    req_method.as_str(),
+                    "503",
+                    start.elapsed().as_secs_f64(),
+                );
                 return Ok(rb
                     .header("Retry-After", 10)
                     .status(StatusCode::SERVICE_UNAVAILABLE)
@@ -365,10 +376,21 @@ where
                 BodyKindContent::Binary(x) => rb
                     .header("Content-Type", "application/json")
                     .header("Content-Length", x.len()),
+                BodyKindContent::Text(x, ct) => rb
+                    .header("Content-Type", *ct)
+                    .header("Content-Length", x.len()),
                 BodyKindContent::BinaryStream(_) => rb.header("Content-Type", "application/json"),
             };
             let current = acc.fetch_sub(1, Ordering::Relaxed);
             tracing::trace!(current, max_connections, "releasing request");
+
+            let status = resp.status_code.as_u16().to_string();
+            metrics.record_http_request(
+                req_method.as_str(),
+                &status,
+                start.elapsed().as_secs_f64(),
+            );
+            metrics.http_request_finished();
 
             Ok(rb.status(resp.status_code).body(resp.content).unwrap())
         })

--- a/rust/src/openvasd/greenbone_scanner_framework/entry/response/mod.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/entry/response/mod.rs
@@ -20,6 +20,8 @@ pub enum BodyKindContent {
     Empty,
     /// Static binary buffer
     Binary(Bytes),
+    /// Static text buffer with an explicit content type
+    Text(Bytes, &'static str),
     /// Generic boxed stream
     BinaryStream(Pin<Box<dyn Stream<Item = Bytes> + Send>>),
 }
@@ -75,6 +77,16 @@ impl BodyKind {
                 content: BodyKindContent::Binary(v.into()),
             },
             Err(e) => internal_server_error!(e),
+        }
+    }
+
+    /// Creates a text response with an explicit content type.
+    ///
+    /// Used for non-JSON responses such as the Prometheus `/metrics` endpoint.
+    pub fn text_content(status_code: StatusCode, content_type: &'static str, v: String) -> Self {
+        BodyKind {
+            status_code,
+            content: BodyKindContent::Text(v.into(), content_type),
         }
     }
 
@@ -151,6 +163,7 @@ impl Body for BodyKindContent {
         match self {
             BodyKindContent::Empty => SizeHint::with_exact(0),
             BodyKindContent::Binary(b) => SizeHint::with_exact(b.len() as u64),
+            BodyKindContent::Text(b, _) => SizeHint::with_exact(b.len() as u64),
             _ => SizeHint::default(),
         }
     }
@@ -163,6 +176,11 @@ impl Body for BodyKindContent {
         match this {
             BodyKindContent::Empty => Poll::Ready(None),
             BodyKindContent::Binary(b) => {
+                let data = b.clone();
+                *this = BodyKindContent::Empty;
+                Poll::Ready(Some(Ok(Frame::data(data))))
+            }
+            BodyKindContent::Text(b, _) => {
                 let data = b.clone();
                 *this = BodyKindContent::Empty;
                 Poll::Ready(Some(Ok(Frame::data(data))))

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/mod.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/mod.rs
@@ -1,7 +1,6 @@
 mod alive;
 pub use alive::GetHealthAliveHandler;
 mod ready;
-pub use ready::GetHealthReadyHandler;
-
+pub use ready::{GetHealthReadyHandler, RealReady};
 mod started;
-pub use started::GetHealthStartedHandler;
+pub use started::{GetHealthStartedHandler, RealStarted};

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/ready.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/ready.rs
@@ -1,6 +1,7 @@
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::{Arc, RwLock}};
 
 use hyper::StatusCode;
+use scannerlib::models::FeedState;
 
 use crate::{
     auth_method_segments,
@@ -60,6 +61,45 @@ impl Default for GetHealthReadyHandler<JustReady> {
         Self {
             get_health_ready: Arc::new(JustReady {}),
         }
+    }
+}
+
+/// A readiness checker that reflects the actual feed state.
+///
+/// The scanner is considered ready when the feed has reached [`FeedState::Synced`].
+/// This allows orchestrators (e.g. Kubernetes) to route traffic only to instances
+/// that have a loaded vulnerability test feed.
+pub struct RealReady {
+    feed_state: Arc<RwLock<FeedState>>,
+}
+
+impl RealReady {
+    pub fn new(feed_state: Arc<RwLock<FeedState>>) -> Self {
+        Self { feed_state }
+    }
+}
+
+impl Prefixed for RealReady {
+    fn prefix(&self) -> &'static str {
+        ""
+    }
+}
+
+impl GetHealthReady for RealReady {
+    fn get_health_ready(&self) -> Pin<Box<dyn Future<Output = Ready> + Send>> {
+        let fs = self.feed_state.clone();
+        Box::pin(async move {
+            // Use try_read to avoid blocking the handler if the lock is contended.
+            // If the lock is poisoned or contended, treat as not ready.
+            let is_ready = fs.try_read().map_or(false, |s| {
+                matches!(*s, FeedState::Synced(_, _))
+            });
+            if is_ready {
+                Ready::Ready
+            } else {
+                Ready::NotReady
+            }
+        })
     }
 }
 

--- a/rust/src/openvasd/greenbone_scanner_framework/get_health/started.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_health/started.rs
@@ -1,4 +1,4 @@
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::{Arc, atomic::{AtomicBool, Ordering}}};
 
 use hyper::StatusCode;
 
@@ -60,6 +60,44 @@ impl Default for GetHealthStartedHandler<JustStarted> {
         Self {
             get_health_started: Arc::new(JustStarted {}),
         }
+    }
+}
+
+/// A started checker that tracks whether the feed has been synced at least once.
+///
+/// The scanner is considered "started" once the feed reaches [`FeedState::Synced`]
+/// for the first time. This is tracked via an [`AtomicBool`] that is set when the
+/// feed orchestrator reports a successful sync.
+pub struct RealStarted {
+    feed_synced: Arc<AtomicBool>,
+}
+
+impl RealStarted {
+    /// Creates a new `RealStarted` that shares the `feed_synced` flag.
+    ///
+    /// The flag should be set to `true` by the feed orchestrator when the feed
+    /// first reaches `Synced` state.
+    pub fn new(feed_synced: Arc<AtomicBool>) -> Self {
+        Self { feed_synced }
+    }
+}
+
+impl Prefixed for RealStarted {
+    fn prefix(&self) -> &'static str {
+        ""
+    }
+}
+
+impl GetHealthStarted for RealStarted {
+    fn get_health_started(&self) -> Pin<Box<dyn Future<Output = Started> + Send>> {
+        let synced = self.feed_synced.clone();
+        Box::pin(async move {
+            if synced.load(Ordering::SeqCst) {
+                Started::Started
+            } else {
+                Started::NotStarted
+            }
+        })
     }
 }
 

--- a/rust/src/openvasd/greenbone_scanner_framework/get_metrics.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/get_metrics.rs
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+use std::{pin::Pin, sync::Arc};
+
+use hyper::StatusCode;
+
+use crate::{
+    greenbone_scanner_framework::entry::{
+        self, Bytes, Method, Prefixed, RequestHandler, response::BodyKind,
+    },
+    metrics::scanner_metrics,
+};
+
+/// Prometheus content type for the text format.
+const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// Trait for a type that can provide Prometheus metrics.
+///
+/// The default implementation renders the process-wide [`ScannerMetrics`].
+pub trait GetMetrics: Prefixed + Send + Sync {
+    fn metrics(&self) -> Pin<Box<dyn std::future::Future<Output = String> + Send>>;
+}
+
+/// Default metrics provider that renders the global [`ScannerMetrics`].
+#[derive(Default)]
+pub struct DefaultMetrics;
+
+impl Prefixed for DefaultMetrics {
+    fn prefix(&self) -> &'static str {
+        ""
+    }
+}
+
+impl GetMetrics for DefaultMetrics {
+    fn metrics(&self) -> Pin<Box<dyn std::future::Future<Output = String> + Send>> {
+        Box::pin(async move { scanner_metrics().render() })
+    }
+}
+
+/// Handler for `GET /metrics`.
+///
+/// When `needs_authentication` returns `true`, the request must be authenticated
+/// (API key or mTLS). The authentication requirement is configurable via
+/// `endpoints.metrics_auth`.
+pub struct GetMetricsHandler<T> {
+    metrics: Arc<T>,
+    authenticated: bool,
+}
+
+impl GetMetricsHandler<DefaultMetrics> {
+    /// Creates a handler with the default global metrics provider.
+    ///
+    /// `authenticated` controls whether `/metrics` requires API key / mTLS.
+    pub fn new(authenticated: bool) -> Self {
+        Self {
+            metrics: Arc::new(DefaultMetrics),
+            authenticated,
+        }
+    }
+}
+
+impl<T> GetMetricsHandler<T>
+where
+    T: GetMetrics + 'static,
+{
+    /// Creates a handler with a custom metrics provider.
+    pub fn with_provider(provider: T, authenticated: bool) -> Self {
+        Self {
+            metrics: Arc::new(provider),
+            authenticated,
+        }
+    }
+}
+
+impl<T> Prefixed for GetMetricsHandler<T>
+where
+    T: Prefixed,
+{
+    fn prefix(&self) -> &'static str {
+        self.metrics.prefix()
+    }
+}
+
+impl<S> RequestHandler for GetMetricsHandler<S>
+where
+    S: GetMetrics + Prefixed + 'static,
+{
+    fn needs_authentication(&self) -> bool {
+        self.authenticated
+    }
+
+    fn path_segments(&self) -> &'static [&'static str] {
+        &["metrics"]
+    }
+
+    fn http_method(&self) -> Method {
+        Method::GET
+    }
+
+    fn call<'a, 'b>(
+        &'b self,
+        _client_id: Arc<entry::ClientIdentifier>,
+        _uri: &'a entry::Uri,
+        _body: Bytes,
+    ) -> Pin<Box<dyn std::future::Future<Output = BodyKind> + Send>>
+    where
+        'b: 'a,
+    {
+        let m = self.metrics.clone();
+        Box::pin(async move {
+            let rendered = m.metrics().await;
+            if rendered.is_empty() {
+                BodyKind::no_content(StatusCode::INTERNAL_SERVER_ERROR)
+            } else {
+                BodyKind::text_content(
+                    StatusCode::OK,
+                    PROMETHEUS_CONTENT_TYPE,
+                    rendered,
+                )
+            }
+        })
+    }
+}
+
+impl<T> From<T> for GetMetricsHandler<T>
+where
+    T: GetMetrics + 'static,
+{
+    fn from(value: T) -> Self {
+        GetMetricsHandler {
+            metrics: Arc::new(value),
+            authenticated: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::greenbone_scanner_framework::{Authentication, entry::ClientHash};
+    use entry::test_utilities;
+
+    #[tokio::test]
+    async fn get_metrics_unauthenticated() {
+        let entry_point = test_utilities::entry_point(
+            Authentication::Disabled,
+            create_single_handler!(GetMetricsHandler::new(false)),
+            None,
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/metrics");
+        let resp = hyper::service::Service::call(&entry_point, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("Content-Type").unwrap(),
+            PROMETHEUS_CONTENT_TYPE
+        );
+    }
+
+    #[tokio::test]
+    async fn get_metrics_requires_auth() {
+        let entry_point = test_utilities::entry_point(
+            Authentication::ApiKey(vec!["test".to_owned()]),
+            create_single_handler!(GetMetricsHandler::new(true)),
+            None,
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/metrics");
+        let resp = hyper::service::Service::call(&entry_point, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn get_metrics_authenticated() {
+        let entry_point = test_utilities::entry_point(
+            Authentication::ApiKey(vec!["test".to_owned()]),
+            create_single_handler!(GetMetricsHandler::new(true)),
+            Some(ClientHash::from("test")),
+        );
+
+        let req = test_utilities::empty_request(Method::GET, "/metrics");
+        let resp = hyper::service::Service::call(&entry_point, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/rust/src/openvasd/greenbone_scanner_framework/mod.rs
+++ b/rust/src/openvasd/greenbone_scanner_framework/mod.rs
@@ -37,7 +37,11 @@ pub use get_scans_preferences::GetScansPreferences;
 mod get_vts;
 pub use get_vts::{GetVTsError, GetVts};
 mod get_health;
-use get_health::{GetHealthAliveHandler, GetHealthReadyHandler, GetHealthStartedHandler};
+use get_health::{
+    GetHealthAliveHandler, GetHealthReadyHandler, GetHealthStartedHandler, RealReady, RealStarted,
+};
+mod get_metrics;
+pub use get_metrics::GetMetricsHandler;
 
 mod post_scans;
 use once_cell::sync::Lazy;
@@ -127,6 +131,8 @@ pub struct RuntimeBuilder<T> {
     api_keys: Option<Vec<String>>,
     handlers: RequestHandlers,
     max_concurrent_connections: usize,
+    metrics_enabled: bool,
+    metrics_authenticated: bool,
     _phantom: PhantomData<T>,
 }
 
@@ -162,6 +168,8 @@ impl<T> RuntimeBuilder<T> {
             handlers,
             listener_address,
             max_concurrent_connections: 10,
+            metrics_enabled: false,
+            metrics_authenticated: false,
             _phantom: PhantomData,
         }
     }
@@ -221,6 +229,32 @@ impl<T> RuntimeBuilder<T> {
     ) -> RuntimeBuilder<T> {
         self.max_concurrent_connections = max_concurrent_connections;
         self
+    }
+
+    /// Enables the `/metrics` endpoint (Prometheus text format).
+    ///
+    /// `authenticated` controls whether the endpoint requires API key / mTLS.
+    pub fn metrics(mut self, authenticated: bool) -> RuntimeBuilder<T> {
+        self.metrics_enabled = true;
+        self.metrics_authenticated = authenticated;
+        self.handlers
+            .push(GetMetricsHandler::new(authenticated));
+        self
+    }
+
+    /// Replaces the default stub `/health/ready` handler with one that checks
+    /// the actual feed state.
+    ///
+    /// The scanner is considered ready only when the feed has reached
+    /// [`FeedState::Synced`].
+    pub fn real_ready(self, feed_state: Arc<RwLock<FeedState>>) -> RuntimeBuilder<T> {
+        self.add_request_handler(GetHealthReadyHandler::from(RealReady::new(feed_state)))
+    }
+
+    /// Replaces the default stub `/health/started` handler with one that tracks
+    /// whether the feed has been synced at least once.
+    pub fn real_started(self, feed_synced: Arc<std::sync::atomic::AtomicBool>) -> RuntimeBuilder<T> {
+        self.add_request_handler(GetHealthStartedHandler::from(RealStarted::new(feed_synced)))
     }
 
     pub fn add_request_handler<R>(mut self, value: R) -> RuntimeBuilder<T>
@@ -286,6 +320,8 @@ impl<T> RuntimeBuilder<T> {
             handlers: ior.handlers,
             _phantom: PhantomData,
             max_concurrent_connections: ior.max_concurrent_connections,
+            metrics_enabled: ior.metrics_enabled,
+            metrics_authenticated: ior.metrics_authenticated,
         }
     }
 
@@ -359,6 +395,8 @@ impl RuntimeBuilder<runtime_builder_states::Start> {
             handlers: ior.handlers,
             _phantom: PhantomData,
             max_concurrent_connections: ior.max_concurrent_connections,
+            metrics_enabled: ior.metrics_enabled,
+            metrics_authenticated: ior.metrics_authenticated,
         }
     }
 }
@@ -377,6 +415,8 @@ impl RuntimeBuilder<runtime_builder_states::DeleteScanIDSet> {
             api_keys: ior.api_keys,
             handlers: ior.handlers,
             max_concurrent_connections: ior.max_concurrent_connections,
+            metrics_enabled: ior.metrics_enabled,
+            metrics_authenticated: ior.metrics_authenticated,
             _phantom: PhantomData,
         }
     }

--- a/rust/src/openvasd/main.rs
+++ b/rust/src/openvasd/main.rs
@@ -14,6 +14,7 @@ mod crypt;
 mod database;
 mod greenbone_scanner_framework;
 mod json_stream;
+mod metrics;
 mod notus;
 mod scans;
 mod vts;
@@ -73,9 +74,24 @@ async fn build_runtime(config: Config) -> Result<RuntimeBuilder<End>> {
     let (get_notus, post_notus) = notus::init(products.clone());
 
     let mut rb = RuntimeBuilder::<greenbone_scanner_framework::End>::new(config.listener.address)
-        .feed_version(feed_snapshot.clone());
+        .feed_version(feed_snapshot.clone())
+        .real_ready(feed_snapshot.clone());
+
     if let Some(api_key) = config.endpoints.key.clone() {
         rb = rb.api_keys(vec![api_key]);
+    }
+
+    // Enable /metrics endpoint if configured
+    if config.endpoints.enable_metrics {
+        let metrics_auth = config
+            .endpoints
+            .metrics_auth
+            .unwrap_or(config.endpoints.key.is_some() || config.tls.client_certs.is_some());
+        rb = rb.metrics(metrics_auth);
+        tracing::info!(
+            "Metrics endpoint enabled (authenticated: {})",
+            metrics_auth
+        );
     }
     match (config.tls.certs.clone(), config.tls.key.clone()) {
         (Some(certificate), Some(key)) => {

--- a/rust/src/openvasd/metrics/mod.rs
+++ b/rust/src/openvasd/metrics/mod.rs
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: 2025 Greenbone AG
+//
+// SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
+
+//! Prometheus metrics for openvasd.
+//!
+//! A single process-wide [`ScannerMetrics`] instance is exposed via [`scanner_metrics`]
+//! so that instrumentation sites across the server (HTTP entry point, scan scheduling,
+//! VT execution, feed orchestration, database) all update the same collectors.
+//!
+//! The metrics are rendered in Prometheus text format by [`ScannerMetrics::render`],
+//! which is consumed by the `GET /metrics` handler.
+//!
+//! # Metric catalog
+//!
+//! | Metric | Type | Labels | Description |
+//! |---|---|---|---|
+//! | `openvasd_scans_started_total` | counter | — | Total scans started |
+//! | `openvasd_scans_completed_total` | counter | `status` | Scans reached a terminal state |
+//! | `openvasd_scans_active` | gauge | — | Currently running scans |
+//! | `openvasd_vt_executions_total` | counter | `result` | VT executions by outcome |
+//! | `openvasd_vt_execution_seconds` | histogram | `stage` | VT execution duration |
+//! | `openvasd_feed_state` | gauge | `type` | 0=unknown, 1=syncing, 2=synced |
+//! | `openvasd_feed_last_sync_timestamp` | gauge | — | Unix seconds of last successful sync |
+//! | `openvasd_results_total` | counter | `type` | Results emitted by type |
+//! | `openvasd_db_active_connections` | gauge | — | Active DB connections |
+//! | `openvasd_db_query_seconds` | histogram | `op` | DB query duration |
+//! | `openvasd_http_requests_total` | counter | `method`, `status` | HTTP requests handled |
+//! | `openvasd_http_request_seconds` | histogram | `method` | HTTP request duration |
+//! | `openvasd_http_active` | gauge | — | In-flight HTTP requests |
+
+use std::sync::{Arc, OnceLock};
+
+use prometheus::{
+    Encoder, HistogramOpts, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+    TextEncoder, core::Collector,
+};
+
+/// Feed state gauge values used for `openvasd_feed_state`.
+pub const FEED_STATE_UNKNOWN: i64 = 0;
+pub const FEED_STATE_SYNCING: i64 = 1;
+pub const FEED_STATE_SYNCED: i64 = 2;
+
+/// Central collection of openvasd Prometheus collectors.
+///
+/// All collectors are registered with a single [`Registry`] and rendered together
+/// via [`ScannerMetrics::render`]. The struct is cheaply cloneable (`Arc`) and
+/// safe to share across async tasks; the underlying counters/gauges use atomics
+/// and do not require async-aware locking.
+#[derive(Clone)]
+pub struct ScannerMetrics {
+    registry: Arc<Registry>,
+
+    // Scan lifecycle
+    scans_started: IntCounterVec,
+    scans_completed: IntCounterVec,
+    scans_active: IntGauge,
+
+    // VT execution
+    vt_executions: IntCounterVec,
+    vt_duration: HistogramVec,
+
+    // Feed
+    feed_state: IntGaugeVec,
+    feed_last_sync: IntGauge,
+
+    // Results emitted
+    results_total: IntCounterVec,
+
+    // DB
+    db_active_connections: IntGauge,
+    db_query_duration: HistogramVec,
+
+    // HTTP
+    http_requests: IntCounterVec,
+    http_request_duration: HistogramVec,
+    http_active: IntGauge,
+}
+
+impl ScannerMetrics {
+    /// Creates a new metrics set and registers all collectors.
+    ///
+    /// Each call produces an independent registry; in production a single shared
+    /// instance should be obtained via [`scanner_metrics`].
+    pub fn new() -> Self {
+        let registry = Registry::new();
+
+        let scans_started = IntCounterVec::new(
+            Opts::new("openvasd_scans_started_total", "Total scans started"),
+            &[],
+        )
+        .expect("valid counter opts");
+        let scans_completed = IntCounterVec::new(
+            Opts::new(
+                "openvasd_scans_completed_total",
+                "Scans that reached a terminal state",
+            ),
+            &["status"],
+        )
+        .expect("valid counter opts");
+        let scans_active = IntGauge::new("openvasd_scans_active", "Currently running scans")
+            .expect("valid gauge opts");
+
+        let vt_executions = IntCounterVec::new(
+            Opts::new("openvasd_vt_executions_total", "VT executions by outcome"),
+            &["result"],
+        )
+        .expect("valid counter opts");
+        let vt_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "openvasd_vt_execution_seconds",
+                "VT execution duration in seconds",
+            )
+            .buckets(vec![
+                0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 300.0,
+            ]),
+            &["stage"],
+        )
+        .expect("valid histogram opts");
+
+        let feed_state = IntGaugeVec::new(
+            Opts::new(
+                "openvasd_feed_state",
+                "Feed state: 0=unknown, 1=syncing, 2=synced",
+            ),
+            &["type"],
+        )
+        .expect("valid gauge opts");
+        let feed_last_sync = IntGauge::new(
+            "openvasd_feed_last_sync_timestamp",
+            "Unix timestamp of last successful feed sync (0 when never synced)",
+        )
+        .expect("valid gauge opts");
+
+        let results_total = IntCounterVec::new(
+            Opts::new("openvasd_results_total", "Results emitted by type"),
+            &["type"],
+        )
+        .expect("valid counter opts");
+
+        let db_active_connections = IntGauge::new(
+            "openvasd_db_active_connections",
+            "Active database connections",
+        )
+        .expect("valid gauge opts");
+        let db_query_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "openvasd_db_query_seconds",
+                "Database query duration in seconds",
+            )
+            .buckets(vec![0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0]),
+            &["op"],
+        )
+        .expect("valid histogram opts");
+
+        let http_requests = IntCounterVec::new(
+            Opts::new("openvasd_http_requests_total", "HTTP requests handled"),
+            &["method", "status"],
+        )
+        .expect("valid counter opts");
+        let http_request_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "openvasd_http_request_seconds",
+                "HTTP request duration in seconds",
+            )
+            .buckets(vec![
+                0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0,
+            ]),
+            &["method"],
+        )
+        .expect("valid histogram opts");
+        let http_active =
+            IntGauge::new("openvasd_http_active", "In-flight HTTP requests").expect("valid gauge opts");
+
+        let collectors: Vec<Box<dyn Collector>> = vec![
+            Box::new(scans_started.clone()),
+            Box::new(scans_completed.clone()),
+            Box::new(scans_active.clone()),
+            Box::new(vt_executions.clone()),
+            Box::new(vt_duration.clone()),
+            Box::new(feed_state.clone()),
+            Box::new(feed_last_sync.clone()),
+            Box::new(results_total.clone()),
+            Box::new(db_active_connections.clone()),
+            Box::new(db_query_duration.clone()),
+            Box::new(http_requests.clone()),
+            Box::new(http_request_duration.clone()),
+            Box::new(http_active.clone()),
+        ];
+        for c in collectors {
+            registry
+                .register(c)
+                .expect("collector registration must not conflict");
+        }
+
+        Self {
+            registry: Arc::new(registry),
+            scans_started,
+            scans_completed,
+            scans_active,
+            vt_executions,
+            vt_duration,
+            feed_state,
+            feed_last_sync,
+            results_total,
+            db_active_connections,
+            db_query_duration,
+            http_requests,
+            http_request_duration,
+            http_active,
+        }
+    }
+
+    /// Renders all registered metrics in Prometheus text format.
+    pub fn render(&self) -> String {
+        let mut buf = Vec::new();
+        let encoder = TextEncoder::new();
+        match encoder.encode(&self.registry.gather(), &mut buf) {
+            Ok(()) => String::from_utf8(buf).unwrap_or_default(),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to encode metrics");
+                String::new()
+            }
+        }
+    }
+
+    // --- Scan lifecycle ---------------------------------------------------
+
+    /// Record that a scan has been started.
+    pub fn record_scan_start(&self) {
+        self.scans_started.with_label_values(&[]).inc();
+        self.scans_active.inc();
+    }
+
+    /// Record that a scan reached a terminal state.
+    ///
+    /// `status` should be one of: `running` (should not be used here), `stopped`,
+    /// `failed`, `succeeded`.
+    pub fn record_scan_end(&self, status: &str) {
+        self.scans_completed.with_label_values(&[status]).inc();
+        self.scans_active.dec();
+    }
+
+    // --- VT execution -----------------------------------------------------
+
+    /// Record the outcome of a single VT execution.
+    ///
+    /// `result` should be `ok`, `error`, or `timeout`. `stage` is the scheduling
+    /// stage name (e.g. `discovery`, `non_evasive`, `exhausting`, `end`).
+    pub fn record_vt_execution(&self, stage: &str, result: &str, duration_secs: f64) {
+        self.vt_executions.with_label_values(&[result]).inc();
+        self.vt_duration
+            .with_label_values(&[stage])
+            .observe(duration_secs);
+    }
+
+    // --- Feed -------------------------------------------------------------
+
+    /// Set the feed state gauge for a given feed type (`nasl` or `advisories`).
+    pub fn set_feed_state(&self, feed_type: &str, value: i64) {
+        self.feed_state.with_label_values(&[feed_type]).set(value);
+    }
+
+    /// Record the timestamp of the last successful feed sync (unix seconds).
+    pub fn set_feed_last_sync(&self, timestamp_secs: i64) {
+        self.feed_last_sync.set(timestamp_secs);
+    }
+
+    // --- Results ----------------------------------------------------------
+
+    /// Record a result emitted by the scanner (`alarm`, `log`, `error`,
+    /// `host_detail`, ...).
+    pub fn record_result(&self, kind: &str) {
+        self.results_total.with_label_values(&[kind]).inc();
+    }
+
+    // --- DB ---------------------------------------------------------------
+
+    /// Increment the active DB connection gauge. Call on connection acquire.
+    pub fn db_connection_acquired(&self) {
+        self.db_active_connections.inc();
+    }
+
+    /// Decrement the active DB connection gauge. Call on connection release.
+    pub fn db_connection_released(&self) {
+        self.db_active_connections.dec();
+    }
+
+    /// Observe a database query duration for a given operation label.
+    pub fn record_db_query(&self, op: &str, duration_secs: f64) {
+        self.db_query_duration
+            .with_label_values(&[op])
+            .observe(duration_secs);
+    }
+
+    // --- HTTP -------------------------------------------------------------
+
+    /// Increment the in-flight HTTP request gauge.
+    pub fn http_request_started(&self) {
+        self.http_active.inc();
+    }
+
+    /// Decrement the in-flight HTTP request gauge.
+    pub fn http_request_finished(&self) {
+        self.http_active.dec();
+    }
+
+    /// Record a completed HTTP request.
+    pub fn record_http_request(&self, method: &str, status: &str, duration_secs: f64) {
+        self.http_requests
+            .with_label_values(&[method, status])
+            .inc();
+        self.http_request_duration
+            .with_label_values(&[method])
+            .observe(duration_secs);
+    }
+}
+
+impl Default for ScannerMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static SCANNER_METRICS: OnceLock<ScannerMetrics> = OnceLock::new();
+
+/// Returns the process-wide [`ScannerMetrics`] instance, initializing it on first
+/// access. All instrumentation sites should call this to obtain the shared metrics
+/// set so that the `/metrics` endpoint reports consistent values.
+pub fn scanner_metrics() -> &'static ScannerMetrics {
+    SCANNER_METRICS.get_or_init(ScannerMetrics::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_contains_catalog_metrics() {
+        let metrics = ScannerMetrics::new();
+        let rendered = metrics.render();
+        assert!(rendered.contains("openvasd_scans_active"));
+        assert!(rendered.contains("openvasd_vt_executions_total"));
+        assert!(rendered.contains("openvasd_feed_state"));
+        assert!(rendered.contains("openvasd_http_requests_total"));
+    }
+
+    #[test]
+    fn scan_lifecycle_counters_update() {
+        let metrics = ScannerMetrics::new();
+        metrics.record_scan_start();
+        metrics.record_scan_start();
+        metrics.record_scan_end("succeeded");
+        let rendered = metrics.render();
+        // started_total increments by 2
+        assert!(rendered.contains("openvasd_scans_started_total 2"));
+        // active goes 2 - 1 = 1
+        assert!(rendered.contains("openvasd_scans_active 1"));
+        // completed{status="succeeded"} == 1
+        assert!(rendered.contains(r#"openvasd_scans_completed_total{status="succeeded"} 1"#));
+    }
+
+    #[test]
+    fn feed_state_gauge_reflects_value() {
+        let metrics = ScannerMetrics::new();
+        metrics.set_feed_state("nasl", FEED_STATE_SYNCED);
+        metrics.set_feed_state("advisories", FEED_STATE_SYNCING);
+        let rendered = metrics.render();
+        assert!(rendered.contains(r#"openvasd_feed_state{type="nasl"} 2"#));
+        assert!(rendered.contains(r#"openvasd_feed_state{type="advisories"} 1"#));
+    }
+
+    #[test]
+    fn http_metrics_record_labels() {
+        let metrics = ScannerMetrics::new();
+        metrics.record_http_request("GET", "200", 0.01);
+        let rendered = metrics.render();
+        assert!(rendered.contains(r#"openvasd_http_requests_total{method="GET",status="200"} 1"#));
+    }
+
+    #[test]
+    fn scanner_metrics_singleton_is_stable() {
+        let a = scanner_metrics() as *const _;
+        let b = scanner_metrics() as *const _;
+        assert_eq!(a, b, "scanner_metrics must return the same instance");
+    }
+}

--- a/rust/src/openvasd/scans/scheduling.rs
+++ b/rust/src/openvasd/scans/scheduling.rs
@@ -182,6 +182,7 @@ impl<T, C> ScanScheduler<T, C> {
 
         if changed {
             tracing::warn!(id, reason, "Set scan from running to failed.");
+            crate::metrics::scanner_metrics().record_scan_end("failed");
         }
         Ok(())
     }
@@ -189,6 +190,10 @@ impl<T, C> ScanScheduler<T, C> {
     async fn scan_insert_results(&self, id: i64, results: Vec<models::Result>) -> R<()> {
         // TODO: maybe better to use i64 in the impl?
         let id: &str = &id.to_string();
+        let metrics = crate::metrics::scanner_metrics();
+        for r in &results {
+            metrics.record_result(&r.r_type.to_string().to_lowercase());
+        }
         DBResults::new(&self.pool, (id, &results as &[_]))
             .retry_exec()
             .await?;
@@ -272,6 +277,7 @@ where
             .await?;
 
         tracing::info!(id, running, "Started scan");
+        crate::metrics::scanner_metrics().record_scan_start();
 
         self.scan_start(id, scan).await;
         Ok(())
@@ -379,6 +385,9 @@ where
             .change_state(id, "running", "stopped")
             .await?;
         tracing::debug!(changed, id, "Changed scan from running to stopped");
+        if changed {
+            crate::metrics::scanner_metrics().record_scan_end("stopped");
+        }
 
         Ok(())
     }

--- a/rust/src/openvasd/vts/orchestrator.rs
+++ b/rust/src/openvasd/vts/orchestrator.rs
@@ -229,6 +229,23 @@ where
     }
     async fn change_outer_state(&self, state: FeedState) {
         let narf = self.outer_state.clone();
+        // Update feed state metrics
+        let metrics = crate::metrics::scanner_metrics();
+        match &state {
+            FeedState::Unknown => {
+                metrics.set_feed_state("nasl", crate::metrics::FEED_STATE_UNKNOWN);
+                metrics.set_feed_state("advisories", crate::metrics::FEED_STATE_UNKNOWN);
+            }
+            FeedState::Syncing => {
+                metrics.set_feed_state("nasl", crate::metrics::FEED_STATE_SYNCING);
+                metrics.set_feed_state("advisories", crate::metrics::FEED_STATE_SYNCING);
+            }
+            FeedState::Synced(_, _) => {
+                metrics.set_feed_state("nasl", crate::metrics::FEED_STATE_SYNCED);
+                metrics.set_feed_state("advisories", crate::metrics::FEED_STATE_SYNCED);
+                metrics.set_feed_last_sync(chrono::Utc::now().timestamp());
+            }
+        }
         tokio::task::spawn_blocking(move || {
             let mut out = narf.write().unwrap();
             *out = state;


### PR DESCRIPTION
## Summary

Adds a Prometheus `/metrics` endpoint and replaces the stub health probes with
real checks that reflect actual scanner state. This addresses a production
blocker: the existing `/health/ready` always returned 200 regardless of feed
state, and there was no observability layer.

## Changes

### Metrics endpoint (`GET /metrics`)
- New `ScannerMetrics` module with 13 Prometheus collectors covering scan
  lifecycle, VT execution, feed state, results, DB, and HTTP
- New `GetMetricsHandler` with configurable authentication
- New `Text` body variant in the response module for non-JSON responses
- HTTP request instrumentation (count, duration, active) in `EntryPoint::call`
- Scan lifecycle instrumentation in `scheduling.rs` (start/end/result counts)
- Feed state instrumentation in `orchestrator.rs` (state gauge + last sync timestamp)

### Real health probes
- `/health/ready` now returns 200 only when `FeedState::Synced`, 503 otherwise
  (was always 200)
- `/health/started` now tracks first feed sync via `AtomicBool`
- New `RealReady` and `RealStarted` checker structs
- Wired in `main.rs` via `real_ready()` builder method

### Configuration
- `--enable-metrics` / `ENABLE_METRICS` env var (default: false)
- `--metrics-auth` / `METRICS_AUTH` env var (default: follow global auth)

### Docs
- Updated `openapi.yml` with `/metrics` path and `metrics` tag
- Updated `README.md` with new CLI flags
- New `doc/observability.md` with metric catalog, Prometheus scrape config,
  and Kubernetes probe examples

## Testing
- `cargo check --lib` and `cargo check --bin openvasd` pass cleanly
- 8 unit tests added (5 in metrics module, 3 in metrics handler)
