### PR TITLE
Fix: set promisc mode to false, since always use any interface

### DIFF
--- a/rust/src/alive_test/alive_test.rs
+++ b/rust/src/alive_test/alive_test.rs
@@ -69,7 +69,7 @@ fn pkt_stream(
     capture_inactive: Capture<Inactive>,
 ) -> Result<PacketStream<Active, PktCodec>, pcap::Error> {
     let cap = capture_inactive
-        .promisc(true)
+        .promisc(false)
         .immediate_mode(true)
         .timeout(DEFAULT_TIMEOUT * 1000)
         .immediate_mode(true)


### PR DESCRIPTION
This was working before for pcap v 1.10.3 in debian bookworm, because the error was silenced. With debian trixie and the new pcap 1.10.5 this was fixed and it is not allowed anymore, because it is not possible to set all interfaces (any) in promiscuos mode at the same time

SC-1742

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
