### PR TITLE
Fix namespace resolution for CIS

### DIFF
--- a/rust/src/openvasd/api_tests/mod.rs
+++ b/rust/src/openvasd/api_tests/mod.rs
@@ -2,13 +2,18 @@
 //
 // SPDX-License-Identifier: GPL-2.0-or-later WITH x11vnc-openssl-exception
 
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    time::Duration,
+};
 
 use futures::StreamExt;
 use http::{Method, StatusCode};
 use scannerlib::models::{self, Phase, Scan, Status, Target};
 use serde_json::Value;
 use test_builder::{OpenvasdInstance, Snapshottable, Test, WaitForStatusExt};
+
+use crate::container_image_scanner::DockerRegistryV2Mock;
 
 mod test_builder;
 mod test_scan;
@@ -291,6 +296,68 @@ async fn container_image_scanner_deadlock() {
         .await
         .body::<Status>()
         .snapshot("status");
+}
+
+#[tokio::test]
+async fn container_image_scan_registry_subrepository() {
+    const SUBREPOSITORY: &str = "subrepo";
+    const REPOSITORY: &str = "subrepo/image";
+    const TAGS: &[&str] = &["latest", "v1"];
+
+    let mut registry = DockerRegistryV2Mock::serve_repository(REPOSITORY, TAGS).await;
+    let _missing_repository = registry
+        .server
+        .mock("GET", format!("/v2/{SUBREPOSITORY}/tags/list").as_str())
+        .with_status(StatusCode::NOT_FOUND.as_u16().into())
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"{"errors":[{"code":"NAME_UNKNOWN","message":"repository name not known to registry"}]}"#,
+        )
+        .create();
+
+    let registry_address = registry.address();
+    let expected_images = TAGS
+        .iter()
+        .map(|tag| format!("oci://{registry_address}/{REPOSITORY}:{tag}"))
+        .collect::<BTreeSet<_>>();
+
+    let t = Test::new("container_image_scan_registry_subrepository")
+        .config("notus")
+        .await;
+    let scan = Scan {
+        scan_id: "container-image-registry-subrepository".into(),
+        target: Target {
+            hosts: vec![format!("oci://{registry_address}/{SUBREPOSITORY}")],
+            ..Default::default()
+        },
+        scan_preferences: vec![("registry_allow_insecure", "true").into()],
+        ..Default::default()
+    };
+
+    let scan = t.create_container_image_scan(scan).await;
+    scan.start().await;
+    let status = scan
+        .wait_for(Phase::Succeeded.with_timeout(Duration::from_secs(10)))
+        .await
+        .body::<Status>();
+    let host_info = status
+        .host_info
+        .as_ref()
+        .expect("successful scan should include host information");
+    let expected_image_count = expected_images.len() as u64;
+    assert_eq!(host_info.all, expected_image_count);
+    assert_eq!(host_info.finished, expected_image_count);
+    assert_eq!(host_info.dead, 0);
+
+    let discovered_images = scan
+        .get_results()
+        .await
+        .body::<Vec<models::Result>>()
+        .iter()
+        .filter_map(|result| result.hostname.clone())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(discovered_images, expected_images);
+    scan.delete().await;
 }
 
 // This tests against a specific bug in which

--- a/rust/src/openvasd/container_image_scanner/image/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/image/mod.rs
@@ -13,7 +13,7 @@ pub mod packages;
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq)]
 pub struct Image {
     pub registry: Registry,
-    pub image: Option<String>,
+    pub repository: Option<String>,
     pub tag: Option<String>,
 }
 
