### PR TITLE
Fix: queued counter in host_info.

### DIFF
--- a/rust/src/openvasd/database/sqlite/state_change.rs
+++ b/rust/src/openvasd/database/sqlite/state_change.rs
@@ -182,7 +182,7 @@ impl ScanStateController {
         end_time      = COALESCE(?, end_time),
         host_dead     = COALESCE(NULLIF(?, 0), host_dead),
         host_alive    = COALESCE(NULLIF(?, 0), host_alive),
-        host_queued   = COALESCE(NULLIF(?, 0), host_queued),
+        host_queued   = ?,
         host_excluded = COALESCE(NULLIF(?, 0), host_excluded),
         host_all      = COALESCE(NULLIF(?, 0), host_all),
         status        = COALESCE(NULLIF(NULLIF(?, 'stored'), 'requested'), status)


### PR DESCRIPTION
Fix: queued counter in host_info.

When there is no host left in the queued, the sql query will store the old value, because of the NULLIF(?,0) if the value is equal to zero, what is what happends when the scan finishes and there is no more host in the queue to be scanned.

SC-1747
