### PR TITLE
fix(openvasd): normalize Docker Hub references

### DIFF
--- a/rust/src/openvasd/api_tests/mod.rs
+++ b/rust/src/openvasd/api_tests/mod.rs
@@ -187,7 +187,7 @@ async fn scan_lifecycle() {
 #[tokio::test]
 #[ignore = "very slow"]
 async fn container_image_scan_docker_hub_ubuntu_24_04() {
-    const IMAGE: &str = "oci://registry-1.docker.io/library/ubuntu:24.04";
+    const IMAGE: &str = "oci://docker.io/library/ubuntu:24.04";
 
     let t = Test::new("container_image_scan_docker_hub_ubuntu_24_04")
         .config("basic")

--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -1,4 +1,6 @@
-use std::{convert::Infallible, fmt::Display, str::FromStr, time::Duration};
+use std::{convert::Infallible, fmt::Display, str::FromStr, sync::LazyLock, time::Duration};
+
+use regex::Regex;
 
 mod registry;
 
@@ -60,10 +62,10 @@ impl Image {
         self.image.as_ref().map(|x| x as &str)
     }
 
-    fn is_sha256(&self) -> bool {
+    fn is_digest(&self) -> bool {
         self.tag
             .as_ref()
-            .map(|x| x.starts_with("sha256:"))
+            .map(|x| x.contains(':'))
             .unwrap_or_default()
     }
 
@@ -83,6 +85,14 @@ pub enum ImageParseError {
     Empty,
     #[error("No registry found")]
     NoRegistry,
+    #[error("Invalid registry: {0}")]
+    InvalidRegistry(String),
+    #[error("Invalid repository: {0}")]
+    InvalidRepository(String),
+    #[error("Invalid tag: {0}")]
+    InvalidTag(String),
+    #[error("Invalid digest: {0}")]
+    InvalidDigest(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
@@ -157,7 +167,7 @@ impl Display for Image {
                 image: Some(image),
                 tag: Some(tag),
             } => {
-                if self.is_sha256() {
+                if self.is_digest() {
                     write!(f, "oci://{registry}/{}@{}", image, tag)
                 } else {
                     write!(f, "oci://{registry}/{image}:{tag}")
@@ -175,9 +185,22 @@ impl FromStr for Image {
             return Err(ImageParseError::Empty);
         }
         let value = value.strip_prefix("oci://").unwrap_or(value);
-        let mut parts = value.split('/').filter(|s| !s.is_empty());
-        let registry = parts.next().ok_or(ImageParseError::NoRegistry)?;
-        let image_parts: Vec<&str> = parts.collect();
+        if value.is_empty() {
+            return Err(ImageParseError::NoRegistry);
+        }
+
+        let parts: Vec<_> = value.split('/').collect();
+        if parts.iter().any(|part| part.is_empty()) {
+            return Err(ImageParseError::InvalidRepository(value.to_owned()));
+        }
+
+        let registry = parts.first().ok_or(ImageParseError::NoRegistry)?;
+        validate_registry(registry)?;
+        let registry = match *registry {
+            "index.docker.io" => "docker.io",
+            registry => registry,
+        };
+        let image_parts = &parts[1..];
         let mut result = Image {
             registry: registry.to_owned(),
             image: None,
@@ -188,28 +211,100 @@ impl FromStr for Image {
         }
 
         let full_image = image_parts.join("/");
-        let (image, tag) = match full_image.rsplit_once(':') {
-            Some((img, t)) => {
-                if img.ends_with("@sha256") {
-                    (
-                        img.strip_suffix("@sha256").unwrap_or_default().to_string(),
-                        Some(format!("sha256:{t}")),
-                    )
-                } else {
-                    (img.to_string(), Some(t.to_string()))
-                }
+        let (mut image, tag) = if let Some((repository, digest)) = full_image.split_once('@') {
+            if repository.contains('@') || digest.contains('@') {
+                return Err(ImageParseError::InvalidDigest(digest.to_owned()));
             }
-            None => (full_image, None),
+            validate_digest(digest)?;
+            (repository.to_owned(), Some(digest.to_owned()))
+        } else if let Some((repository, tag)) = full_image.rsplit_once(':') {
+            validate_tag(tag)?;
+            (repository.to_owned(), Some(tag.to_owned()))
+        } else {
+            (full_image, None)
         };
+        validate_repository(&image)?;
+        if registry == "docker.io" && !image.contains('/') {
+            image = format!("library/{image}");
+        }
         result.image = Some(image);
         result.tag = tag;
         Ok(result)
     }
 }
 
+static REPOSITORY_COMPONENT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$")
+        .expect("hardcoded repository regex is valid")
+});
+
+fn validate_registry(registry: &str) -> Result<(), ImageParseError> {
+    let url = url::Url::parse(&format!("https://{registry}"))
+        .map_err(|_| ImageParseError::InvalidRegistry(registry.to_owned()))?;
+    if url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(ImageParseError::InvalidRegistry(registry.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_repository(repository: &str) -> Result<(), ImageParseError> {
+    if repository.len() > 255
+        || repository
+            .split('/')
+            .any(|component| !REPOSITORY_COMPONENT.is_match(component))
+    {
+        return Err(ImageParseError::InvalidRepository(repository.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_tag(tag: &str) -> Result<(), ImageParseError> {
+    let valid = !tag.is_empty()
+        && tag.len() <= 128
+        && tag.is_ascii()
+        && tag
+            .bytes()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == b'_')
+        && tag
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, b'_' | b'.' | b'-'));
+    if !valid {
+        return Err(ImageParseError::InvalidTag(tag.to_owned()));
+    }
+    Ok(())
+}
+
+fn validate_digest(digest: &str) -> Result<(), ImageParseError> {
+    let Some((algorithm, encoded)) = digest.split_once(':') else {
+        return Err(ImageParseError::InvalidDigest(digest.to_owned()));
+    };
+    let valid = algorithm == "sha256"
+        && encoded.len() == 64
+        && encoded.bytes().all(|c| c.is_ascii_hexdigit());
+    if !valid {
+        return Err(ImageParseError::InvalidDigest(digest.to_owned()));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Image;
+    use super::{Image, ImageParseError};
+
+    fn image(registry: &str, repository: Option<&str>, reference: Option<&str>) -> Image {
+        Image {
+            registry: registry.to_owned(),
+            image: repository.map(str::to_owned),
+            tag: reference.map(str::to_owned),
+        }
+    }
 
     #[test]
     fn parse_tag() {
@@ -227,20 +322,14 @@ mod tests {
 
     #[test]
     fn parse_shasum() {
-        let user_input = "narf.io/myuser/myimage@sha256:abc1234def56789";
+        let digest = format!("sha256:{}", "a".repeat(64));
+        let user_input = format!("narf.io/myuser/myimage@{digest}");
         let parsed = user_input.parse();
         assert_eq!(
             parsed,
-            Ok(Image {
-                registry: "narf.io".to_owned(),
-                image: Some("myuser/myimage".to_owned()),
-                tag: Some("sha256:abc1234def56789".to_owned())
-            })
+            Ok(image("narf.io", Some("myuser/myimage"), Some(&digest)))
         );
-        assert_eq!(
-            parsed.unwrap().to_string(),
-            "oci://narf.io/myuser/myimage@sha256:abc1234def56789"
-        )
+        assert_eq!(parsed.unwrap().to_string(), format!("oci://{user_input}"));
     }
 
     #[test]
@@ -272,22 +361,17 @@ mod tests {
     }
 
     #[test]
-    fn skip_empty() {
+    fn rejects_empty_path_components() {
         let user_input = "oci:////myregistry//////myimage:mytag";
-        let parsed = user_input.parse();
-        assert_eq!(
-            parsed,
-            Ok(Image {
-                registry: "myregistry".to_owned(),
-                image: Some("myimage".to_owned()),
-                tag: Some("mytag".to_owned())
-            })
-        );
+        assert!(matches!(
+            user_input.parse::<Image>(),
+            Err(ImageParseError::InvalidRepository(_))
+        ));
     }
 
     #[test]
     fn only_registry() {
-        let user_input = "oci:////myregistry//////";
+        let user_input = "oci://myregistry";
         let parsed = user_input.parse();
         assert_eq!(
             parsed,
@@ -301,7 +385,7 @@ mod tests {
 
     #[test]
     fn without_tag() {
-        let user_input = "oci:////myregistry//myimage";
+        let user_input = "oci://myregistry/myimage";
         let parsed = user_input.parse();
         assert_eq!(
             parsed,
@@ -311,5 +395,108 @@ mod tests {
                 tag: None,
             })
         );
+    }
+
+    #[test]
+    fn normalizes_docker_hub_references_without_changing_selector_kind() {
+        assert_eq!(
+            "oci://docker.io/ubuntu:24.04".parse(),
+            Ok(image("docker.io", Some("library/ubuntu"), Some("24.04")))
+        );
+        assert_eq!(
+            "oci://docker.io/library/ubuntu:24.04".parse(),
+            Ok(image("docker.io", Some("library/ubuntu"), Some("24.04")))
+        );
+        assert_eq!(
+            "oci://docker.io/example/application:1.0".parse(),
+            Ok(image("docker.io", Some("example/application"), Some("1.0")))
+        );
+        assert_eq!(
+            "oci://index.docker.io/ubuntu:24.04".parse(),
+            Ok(image("docker.io", Some("library/ubuntu"), Some("24.04")))
+        );
+        assert_eq!(
+            "oci://docker.io/ubuntu".parse(),
+            Ok(image("docker.io", Some("library/ubuntu"), None))
+        );
+        assert_eq!(
+            "oci://docker.io".parse(),
+            Ok(image("docker.io", None, None))
+        );
+    }
+
+    #[test]
+    fn leaves_compatible_registry_references_unchanged() {
+        assert_eq!(
+            "oci://registry-1.docker.io/library/ubuntu:24.04".parse(),
+            Ok(image(
+                "registry-1.docker.io",
+                Some("library/ubuntu"),
+                Some("24.04")
+            ))
+        );
+        assert_eq!(
+            "oci://quay.io/example/application:1.0".parse(),
+            Ok(image("quay.io", Some("example/application"), Some("1.0")))
+        );
+        assert_eq!(
+            "oci://localhost:5000/example/application:1.0".parse(),
+            Ok(image(
+                "localhost:5000",
+                Some("example/application"),
+                Some("1.0")
+            ))
+        );
+        assert_eq!(
+            "oci://localhost:5000".parse(),
+            Ok(image("localhost:5000", None, None))
+        );
+    }
+
+    #[test]
+    fn validates_tags_and_repositories() {
+        assert_eq!(
+            "oci://docker.io/example/app:Release_1.0-rc".parse(),
+            Ok(image(
+                "docker.io",
+                Some("example/app"),
+                Some("Release_1.0-rc")
+            ))
+        );
+        for invalid in [
+            "oci://docker.io/Ubuntu:24.04",
+            "oci://docker.io/example//application:1.0",
+            "oci://docker.io/example/application:",
+            "oci://docker.io/example/application:.bad",
+            "oci://docker.io/example/application:bad!tag",
+        ] {
+            assert!(invalid.parse::<Image>().is_err(), "accepted {invalid}");
+        }
+        let too_long_tag = format!("oci://docker.io/example/application:{}", "a".repeat(129));
+        assert!(matches!(
+            too_long_tag.parse::<Image>(),
+            Err(ImageParseError::InvalidTag(_))
+        ));
+    }
+
+    #[test]
+    fn validates_digests() {
+        let digest = format!("sha256:{}", "a".repeat(64));
+        assert_eq!(
+            format!("oci://docker.io/ubuntu@{digest}").parse(),
+            Ok(image("docker.io", Some("library/ubuntu"), Some(&digest)))
+        );
+        for invalid in [
+            "oci://docker.io/ubuntu@sha256:abc",
+            "oci://docker.io/ubuntu@sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            "oci://docker.io/ubuntu@sha512:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "oci://docker.io/ubuntu@missing-colon",
+            "oci://docker.io/ubuntu@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@extra",
+        ] {
+            assert!(matches!(
+                invalid.parse::<Image>(),
+                Err(ImageParseError::InvalidDigest(_))
+            ));
+        }
     }
 }

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -60,7 +60,17 @@ struct ClientBuilder {
     insecure: bool,
     accept_invalid_certs: bool,
     scope: String,
+    /// Registry name retained in image identity and error reporting.
     registry: String,
+    /// Network endpoint used by the Docker Registry v2 client.
+    endpoint: String,
+}
+
+fn registry_endpoint(logical_registry: &str) -> &str {
+    match logical_registry {
+        "docker.io" => "registry-1.docker.io",
+        other => other,
+    }
 }
 
 impl ClientBuilder {
@@ -125,14 +135,20 @@ impl ClientBuilder {
     pub async fn authenticated(&self) -> Result<docker_registry::v2::Client, RegistryError> {
         let scope = &self.scope;
         let registry = &self.registry;
-        tracing::trace!(scope, registry, "trying to login");
+        let endpoint = &self.endpoint;
+        tracing::trace!(
+            scope,
+            logical_registry = registry,
+            endpoint,
+            "trying to login"
+        );
         let as_ce = |error| self.authenticatation_error(error);
         docker_registry::v2::Client::configure()
             .insecure_registry(self.insecure)
             .accept_invalid_certs(self.accept_invalid_certs)
             .username(self.username.clone())
             .password(self.password.clone())
-            .registry(registry)
+            .registry(endpoint)
             .build()
             .map_err(as_ce)?
             // TODO: change library to automatically use the scope given by the server header
@@ -158,6 +174,7 @@ impl Client {
         scope: String,
         registry: String,
     ) -> Result<Client, RegistryError> {
+        let endpoint = registry_endpoint(&registry).to_owned();
         let builder = ClientBuilder {
             username,
             password,
@@ -165,6 +182,7 @@ impl Client {
             accept_invalid_certs,
             scope,
             registry,
+            endpoint,
         };
         let client = builder.authenticated().await?;
         Ok(Self { builder, client })
@@ -1057,8 +1075,9 @@ pub mod fake {
 mod tests {
 
     use futures::StreamExt;
+    use mockito::Matcher;
 
-    use super::fake::RegistryMock;
+    use super::{Client, ClientBuilder, fake::RegistryMock, registry_endpoint};
     use crate::container_image_scanner::image::{
         Credential, DockerV2Registry, Image, RegistryPreference,
     };
@@ -1150,5 +1169,177 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn resolves_only_the_logical_docker_hub_endpoint() {
+        assert_eq!(registry_endpoint("docker.io"), "registry-1.docker.io");
+        assert_eq!(
+            registry_endpoint("registry-1.docker.io"),
+            "registry-1.docker.io"
+        );
+        assert_eq!(registry_endpoint("quay.io"), "quay.io");
+        assert_eq!(registry_endpoint("localhost:5000"), "localhost:5000");
+    }
+
+    #[tokio::test]
+    async fn authenticates_at_transport_endpoint_with_normalized_scope() {
+        let mut server = mockito::Server::new_async().await;
+        let scope = "repository:library/ubuntu:pull";
+        let challenge = server
+            .mock("GET", "/v2/")
+            .with_status(401)
+            .with_header(
+                "WWW-Authenticate",
+                &format!(r#"Bearer realm="http://{}/token""#, server.host_with_port()),
+            )
+            .create_async()
+            .await;
+        let token = server
+            .mock("GET", "/token")
+            .match_query(Matcher::UrlEncoded("scope".to_owned(), scope.to_owned()))
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(r#"{"token":"waldfee"}"#)
+            .create_async()
+            .await;
+        let tags = server
+            .mock("GET", "/v2/library/ubuntu/tags/list")
+            .match_header("authorization", "Bearer waldfee")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(r#"{"name":"library/ubuntu","tags":["24.04"]}"#)
+            .create_async()
+            .await;
+
+        let builder = ClientBuilder {
+            username: None,
+            password: None,
+            insecure: true,
+            accept_invalid_certs: false,
+            scope: scope.to_owned(),
+            registry: "docker.io".to_owned(),
+            endpoint: server.host_with_port(),
+        };
+        let client = builder.authenticated().await.expect("authenticate");
+        let client = Client { builder, client };
+        let resolved: Vec<_> = client
+            .get_tags("library/ubuntu", None)
+            .map(|tag| Image {
+                registry: client.builder.registry.clone(),
+                image: Some("library/ubuntu".to_owned()),
+                tag: Some(tag.expect("tag")),
+            })
+            .collect()
+            .await;
+
+        assert_eq!(
+            resolved,
+            vec![Image {
+                registry: "docker.io".to_owned(),
+                image: Some("library/ubuntu".to_owned()),
+                tag: Some("24.04".to_owned()),
+            }]
+        );
+        challenge.assert_async().await;
+        token.assert_async().await;
+        tags.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn follows_cross_origin_blob_redirect_without_forwarding_authorization() {
+        const EMPTY_SHA256: &str =
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let mut registry = mockito::Server::new_async().await;
+        let mut storage = mockito::Server::new_async().await;
+        let challenge = registry
+            .mock("GET", "/v2/")
+            .with_status(401)
+            .with_header(
+                "WWW-Authenticate",
+                &format!(
+                    r#"Bearer realm="http://{}/token""#,
+                    registry.host_with_port()
+                ),
+            )
+            .create_async()
+            .await;
+        let token = registry
+            .mock("GET", "/token")
+            .match_query(Matcher::Any)
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(r#"{"token":"secret-registry-token"}"#)
+            .create_async()
+            .await;
+        let redirect = registry
+            .mock(
+                "GET",
+                format!("/v2/library/ubuntu/blobs/{EMPTY_SHA256}").as_str(),
+            )
+            .match_header("authorization", "Bearer secret-registry-token")
+            .with_status(307)
+            .with_header(
+                "Location",
+                &format!("http://{}/blob", storage.host_with_port()),
+            )
+            .create_async()
+            .await;
+        let blob = storage
+            .mock("GET", "/blob")
+            .match_header("authorization", Matcher::Missing)
+            .with_status(200)
+            .with_body([])
+            .create_async()
+            .await;
+
+        let builder = ClientBuilder {
+            username: None,
+            password: None,
+            insecure: true,
+            accept_invalid_certs: false,
+            scope: "repository:library/ubuntu:pull".to_owned(),
+            registry: "docker.io".to_owned(),
+            endpoint: registry.host_with_port(),
+        };
+        let client = builder.authenticated().await.expect("authenticate");
+        let client = Client { builder, client };
+
+        assert_eq!(
+            client
+                .get_blob("library/ubuntu", EMPTY_SHA256)
+                .await
+                .expect("follow signed blob redirect"),
+            Vec::<u8>::new()
+        );
+        challenge.assert_async().await;
+        token.assert_async().await;
+        redirect.assert_async().await;
+        blob.assert_async().await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access to Docker Hub"]
+    async fn authenticates_logical_docker_hub_reference_anonymously() {
+        let image: Image = "oci://docker.io/ubuntu:24.04"
+            .parse()
+            .expect("valid Docker Hub reference");
+        let registry = DockerV2Registry::initialize(None, Vec::new()).expect("initialize registry");
+        let client = registry
+            .pull_client(
+                image.registry.as_str(),
+                image.image().expect("normalized repository"),
+            )
+            .await
+            .expect("authenticate anonymously with Docker Hub");
+
+        client
+            .get_manifest(
+                image.image().expect("normalized repository"),
+                image.tag().expect("explicit tag"),
+            )
+            .await
+            .expect("retrieve the Docker Hub manifest");
+        assert_eq!(image.to_string(), "oci://docker.io/library/ubuntu:24.04");
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Docker Hub targets using the user-facing `docker.io` registry failed authentication because openvasd contacted `https://docker.io/v2/`, which redirects to the Docker website instead of the Registry v2 API. Single-component official image names also needed Docker Hub's `library/` namespace normalization.

Fixes greenbone/openvas-scanner#2220

## Why This Change Was Made

Docker Hub's logical image identity and network endpoint are different concepts. Keeping `docker.io/library/ubuntu:24.04` as the image identity while contacting `registry-1.docker.io` fixes the actual routing defect without replacing the existing `docker-registry` 0.9 client or changing scanner selection semantics.

## User Impact

- `oci://docker.io/library/ubuntu:24.04` works without requiring callers to know Docker Hub's internal Registry v2 endpoint.
- `oci://docker.io/ubuntu:24.04` normalizes to the official `library/ubuntu` repository.
- Untagged repository selectors still enumerate all tags; no implicit `latest` default is introduced.
- Results and host details continue to identify images with logical `docker.io` names.

## Implementation

- Validate registry, repository, tag, and SHA-256 digest syntax at the image parsing boundary while retaining catalog, all-tags, and exact-reference selector states.
- Canonicalize `index.docker.io` to `docker.io` and add `library/` only to single-component Docker Hub repositories.
- Resolve logical `docker.io` to `registry-1.docker.io` only when constructing the Registry v2 client.
- Preserve explicit `registry-1.docker.io`, non-Docker-Hub registries, ports, TLS settings, certificate preferences, and credentials.
- Cover cross-origin blob redirects and verify that Registry authorization is not forwarded to the redirected storage origin.
- Update the existing ignored Docker Hub scan to use the logical `docker.io` form and add a focused ignored live authentication/manifest test.

## Evidence

Run in a clean Rust container with the repository's generated native archive bundle:

- `cargo fmt --all -- --check` — passed.
- `cargo test -p scannerlib --bin openvasd` — 144 passed, 0 failed, 2 ignored.
- `cargo clippy -p scannerlib --bin openvasd --tests -- -D warnings` — passed.
- `cargo test -p scannerlib --bin openvasd container_image_scanner::image::registry::docker_v2_registry::tests::authenticates_logical_docker_hub_reference_anonymously -- --ignored --exact --nocapture` — passed (1 passed) against Docker Hub in 0.71s, using `oci://docker.io/ubuntu:24.04` anonymously.
- `cargo test -p scannerlib --bin openvasd api_tests::container_image_scan_docker_hub_ubuntu_24_04 -- --ignored --exact --nocapture` — reached the existing 600-second full debug-scan timeout on the test host. The focused live authentication and manifest retrieval completed successfully; the limitation is the full extraction/scanning runtime in that environment.

## Compatibility / Non-goals

- Keeps `docker-registry` 0.9; this does not migrate to `oci-client`.
- Does not implement Docker Hub catalog search, short-name resolution, mirrors, or `registries.conf` behavior.
- Does not change omitted tags to `latest` or alter registry credential policy.
- Explicit `registry-1.docker.io` targets remain accepted and unchanged.
- Legitimate signed blob redirects remain supported, with sensitive authorization stripped across origins by the existing HTTP client redirect behavior (covered by a mock test).

Agent: GEA
Model: openai/gpt-5.6-sol
Thinking: high

## Jira

SC-1751