@@ -100,8 +100,8 @@ impl FromStr for ImageState {
 }
 
 impl Image {
-    pub fn image(&self) -> Option<&str> {
-        self.image.as_ref().map(|x| x as &str)
+    pub fn repository(&self) -> Option<&str> {
+        self.repository.as_deref()
     }
 
     fn is_sha256(&self) -> bool {
@@ -188,23 +188,23 @@ impl Display for Image {
         match self {
             Image {
                 registry,
-                image: None,
+                repository: None,
                 tag: _,
             } => write!(f, "oci://{registry}"),
             Image {
                 registry,
-                image: Some(image),
+                repository: Some(repository),
                 tag: None,
-            } => write!(f, "oci://{registry}/{image}"),
+            } => write!(f, "oci://{registry}/{repository}"),
             Image {
                 registry,
-                image: Some(image),
+                repository: Some(repository),
                 tag: Some(tag),
             } => {
                 if self.is_sha256() {
-                    write!(f, "oci://{registry}/{}@{}", image, tag)
+                    write!(f, "oci://{registry}/{}@{}", repository, tag)
                 } else {
-                    write!(f, "oci://{registry}/{image}:{tag}")
+                    write!(f, "oci://{registry}/{repository}:{tag}")
                 }
             }
         }
@@ -221,31 +221,34 @@ impl FromStr for Image {
         let value = value.strip_prefix("oci://").unwrap_or(value);
         let mut parts = value.split('/').filter(|s| !s.is_empty());
         let registry = parts.next().ok_or(ImageParseError::NoRegistry)?;
-        let image_parts: Vec<&str> = parts.collect();
+        let repository_parts: Vec<&str> = parts.collect();
         let mut result = Image {
             registry: registry.into(),
-            image: None,
+            repository: None,
             tag: None,
         };
-        if image_parts.is_empty() {
+        if repository_parts.is_empty() {
             return Ok(result);
         }
 
-        let full_image = image_parts.join("/");
-        let (image, tag) = match full_image.rsplit_once(':') {
-            Some((img, t)) => {
-                if img.ends_with("@sha256") {
+        let full_repository = repository_parts.join("/");
+        let (repository, tag) = match full_repository.rsplit_once(':') {
+            Some((repository, tag)) => {
+                if repository.ends_with("@sha256") {
                     (
-                        img.strip_suffix("@sha256").unwrap_or_default().to_string(),
-                        Some(format!("sha256:{t}")),
+                        repository
+                            .strip_suffix("@sha256")
+                            .unwrap_or_default()
+                            .to_string(),
+                        Some(format!("sha256:{tag}")),
                     )
                 } else {
-                    (img.to_string(), Some(t.to_string()))
+                    (repository.to_string(), Some(tag.to_string()))
                 }
             }
-            None => (full_image, None),
+            None => (full_repository, None),
         };
-        result.image = Some(result.registry.normalize_repository(image));
+        result.repository = Some(result.registry.normalize_repository(repository));
         result.tag = tag;
         Ok(result)
     }
@@ -263,7 +266,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry".into(),
-                image: Some("myimage".to_owned()),
+                repository: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
         );
@@ -277,7 +280,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "narf.io".into(),
-                image: Some("myuser/myimage".to_owned()),
+                repository: Some("myuser/myimage".to_owned()),
                 tag: Some("sha256:abc1234def56789".to_owned())
             })
         );
@@ -295,7 +298,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry:6969".into(),
-                image: Some("myimage".to_owned()),
+                repository: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
         );
@@ -309,7 +312,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry".into(),
-                image: Some("myimage".to_owned()),
+                repository: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
         );
@@ -323,7 +326,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry".into(),
-                image: Some("myimage".to_owned()),
+                repository: Some("myimage".to_owned()),
                 tag: Some("mytag".to_owned())
             })
         );
@@ -337,7 +340,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry".into(),
-                image: None,
+                repository: None,
                 tag: None,
             })
         );
@@ -351,7 +354,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "myregistry".into(),
-                image: Some("myimage".to_owned()),
+                repository: Some("myimage".to_owned()),
                 tag: None,
             })
         );
@@ -364,7 +367,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "docker.io".into(),
-                image: Some("library/ubuntu".to_owned()),
+                repository: Some("library/ubuntu".to_owned()),
                 tag: Some("24.04".to_owned()),
             })
         );
@@ -388,7 +391,7 @@ mod tests {
             parsed,
             Ok(Image {
                 registry: "docker.io".into(),
-                image: Some("library/ubuntu".to_owned()),
+                repository: Some("library/ubuntu".to_owned()),
                 tag: None,
             })
         );

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -215,14 +215,21 @@ impl Client {
             .map_err(|x| self.builder.catalog_error(x))
     }
 
