### PR TITLE
Fix: nasl_psrp_cli() waits for the spawned process.

### DIFF
--- a/nasl/nasl_smb.c
+++ b/nasl/nasl_smb.c
@@ -772,9 +772,6 @@ nasl_psrp_cli (lex_ctxt *lexic)
     NULL, argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD, NULL,
     NULL, &child_pid, NULL, &sout, NULL, &err);
 
-  for (int i = 0; i < argv_pos; i++)
-    g_free (argv[i]);
-
   if (ret == FALSE)
     {
       char *err_aux = err ? g_strdup (err->message) : g_strdup ("Error");
@@ -783,6 +780,15 @@ nasl_psrp_cli (lex_ctxt *lexic)
         g_error_free (err);
       return array_from_psrp_error (2, err_aux);
     }
+
+  // Set the process group id of the spawned process to its own id.
+  // Then the spawn process becomes group leader and the grandpather process
+  // (host attack process) can not reap it via sighand_chld() leaving the
+  // calling process (nasl function process) to wait for the child
+  setpgid (child_pid, child_pid);
+
+  for (int i = 0; i < argv_pos; i++)
+    g_free (argv[i]);
 
   string = g_string_new ("");
   while (1)
@@ -809,15 +815,17 @@ nasl_psrp_cli (lex_ctxt *lexic)
     }
   close (sout);
 
-  /* waitpid(-1) in sighand_chld may have already reaped this child before
-   * we get here, which is why g_child_watch_add() fails with ECHILD.
-   * Use waitpid() directly and treat ECHILD as a successful reap with
+  /* Use waitpid() directly and treat ECHILD as a successful reap with
    * an unknown (assumed zero) exit code. */
   int wait_status = 0;
   if (waitpid (child_pid, &wait_status, 0) == -1)
     {
       if (errno == ECHILD)
-        err_code = 0; /* already reaped by SIGCHLD handler */
+        {
+          g_warning ("%s: child process already reaped by SIGCHLD handler",
+                     __func__);
+          err_code = 0; /* already reaped by SIGCHLD handler */
+        }
       else
         err_code = -1;
     }


### PR DESCRIPTION
Fix: nasl_psrp_cli() waits for the spawned process.

Set the process group id of the spawned process to its own id. Then the spawn process becomes group leader and the grandpather process (host attack process) can not reap it via sighand_chld(), being the calling process (nasl function process) the only process that waits for the child.

SC-1745

**IMPORTANT**
Please read [the contributing guidelines](https://github.com/greenbone/openvas-scanner/blob/main/README.md#Contributing).

IMPORTANT: If you have encountered a bug or have a specific feature request, please strongly consider opening an issue for it instead of a PR. It is often easier for maintainers to implement a fix or feature than it is to review a pull request for it. This is especially true for verbose AI generated pull requests. A well-written issue allows maintainers to decide what to do about it instead of presenting us with a finished solution that we can either accept or reject.

1. If you are a first time contributor, add a corresponding RELICENSE file to your first pull request.
2. Please stick to [conventional commits](https://github.com/greenbone/openvas-scanner/blob/main/CONVENTIONAL-COMMITS.md) and label your changes accordingly.
3. Disclose any use of generative AI in your pull request.

Failure to stick to these requirements will get the PR closed IMMEDIATELY.
