### PR TITLE
Remove example of target schema in openapi spec

### DIFF
--- a/rust/api/openapi.yml
+++ b/rust/api/openapi.yml
@@ -220,8 +220,6 @@ paths:
             schema:
               $ref: "#/components/schemas/ScanReq"
             examples:
-              schema:
-                description: "Schema of a Scan."
               create simple scan:
                 $ref: "./components/examples/scans.yml#/scan_simple"
               create complex scan:


### PR DESCRIPTION
This example was more confusing than helpful.

Jira: SC-1744