-    pub fn get_tags<'a>(
+    pub fn get_images<'a>(
         &'a self,
-        name: &'a str,
-        paginate: Option<u32>,
-    ) -> impl Stream<Item = Result<String, RegistryError>> + 'a {
+        registry: &'a Registry,
+        repository: &'a str,
+    ) -> impl Stream<Item = Result<Image, RegistryError>> + 'a {
         self.client
-            .get_tags(name, paginate)
-            .map_err(|x| self.builder.tag_error(x))
+            .get_tags(repository, None)
+            .map_err(|tag| self.builder.tag_error(tag))
+            .map(|tag| {
+                tag.map(|tag| Image {
+                    registry: registry.clone(),
+                    image: Some(repository.to_owned()),
+                    tag: Some(tag),
+                })
+            })
     }
 
     pub async fn get_manifest(
@@ -362,20 +369,9 @@ impl DockerV2Registry {
                     .await;
             }
         };
-        let repos: Vec<Result<Image, RegistryError>> = client
-            .get_tags(repository, None)
-            .map(|x| match x {
-                Ok(x) => Ok(Image {
-                    registry: registry.clone(),
-                    image: Some(repository.to_owned()),
-                    tag: Some(x),
-                }),
-                Err(x) => Err(x),
-            })
-            .collect()
-            .await;
+        let images: Vec<_> = client.get_images(registry, repository).collect().await;
 
