### PR TITLE
Fix #2220 by properly deriving the endpoint of a registry. SC-1751

### DIFF
--- a/rust/src/openvasd/api_tests/mod.rs
+++ b/rust/src/openvasd/api_tests/mod.rs
@@ -238,7 +238,7 @@ async fn vt_requirements() {
 #[tokio::test]
 #[ignore = "very slow"]
 async fn container_image_scan_docker_hub_ubuntu_24_04() {
-    const IMAGE: &str = "oci://registry-1.docker.io/library/ubuntu:24.04";
+    const IMAGE: &str = "oci://docker.io/library/ubuntu:24.04";
 
     let t = Test::new("container_image_scan_docker_hub_ubuntu_24_04")
         .config("basic")

--- a/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
+++ b/rust/src/openvasd/container_image_scanner/endpoints/scans.rs
@@ -407,7 +407,7 @@ pub mod scans_utils {
                 .clone()
                 .into_iter()
                 .map(|mut x| {
-                    x.registry = self.registry.address();
+                    x.registry = self.registry.address().into();
                     x.to_string()
                 })
                 .collect();
@@ -711,7 +711,7 @@ mod test {
             &[200, 200, 200, 200, 200, 200, 503],
         )
         .await;
-        image.registry = registry.address();
+        image.registry = registry.address().into();
 
         let scan = fakes.insecure_scan("blob-503-during-scan", [image.to_string()]);
 

--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -12,9 +12,53 @@ pub mod packages;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq)]
 pub struct Image {
-    pub registry: String,
+    pub registry: Registry,
     pub image: Option<String>,
     pub tag: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd, Eq)]
+pub struct Registry(String);
+
+impl Registry {
+    pub fn endpoint(&self) -> &str {
+        match self.0.as_str() {
+            "docker.io" => "registry-1.docker.io",
+            name => name,
+        }
+    }
+
+    fn normalize_repository(&self, repository: String) -> String {
+        if self.0 == "docker.io" && !repository.is_empty() && !repository.contains('/') {
+            format!("library/{repository}")
+        } else {
+            repository
+        }
+    }
+}
+
+impl AsRef<str> for Registry {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Registry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<String> for Registry {
+    fn from(name: String) -> Self {
+        Self(name)
+    }
+}
+
+impl From<&str> for Registry {
+    fn from(name: &str) -> Self {
+        Self(name.to_owned())
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -179,7 +223,7 @@ impl FromStr for Image {
         let registry = parts.next().ok_or(ImageParseError::NoRegistry)?;
         let image_parts: Vec<&str> = parts.collect();
         let mut result = Image {
-            registry: registry.to_owned(),
+            registry: registry.into(),
             image: None,
             tag: None,
         };
@@ -201,7 +245,7 @@ impl FromStr for Image {
             }
             None => (full_image, None),
         };
-        result.image = Some(image);
+        result.image = Some(result.registry.normalize_repository(image));
         result.tag = tag;
         Ok(result)
     }
@@ -218,7 +262,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry".to_owned(),
+                registry: "myregistry".into(),
                 image: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
@@ -232,7 +276,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "narf.io".to_owned(),
+                registry: "narf.io".into(),
                 image: Some("myuser/myimage".to_owned()),
                 tag: Some("sha256:abc1234def56789".to_owned())
             })
@@ -250,7 +294,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry:6969".to_owned(),
+                registry: "myregistry:6969".into(),
                 image: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
@@ -264,7 +308,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry".to_owned(),
+                registry: "myregistry".into(),
                 image: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
@@ -278,7 +322,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry".to_owned(),
+                registry: "myregistry".into(),
                 image: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
@@ -292,7 +336,7 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry".to_owned(),
+                registry: "myregistry".into(),
                 image: None,
                 tag: None,
             })
