### PR TITLE
Fix deadlock on slow db connection.

### DIFF
--- a/rust/src/openvasd/api_tests/mod.rs
+++ b/rust/src/openvasd/api_tests/mod.rs
@@ -4,6 +4,7 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
+use futures::StreamExt;
 use http::{Method, StatusCode};
 use scannerlib::models::{self, Phase, Scan, Status, Target};
 use serde_json::Value;
@@ -238,6 +239,52 @@ async fn container_image_scanner_deadlock() {
         .await
         .body::<Status>()
         .snapshot("status");
+}
+
+// This tests against a specific bug in which
+// a streamed response would own its own database
+// connection, which led to problems if only a single
+// db connection was allowed at a time, since the stream
+// might be read slowly, blocking all other async tasks
+// from making progress.
+#[tokio::test]
+async fn streamed_response_does_not_block_db() {
+    let t = Test::new("streamed_response_does_not_block_db")
+        .config("cis_single_db_connection")
+        .await;
+
+    // Make the first streamed row very large.
+    t.container_image_scans(POST)
+        .json(Scan {
+            scan_id: "x".repeat(16 * 1024 * 1024),
+            ..Default::default()
+        })
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let response = t
+        .container_image_scans(GET)
+        .stream()
+        .await
+        .error_for_status()
+        .unwrap();
+    let mut body = response.bytes_stream();
+    body.next().await.unwrap().unwrap();
+    let slow_reader = tokio::spawn(async move {
+        while let Some(chunk) = body.next().await {
+            chunk.unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    let second_request = t.container_image_scans(POST).json(Scan {
+        scan_id: "second-scan".into(),
+        ..Default::default()
+    });
+    let result = tokio::time::timeout(Duration::from_secs(2), second_request).await;
+    slow_reader.abort();
+
+    result.unwrap().assert_status(StatusCode::CREATED);
 }
 
 #[cfg(feature = "requires-compose")]

--- a/rust/src/openvasd/api_tests/test_builder.rs
+++ b/rust/src/openvasd/api_tests/test_builder.rs
@@ -451,6 +451,11 @@ impl<S: Serialize> Request<S> {
         request
     }
 
+    /// Sends the request without consuming the response body.
+    pub async fn stream(self) -> reqwest::Response {
+        self.build_reqwest_request().send().await.unwrap()
+    }
+
     async fn get_response(&self) -> Response {
         let reqwest = self.build_reqwest_request();
         let test_name = format!("{} {} {}", self.test_name, self.method, self.path);

--- a/rust/src/openvasd/api_tests/test_scan.rs
+++ b/rust/src/openvasd/api_tests/test_scan.rs
@@ -4,9 +4,13 @@ use http::StatusCode;
 use reqwest::Method;
 use scannerlib::models::{self, Scan};
 
-use super::test_builder::{OpenvasdInstance, Response, WaitFor};
+use super::test_builder::{OpenvasdInstance, Request, Response, WaitFor};
 
 impl OpenvasdInstance {
+    pub fn container_image_scans(&self, method: Method) -> Request<()> {
+        self.request(method, "/container-image-scanner/scans")
+    }
+
     pub async fn create_scan(&self, scan: Scan) -> TestScan<'_> {
         self.create_scan_at("/scans", scan).await
     }

--- a/rust/src/openvasd/database/sqlite/scans.rs
+++ b/rust/src/openvasd/database/sqlite/scans.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures::{StreamExt, stream};
 use scannerlib::models::{self, AliveTestMethods};
 use sqlx::{Connection, Row, Sqlite, SqlitePool, query, query_scalar, sqlite::SqliteRow};
 
@@ -503,17 +503,29 @@ where
 {
     fn stream_fetch(self) -> DAOStreamer<String> {
         let (db, client_id) = self.inner();
-        let result = query(
-            r#"
+        let pool = db.clone();
+        // The code below is a temporary fix for a problem we encountered where a response being
+        // read slowly if sqlite was configured to only a single connection at a time would lead to
+        // a deadlock.
+        // The implementation is not great, since it fetches all entries from the DB and
+        // then streams them from memory instead of streaming them from the DB, but it prevents the
+        // bug, which occurred due to the async task owning the DB connection.
+        // TODO: Fix this implementation by removing all these traits and properly implementing the DB access.
+        let result = stream::once(async move {
+            match query_scalar::<_, String>(
+                r#"
                 SELECT scan_id FROM client_scan_map WHERE client_id = ?
             "#,
-        )
-        .bind(client_id)
-        .fetch(db)
-        .map(|x| {
-            x.map(|x| x.get::<String, _>("scan_id"))
-                .map_err(DAOError::from)
-        });
+            )
+            .bind(client_id)
+            .fetch_all(&pool)
+            .await
+            {
+                Ok(scan_ids) => scan_ids.into_iter().map(Ok).collect(),
+                Err(error) => vec![Err(DAOError::from(error))],
+            }
+        })
+        .flat_map(stream::iter);
         Box::pin(result)
     }
 }


### PR DESCRIPTION
Fix deadlock on slow db connection.

This fixes a specific bug in which a streamed response would own
its own database connection, which led to problems if only a single db
connection was allowed at a time, since the stream might be read slowly,
blocking all other async tasks from making progress.

Jira: SC-1714