-        if matches!(repos.as_slice(), [Err(error)] if error.status_code == Some(404)) {
+        if matches!(images.as_slice(), [Err(error)] if error.status_code == Some(404)) {
             tracing::info!(%registry, repository, "Repository was not found; searching the registry catalog by namespace");
             return self
                 .resolve_catalog(
@@ -385,7 +381,7 @@ impl DockerV2Registry {
                 .await;
         }
 
-        repos
+        images
     }
 
     async fn resolve_repository(
@@ -400,29 +396,9 @@ impl DockerV2Registry {
                 return vec![Err(e)];
             }
         };
-        let repos: Vec<Result<Image, RegistryError>> = client
-            .get_tags(repository, None)
-            .map(|x| match x {
-                Ok(x) => {
-                    let image = Image {
-                        registry: registry.clone(),
-                        image: Some(repository.to_owned()),
-                        tag: Some(x),
-                    };
-                    tracing::trace!(%image, "Found");
-                    Ok(image)
-                }
-                Err(x) => {
-                    tracing::warn!(error=%x, "unable to resolve_repository");
-                    Err(x)
-                }
-            })
-            .collect()
-            .await;
-
-        tracing::debug!(%registry, repository, images = repos.len(), "resolved");
-
-        repos
+        let images: Vec<_> = client.get_images(registry, repository).collect().await;
+        tracing::debug!(%registry, repository, tags = images.len(), "resolved");
+        images
     }
 
     async fn resolve_catalog(

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -226,7 +226,7 @@ impl Client {
             .map(|tag| {
                 tag.map(|tag| Image {
                     registry: registry.clone(),
-                    image: Some(repository.to_owned()),
+                    repository: Some(repository.to_owned()),
                     tag: Some(tag),
                 })
             })
@@ -234,11 +234,11 @@ impl Client {
 
     pub async fn get_manifest(
         &self,
-        name: &str,
+        repository: &str,
         reference: &str,
     ) -> Result<(Manifest, Option<String>), RegistryError> {
         self.client
-            .get_manifest_and_ref(name, reference)
+            .get_manifest_and_ref(repository, reference)
             .await
             .map_err(|source| self.builder.manifest_error(source))
     }
@@ -278,10 +278,10 @@ impl Client {
 
     pub async fn resolve_manifests(
         &self,
-        name: &str,
+        repository: &str,
         reference: &str,
     ) -> Vec<Result<(Manifest, String, Option<Digest>), RegistryError>> {
-        let og = self.get_manifest(name, reference).await;
+        let og = self.get_manifest(repository, reference).await;
         let manifests = match og {
             Ok((Manifest::ML(ml), _)) => ml.manifests,
             Ok((Manifest::OciIndex(oi), _)) => oi.manifests,
@@ -302,7 +302,7 @@ impl Client {
                 );
                 continue;
             }
-            match self.get_manifest(name, &m.digest).await {
+            match self.get_manifest(repository, &m.digest).await {
                 Ok((m, digest)) => {
                     results.push(self.manifest_to_architecture(digest, m));
                 }
@@ -312,9 +312,9 @@ impl Client {
         results
     }
 
-    pub async fn get_blob(&self, name: &str, digest: &str) -> Result<Vec<u8>, RegistryError> {
+    pub async fn get_blob(&self, repository: &str, digest: &str) -> Result<Vec<u8>, RegistryError> {
         self.client
-            .get_blob(name, digest)
+            .get_blob(repository, digest)
             .await
             .map_err(|source| self.builder.blob_error(source))
     }
@@ -451,7 +451,7 @@ impl DockerV2Registry {
         &self,
         image: &Image,
     ) -> Result<(Client, Vec<Result<ArchitectureLayer, RegistryError>>), RegistryError> {
-        let repository = match image.image() {
+        let repository = match image.repository() {
             None => {
                 return Err(RegistryError::no_repository());
             }
@@ -505,14 +505,17 @@ impl DockerV2Registry {
         match image {
             Image {
                 registry,
-                image: None,
+                repository: None,
                 tag: _,
             } => self.resolve_catalog(&registry, None).await,
             Image {
                 registry,
-                image: Some(image),
+                repository: Some(repository),
                 tag: None,
-            } => self.resolve_or_search_repository(&registry, &image).await,
+            } => {
+                self.resolve_or_search_repository(&registry, &repository)
+                    .await
+            }
             image => vec![Ok(image)],
         }
     }
@@ -543,8 +546,7 @@ impl DockerV2Registry {
                     Ok((image_digest, arch, d)) => {
                         let blob = client.get_blob(
                             image
-                                .image()
-                                .as_ref()
+                                .repository()
                                 .expect("already verified in fetch_digest_layer"),
                             d.as_ref(),
                         );
@@ -674,7 +676,11 @@ pub mod fake {
             image: &Image,
             status_code: usize,
         ) -> mockito::Mock {
-            let url = format!("/v2/{}/blobs/{}", image.image().unwrap(), self.digest());
+            let url = format!(
+                "/v2/{}/blobs/{}",
+                image.repository().unwrap(),
+                self.digest()
+            );
             server
                 .mock("GET", &url as &str)
                 .with_status(status_code)
@@ -713,8 +719,11 @@ pub mod fake {
         }
 
         pub fn mock(&self, server: &mut mockito::ServerGuard, status_code: usize) -> mockito::Mock {
-            let bobconfig_url =
-                format!("/v2/{}/blobs/{}", self.image.image().unwrap(), self.digest);
+            let bobconfig_url = format!(
+                "/v2/{}/blobs/{}",
+                self.image.repository().unwrap(),
+                self.digest
+            );
 
             server
                 .mock("GET", &bobconfig_url as &str)
@@ -733,7 +742,7 @@ pub mod fake {
             let repos = self
                 .images
                 .iter()
-                .filter_map(|x| x.image.as_ref())
+                .filter_map(|image| image.repository.as_ref())
                 .map(|x| format!(r#""{x}""#))
                 .unique()
                 .join(",");
@@ -826,12 +835,12 @@ pub mod fake {
         ) -> Vec<mockito::Mock> {
             let ml_path = format!(
                 "/v2/{}/manifests/{}",
-                self.blobconfig.image.image().unwrap(),
+                self.blobconfig.image.repository().unwrap(),
                 self.blobconfig.image.tag().unwrap()
             );
             let image_path = format!(
                 "/v2/{}/manifests/{}",
-                self.blobconfig.image.image().unwrap(),
+                self.blobconfig.image.repository().unwrap(),
                 self.blobconfig.digest
             );
             let mut mock_it = |media_type, path: &str, json| {
@@ -897,9 +906,9 @@ pub mod fake {
                 .images
                 .iter()
                 .cloned()
-                .filter_map(|entry| entry.image.map(|image| (image, entry.tag)))
-                .fold(HashMap::new(), |mut table, (image, tag)| {
-                    let entry = table.entry(image).or_default();
+                .filter_map(|entry| entry.repository.map(|repository| (repository, entry.tag)))
+                .fold(HashMap::new(), |mut table, (repository, tag)| {
+                    let entry = table.entry(repository).or_default();
                     if let Some(tag) = tag {
                         entry.insert(tag);
                     }
@@ -1033,7 +1042,7 @@ pub mod fake {
                 .iter()
                 .map(|tag| Image {
                     registry: Default::default(),
-                    image: Some(repository.to_owned()),
+                    repository: Some(repository.to_owned()),
                     tag: Some((*tag).to_owned()),
                 })
                 .collect::<Vec<_>>();
@@ -1045,12 +1054,12 @@ pub mod fake {
                 Image {
                     // registry will always be the addr of the mock
                     registry: Default::default(),
-                    image: Some("nichtsfrei/victim".to_owned()),
+                    repository: Some("nichtsfrei/victim".to_owned()),
                     tag: "latest".to_owned().into(),
                 },
                 Image {
                     registry: Default::default(),
-                    image: Some("nichtsfrei/victim".to_owned()),
+                    repository: Some("nichtsfrei/victim".to_owned()),
                     tag: "v1".to_owned().into(),
                 },
             ]
@@ -1109,33 +1118,33 @@ mod tests {
             Image {
                 // registry will always be the addr of the mock
                 registry: Default::default(),
-                image: Some("nichtsfrei/victim".to_owned()),
+                repository: Some("nichtsfrei/victim".to_owned()),
                 tag: "latest".to_owned().into(),
             },
             Image {
                 registry: Default::default(),
-                image: Some("nichtsfrei/victim".to_owned()),
+                repository: Some("nichtsfrei/victim".to_owned()),
                 tag: "v1".to_owned().into(),
             },
             Image {
                 registry: Default::default(),
-                image: Some("nichtsfrei/victim".to_owned()),
+                repository: Some("nichtsfrei/victim".to_owned()),
                 tag: "v2".to_owned().into(),
             },
             Image {
                 // registry will always be the addr of the mock
                 registry: Default::default(),
-                image: Some("greenbone/gvmd".to_owned()),
+                repository: Some("greenbone/gvmd".to_owned()),
                 tag: "latest".to_owned().into(),
             },
             Image {
                 registry: Default::default(),
-                image: Some("greenbone/gvmd".to_owned()),
+                repository: Some("greenbone/gvmd".to_owned()),
                 tag: "v1".to_owned().into(),
             },
             Image {
                 registry: Default::default(),
-                image: Some("greenbone/gvmd".to_owned()),
+                repository: Some("greenbone/gvmd".to_owned()),
                 tag: "v2".to_owned().into(),
             },
         ];
@@ -1154,7 +1163,7 @@ mod tests {
                 .expect("Registry cannot fail to initialize");
         let image = Image {
             registry: addr.clone().into(),
-            image: None,
+            repository: None,
             tag: None,
         };
         let client = aha.resolve_image(image).await;
@@ -1167,7 +1176,7 @@ mod tests {
         let mut image = Image {
             // registry will always be the addr of the mock
             registry: Default::default(),
-            image: Some("nichtsfrei/victim".to_owned()),
+            repository: Some("nichtsfrei/victim".to_owned()),
             tag: "latest".to_owned().into(),
         };
 

--- a/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
+++ b/rust/src/openvasd/container_image_scanner/image/registry/docker_v2_registry.rs
@@ -42,14 +42,23 @@ pub struct DockerV2Registry {
 
 #[derive(Debug, Clone)]
 enum Filter {
-    StartsWith(String),
+    /// Filter out repositories that do not start
+    /// with the specified namespace
+    /// i.e. RepositoryNamespace("foo") filters for
+    /// foo/a
+    /// foo/b
+    /// but not for
+    /// foo_bar/a
+    RepositoryNamespace(String),
 }
 
 impl Filter {
     pub fn matches(&self, other: &str) -> bool {
         tracing::trace!(?self, other, "Matches");
         match self {
-            Filter::StartsWith(value) => other.starts_with(value),
+            Filter::RepositoryNamespace(value) => other
+                .strip_prefix(value)
+                .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('/')),
         }
     }
 }
@@ -76,8 +85,11 @@ impl ClientBuilder {
             status_code: match source {
                 // This can happen on wrong body response, which could be sign of limited
                 // availability. That's why we treat it as a 503.
-                docker_registry::errors::Error::Reqwest(_) => Some(503),
+                docker_registry::errors::Error::Reqwest(error) => {
+                    Some(error.status().map_or(503, |status| status.as_u16()))
+                }
                 docker_registry::errors::Error::UnexpectedHttpStatus(status)
+                | docker_registry::errors::Error::Client { status }
                 | docker_registry::errors::Error::Server { status } => Some(status.as_u16()),
                 _ => None,
             },
@@ -343,7 +355,10 @@ impl DockerV2Registry {
             Err(e) => {
                 tracing::info!(%registry, repository, error=%e, "Trying to find owner through catalog and filtering.");
                 return self
-                    .resolve_catalog(registry, Some(Filter::StartsWith(repository.to_owned())))
+                    .resolve_catalog(
+                        registry,
+                        Some(Filter::RepositoryNamespace(repository.to_owned())),
+                    )
                     .await;
             }
         };
@@ -359,6 +374,16 @@ impl DockerV2Registry {
             })
             .collect()
             .await;
+
+        if matches!(repos.as_slice(), [Err(error)] if error.status_code == Some(404)) {
+            tracing::info!(%registry, repository, "Repository was not found; searching the registry catalog by namespace");
+            return self
+                .resolve_catalog(
+                    registry,
+                    Some(Filter::RepositoryNamespace(repository.to_owned())),
+                )
+                .await;
+        }
 
         repos
     }
@@ -1027,6 +1052,18 @@ pub mod fake {
     }
 
     impl RegistryMock {
+        pub async fn serve_repository(repository: &str, tags: &[&str]) -> Self {
+            let images = tags
+                .iter()
+                .map(|tag| Image {
+                    registry: Default::default(),
+                    image: Some(repository.to_owned()),
+                    tag: Some((*tag).to_owned()),
+                })
+                .collect::<Vec<_>>();
+            Self::from_images(&images).await
+        }
+
         pub fn supported_images() -> Vec<Image> {
             vec![
                 Image {

--- a/rust/src/openvasd/container_image_scanner/mod.rs
+++ b/rust/src/openvasd/container_image_scanner/mod.rs
@@ -8,6 +8,8 @@ mod scheduling;
 mod timings;
 
 pub use config::Config;
+#[cfg(test)]
+pub(crate) use image::DockerRegistryV2Mock;
 pub(crate) use scannerlib::{ExternalError, PromiseRef, Streamer};
 
 use std::sync::{Arc, RwLock};


### PR DESCRIPTION
Jira: SC-1760

Fix namespace resolution.

When a container image scanner target is passed in untagged form as 
`oci://repo/foo`
we cannot know for sure what the foo refers to. It might either be a
repository
or be intended as a namespace containing multiple repositories such as
`oci://registry/foo/bar`
`oci://registry/foo/baz`

Unfortunately we cannot find out which one it is in advance. The prior
implementation tried  to authenticate and list tags for `foo` as a
repository. It only searched the registry catalog as a namespace
when authentication failed.

Some registries would succesfully authenticate the request but return
404 when tags are requested for such a repository. 

In this case our scan would fail at 0% progress. 

This fix continues when a 404 is returned and searches the registry
catalog for repositories below `foo/` instead.

I also cleaned up some of the confusing naming - `Image::image` should be `Image::repository`