@@ -306,8 +350,45 @@ mod tests {
         assert_eq!(
             parsed,
             Ok(Image {
-                registry: "myregistry".to_owned(),
+                registry: "myregistry".into(),
                 image: Some("myimage".to_owned()),
+                tag: None,
+            })
+        );
+    }
+
+    #[test]
+    fn normalize_docker_hub_official_image() {
+        let parsed = "oci://docker.io/ubuntu:24.04".parse();
+        assert_eq!(
+            parsed,
+            Ok(Image {
+                registry: "docker.io".into(),
+                image: Some("library/ubuntu".to_owned()),
+                tag: Some("24.04".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn keep_docker_hub_namespace() {
+        for user_input in [
+            "oci://docker.io/library/ubuntu:24.04",
+            "oci://docker.io/example/application:1.0",
+        ] {
+            let parsed: Image = user_input.parse().unwrap();
+            assert_eq!(parsed.to_string(), user_input);
+        }
+    }
+
+    #[test]
+    fn keep_untagged_docker_hub_image_untagged() {
+        let parsed = "oci://docker.io/ubuntu".parse();
+        assert_eq!(
+            parsed,
+            Ok(Image {
+                registry: "docker.io".into(),
+                image: Some("library/ubuntu".to_owned()),
                 tag: None,
             })
         );

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -11,7 +11,7 @@ use super::{PackedLayer, RegistryPreference};
 use crate::container_image_scanner::{
     Streamer,
     image::{
-        Digest, Image,
+        Digest, Image, Registry,
         registry::{RegistryError, RegistryErrorKind},
     },
     timings::Timed,
@@ -60,7 +60,7 @@ struct ClientBuilder {
     insecure: bool,
     accept_invalid_certs: bool,
     scope: String,
-    registry: String,
+    registry: Registry,
 }
 
 impl ClientBuilder {
@@ -69,9 +69,9 @@ impl ClientBuilder {
         kind: RegistryErrorKind,
         source: docker_registry::errors::Error,
     ) -> RegistryError {
-        tracing::warn!(?source, %kind, self.registry, self.scope);
+        tracing::warn!(?source, %kind, registry = %self.registry, self.scope);
         RegistryError {
-            registry: Some(self.registry.to_owned()),
+            registry: Some(self.registry.to_string()),
             kind,
             status_code: match source {
                 // This can happen on wrong body response, which could be sign of limited
@@ -88,9 +88,9 @@ impl ClientBuilder {
     where
         T: std::fmt::Debug,
     {
-        tracing::warn!(?reason, %kind, self.registry, self.scope);
+        tracing::warn!(?reason, %kind, registry = %self.registry, self.scope);
         RegistryError {
-            registry: Some(self.registry.to_owned()),
+            registry: Some(self.registry.to_string()),
             kind,
             status_code: None,
         }
@@ -125,14 +125,20 @@ impl ClientBuilder {
     pub async fn authenticated(&self) -> Result<docker_registry::v2::Client, RegistryError> {
         let scope = &self.scope;
         let registry = &self.registry;
-        tracing::trace!(scope, registry, "trying to login");
+        let endpoint = self.registry.endpoint();
+        tracing::trace!(
+            scope,
+            logical_registry = %registry,
+            endpoint,
+            "trying to login"
+        );
         let as_ce = |error| self.authenticatation_error(error);
         docker_registry::v2::Client::configure()
             .insecure_registry(self.insecure)
             .accept_invalid_certs(self.accept_invalid_certs)
             .username(self.username.clone())
             .password(self.password.clone())
-            .registry(registry)
+            .registry(endpoint)
             .build()
             .map_err(as_ce)?
             // TODO: change library to automatically use the scope given by the server header
@@ -156,7 +162,7 @@ impl Client {
         insecure: bool,
         accept_invalid_certs: bool,
         scope: String,
-        registry: String,
+        registry: Registry,
     ) -> Result<Client, RegistryError> {
         let builder = ClientBuilder {
             username,
@@ -278,7 +284,7 @@ impl Client {
 }
 
 impl DockerV2Registry {
-    async fn catalog_client(&self, registry: &str) -> Result<Client, RegistryError> {
+    async fn catalog_client(&self, registry: &Registry) -> Result<Client, RegistryError> {
         let scope = "registry:catalog:*";
         Client::authenticated(
             self.username.clone(),
@@ -286,12 +292,16 @@ impl DockerV2Registry {
             self.insecure,
             self.accept_invalid_certs,
             scope.to_owned(),
-            registry.to_owned(),
+            registry.clone(),
         )
         .await
     }
 
-    async fn pull_client(&self, registry: &str, repository: &str) -> Result<Client, RegistryError> {
+    async fn pull_client(
+        &self,
+        registry: &Registry,
+        repository: &str,
+    ) -> Result<Client, RegistryError> {
         let scope = format!("repository:{repository}:pull",);
         Client::authenticated(
             self.username.clone(),
@@ -299,21 +309,21 @@ impl DockerV2Registry {
             self.insecure,
             self.accept_invalid_certs,
             scope.to_owned(),
-            registry.to_owned(),
+            registry.clone(),
         )
         .await
     }
 
     async fn resolve_or_search_repository(
         &self,
-        registry: &str,
+        registry: &Registry,
         repository: &str,
     ) -> Vec<Result<Image, RegistryError>> {
-        tracing::debug!(registry, repository, "resolve_or_search_repository");
+        tracing::debug!(%registry, repository, "resolve_or_search_repository");
         let client = match self.pull_client(registry, repository).await {
             Ok(x) => x,
             Err(e) => {
-                tracing::info!(registry, repository, error=%e, "Trying to find owner through catalog and filtering.");
+                tracing::info!(%registry, repository, error=%e, "Trying to find owner through catalog and filtering.");
                 return self
                     .resolve_catalog(registry, Some(Filter::StartsWith(repository.to_owned())))
                     .await;
@@ -323,7 +333,7 @@ impl DockerV2Registry {
             .get_tags(repository, None)
             .map(|x| match x {
                 Ok(x) => Ok(Image {
-                    registry: registry.to_owned(),
+                    registry: registry.clone(),
                     image: Some(repository.to_owned()),
                     tag: Some(x),
                 }),
@@ -337,13 +347,13 @@ impl DockerV2Registry {
 
     async fn resolve_repository(
         &self,
-        registry: &str,
+        registry: &Registry,
         repository: &str,
     ) -> Vec<Result<Image, RegistryError>> {
         let client = match self.pull_client(registry, repository).await {
             Ok(x) => x,
             Err(e) => {
-                tracing::warn!(registry, repository, error=%e, "Unable to resolve repository");
+                tracing::warn!(%registry, repository, error=%e, "Unable to resolve repository");
                 return vec![Err(e)];
             }
         };
@@ -352,7 +362,7 @@ impl DockerV2Registry {
             .map(|x| match x {
                 Ok(x) => {
                     let image = Image {
-                        registry: registry.to_owned(),
+                        registry: registry.clone(),
                         image: Some(repository.to_owned()),
                         tag: Some(x),
                     };
@@ -367,17 +377,17 @@ impl DockerV2Registry {
             .collect()
             .await;
 
-        tracing::debug!(registry, repository, images = repos.len(), "resolved");
+        tracing::debug!(%registry, repository, images = repos.len(), "resolved");
 
         repos
     }
 
     async fn resolve_catalog(
         &self,
-        registry: &str,
+        registry: &Registry,
         filter: Option<Filter>,
     ) -> Vec<Result<Image, RegistryError>> {
-        tracing::debug!(registry, ?filter, "resolve_catalog");
+        tracing::debug!(%registry, ?filter, "resolve_catalog");
         let client = match self.catalog_client(registry).await {
             Ok(x) => x,
             Err(e) => {
@@ -401,7 +411,7 @@ impl DockerV2Registry {
                             {
                                 Some(that.resolve_repository(&registry, &repository).await)
                             } else {
-                                tracing::debug!(registry, repository, "Ignoring");
+                                tracing::debug!(%registry, repository, "Ignoring");
                                 None
                             }
                         }
@@ -1056,12 +1066,11 @@ pub mod fake {
 #[cfg(test)]
 mod tests {
 
-    use futures::StreamExt;
-
     use super::fake::RegistryMock;
     use crate::container_image_scanner::image::{
-        Credential, DockerV2Registry, Image, RegistryPreference,
+        Credential, DockerV2Registry, Image, Registry, RegistryPreference,
     };
+    use futures::StreamExt;
 
     #[tokio::test]
     async fn resolve_images() {
@@ -1113,7 +1122,7 @@ mod tests {
             DockerV2Registry::initialize(Some(credential), vec![RegistryPreference::Insecure])
                 .expect("Registry cannot fail to initialize");
         let image = Image {
-            registry: addr.clone(),
+            registry: addr.clone().into(),
             image: None,
             tag: None,
         };
@@ -1133,7 +1142,7 @@ mod tests {
 
         let server = RegistryMock::from_images(&[image.clone()]).await;
 
-        image.registry = server.server.host_with_port();
+        image.registry = server.server.host_with_port().into();
 
         let credential = Credential {
             username: "user".to_owned(),
@@ -1150,5 +1159,14 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn resolves_docker_hub_endpoint() {
+        assert_eq!(
+            Registry::from("docker.io").endpoint(),
+            "registry-1.docker.io"
+        );
+        assert_eq!(Registry::from("quay.io").endpoint(), "quay.io");
     }
 }

--- a/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/scan.rs
+++ b/rust/src/openvasd/container_image_scanner/scheduling/db/sqlite/scan.rs
@@ -294,6 +294,16 @@ impl<'o> Execute<()> for DBScan<'o, (&str, &Scan)> {
                 3,
             )
             .await?;
+            let excluded_images = scan
+                .target
+                .excluded_hosts
+                .iter()
+                .map(|image| {
+                    Image::from_str(image)
+                        .map(|image| image.to_string())
+                        .unwrap_or_else(|_| image.clone())
+                })
+                .collect::<Vec<_>>();
             insert_values_chunked(
                 &mut *tx,
                 "INSERT OR IGNORE INTO images (id, image, status)",
@@ -302,7 +312,7 @@ impl<'o> Execute<()> for DBScan<'o, (&str, &Scan)> {
                         .push_bind(img)
                         .push_bind(ImageState::Excluded.as_ref());
                 },
-                &scan.target.excluded_hosts,
+                &excluded_images,
                 3,
             )
             .await?;


### PR DESCRIPTION
As @llunved mentioned in #2220, passing in `oci://docker.io/ubuntu:24.04` as a CIS target would result in openvasd trying to contact `https://docker.io/v2/`. This properly derives the endpoint from the URL.

Closes #2220 

Supersedes #2354 

Jira: SC-1751